### PR TITLE
Software backend updates to align to Daniel's

### DIFF
--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -178,7 +178,9 @@ jobs:
 
           mkdir -p "$HOME"/.local/easybuild/modules/all
           module use "$HOME"/.local/easybuild/modules/all
+          #module use "$HOME"/micromamba/envs/omnibenchmark/modulefiles/all
 
+          export MODULEPATH="$HOME"/micromamba/envs/omnibenchmark/modulefiles/all:$MODULEPATH
           export MODULEPATH="$HOME"/.local/easybuild/modules/all:$MODULEPATH
           
           export PYTHONPATH=${PYTHONPATH}:$LMOD_DIR/../init

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04] # [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] # [ubuntu-22.04, macos-latest]
         python-version: ["3.12"]
         poetry-version: ["1.8.0"]
         r-version: ["4.3.3"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] # [ubuntu-latest, macos-latest]
         python-version: ["3.12"]
         poetry-version: ["1.8.0"]
         r-version: ["4.3.3"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04] # [ubuntu-latest, macos-latest]
         python-version: ["3.12"]
         poetry-version: ["1.8.0"]
         r-version: ["4.3.3"]

--- a/omni/benchmark/validation/validator.py
+++ b/omni/benchmark/validation/validator.py
@@ -88,10 +88,10 @@ class Validator:
                 environment_path = Validator.get_environment_path(
                     benchmark_dir, environment.easyconfig
                 )
-                
+
                 if environment.envmodule is None:
                     environment_exists = False
-                    
+
             if software_backend == SoftwareBackendEnum.conda:
                 environment_path = Validator.get_environment_path(
                     benchmark_dir, environment.conda

--- a/omni/benchmark/validation/validator.py
+++ b/omni/benchmark/validation/validator.py
@@ -86,12 +86,12 @@ class Validator:
 
             if software_backend == SoftwareBackendEnum.envmodules:
                 environment_path = Validator.get_environment_path(
-                    benchmark_dir, environment.envmodule
+                    benchmark_dir, environment.easyconfig
                 )
-
+                
                 if environment.envmodule is None:
                     environment_exists = False
-
+                    
             if software_backend == SoftwareBackendEnum.conda:
                 environment_path = Validator.get_environment_path(
                     benchmark_dir, environment.conda

--- a/omni/software/easybuild_backend.py
+++ b/omni/software/easybuild_backend.py
@@ -30,10 +30,19 @@ HOME = op.expanduser("~")
 
 def generate_default_easybuild_config_arguments(
     modulepath: str = op.join(HOME, ".local", "easybuild", "modules"),
-    sourcepath: str = op.join(HOME, ".local", "easybuild", "sources") + ':' + os.getcwd(),
+    sourcepath: str = op.join(HOME, ".local", "easybuild", "sources")
+    + ":"
+    + os.getcwd(),
 ) -> str:
-    args = "--installpath-modules=" + modulepath + " --sourcepath " + sourcepath + ' --quiet'
+    args = (
+        "--installpath-modules="
+        + modulepath
+        + " --sourcepath "
+        + sourcepath
+        + " --quiet"
+    )
     return args
+
 
 set_up_configuration(args=[generate_default_easybuild_config_arguments()], silent=True)
 
@@ -68,7 +77,9 @@ def easybuild_easyconfig(
      - threads (int): number of threads to build the software
     """
 
-    cmd = construct_easybuild_easyconfig_command(easyconfig=op.basename(easyconfig), threads=threads)
+    cmd = construct_easybuild_easyconfig_command(
+        easyconfig=op.basename(easyconfig), threads=threads
+    )
 
     # try:
     ret = subprocess.run(

--- a/omni/software/easybuild_backend.py
+++ b/omni/software/easybuild_backend.py
@@ -23,23 +23,32 @@ from importlib import resources as impresources
 from . import templates
 
 HOME = op.expanduser("~")
+## careful, 'all' will be prepended unless exported, shell-wise, the MODULEPATH/all path as MODULEPATH
+##   when running omb
+# MODULEPATH=op.join(HOME, 'micromamba', 'envs', 'omnibenchmark', 'modulefiles', 'Core')
+MODULEPATH = op.join(HOME, ".local", "easybuild", "modules")
+ROBOTPATH = op.join(
+    HOME, "micromamba", "envs", "omnibenchmark", "easybuild", "easyconfigs"
+)
 
+os.makedirs(MODULEPATH, exist_ok=True)
 
 ## shell-based stuff, partly to be replaced by direct eb API calls -------------------------------------
 
 
 def generate_default_easybuild_config_arguments(
-    modulepath: str = op.join(HOME, ".local", "easybuild", "modules"),
-    sourcepath: str = op.join(HOME, ".local", "easybuild", "sources")
-    + ":"
-    + os.getcwd(),
+    modulepath: str = MODULEPATH,
+    sourcepath: str = ROBOTPATH + ":" + os.getcwd(),
 ) -> str:
     args = "--installpath-modules=" + modulepath + " --sourcepath=" + sourcepath
-    
+
     return args
 
 
-set_up_configuration(args=['--quiet', generate_default_easybuild_config_arguments()], silent=True)
+set_up_configuration(
+    args=["--info"] + generate_default_easybuild_config_arguments().split(" "),
+    silent=True,
+)
 
 
 def construct_easybuild_easyconfig_command(easyconfig: str, threads: int = 2) -> str:

--- a/omni/software/easybuild_backend.py
+++ b/omni/software/easybuild_backend.py
@@ -34,17 +34,12 @@ def generate_default_easybuild_config_arguments(
     + ":"
     + os.getcwd(),
 ) -> str:
-    args = (
-        "--installpath-modules="
-        + modulepath
-        + " --sourcepath "
-        + sourcepath
-        + " --quiet"
-    )
+    args = "--installpath-modules=" + modulepath + " --sourcepath=" + sourcepath
+    
     return args
 
 
-set_up_configuration(args=[generate_default_easybuild_config_arguments()], silent=True)
+set_up_configuration(args=['--quiet', generate_default_easybuild_config_arguments()], silent=True)
 
 
 def construct_easybuild_easyconfig_command(easyconfig: str, threads: int = 2) -> str:

--- a/omni/workflow/snakemake/rules/rule_node.smk
+++ b/omni/workflow/snakemake/rules/rule_node.smk
@@ -140,8 +140,9 @@ def _get_environment_path(benchmark, node):
         environment_path = Validator.get_environment_path(benchmark_dir, environment.apptainer)
 
     elif software_backend == SoftwareBackendEnum.envmodules:
-        environment_path = Validator.get_environment_path(benchmark_dir,environment.envmodule)
-
+        ## it's not a path, just an env name
+        ## environment_path = Validator.get_environment_path(benchmark_dir,environment.envmodule)
+        environment_path = environment.envmodule
     elif software_backend == SoftwareBackendEnum.conda:
         environment_path = Validator.get_environment_path(benchmark_dir, environment.conda)
 

--- a/tests/data/Benchmark_001.yaml
+++ b/tests/data/Benchmark_001.yaml
@@ -3,35 +3,35 @@ description: simple benchmark, somewhat explicit, simple params
 version: 1.0
 benchmarker: "John Doe at Robinsons lab, john.doe@uzh.ch"
 storage: https://storage.github.com/
+benchmark_yaml_spec: 0.01
 storage_api: S3
 storage_bucket_name: benchmark001
-benchmark_yaml_spec: 0.01
 software_backend: envmodules
 software_environments:
-  R:
-    description: "R 4.3.3 with gfbf-2023 toolchain"
-    easyconfig: envs/R-4.3.3-gfbf-2023b.eb
-    envmodule: envs/4.3.3-gfbf-2023b
-    conda: envs/R_4.3.3_try.yaml # or perhaps not
-    apptainer: http://registry.ch/R_4.3.3-gfbf-2023b.sif
-  python:
-    description: "Ppython3.12.0 with gfbf-2023 toolchain"
-    easyconfig: envs/Python-3.9.6-GCCcore-11.2.0.eb
-    envmodule: envs/3.9.6-GCCcore-11.2.0
-    conda: envs/python_vX_test.yaml
-    apptainer: http://registry.ch/Python-3.9.6-GCCcore-11.2.0.eb.sif 
+  zlib_old:
+    description: "zlib-1.2.11"
+    easyconfig: envs/zlib-1.2.11.eb
+    envmodule: "zlib/1.2.11"
+    conda: envs/zlib_1.2.11.yaml
+    apptainer: http://registry.ch/notavailable.sif
+  zlib_new:
+    description: "zlib-1.3.1"
+    easyconfig: envs/zlib-1.3.1.eb
+    envmodule: "zlib/1.3.1"
+    conda: envs/zlib_1.3.1.yaml
+    apptainer: http://registry.ch/notavailable.sif
 stages:
   - id: data
     modules:
       - id: D1
         name: "Dataset 1"
-        software_environment: "python"
+        software_environment: "zlib_old"
         repository:
           url: https://github.com/omnibenchmark-example/data.git
           commit: 63b7b36
       - id: D2
         name: "Dataset 2"
-        software_environment: "python"
+        software_environment: "zlib_new"
         repository:
           url: https://github.com/omnibenchmark-example/data.git
           commit: 63b7b36
@@ -46,7 +46,7 @@ stages:
   - id: process
     modules:
       - id: P1
-        software_environment: "R"
+        software_environment: "zlib_old"
         parameters:
           - values: ["-a 0", "-b 0.1"]
           - values: ["-a 1", "-b 0.1"]
@@ -54,7 +54,7 @@ stages:
           url: https://github.com/omnibenchmark-example/process.git
           commit: aeec1db
       - id: P2
-        software_environment: "R"
+        software_environment: "zlib_new"
         parameters:
           - values: ["-a 0", "-b 0"]
           - values: ["-a 1", "-b 0.1"]
@@ -72,13 +72,13 @@ stages:
   - id: methods
     modules:
       - id: M1
-        software_environment: "python"
+        software_environment: "zlib_old"
         exclude: [ D2 ]
         repository:
           url: https://github.com/omnibenchmark-example/method.git
           commit: 8f2f835
       - id: M2
-        software_environment: "python"
+        software_environment: "zlib_new"
         parameters:
           - values: ["-d1", "-e 1"]
           - values: ["-d1", "-e 2"]
@@ -103,17 +103,17 @@ stages:
   - id: metrics
     modules:
       - id: m1
-        software_environment: "python"
+        software_environment: "zlib_old"
         repository:
           url: https://github.com/omnibenchmark-example/metric.git
           commit: 579c643
       - id: m2
-        software_environment: "python"
+        software_environment: "zlib_old"
         repository:
           url: https://github.com/omnibenchmark-example/metric.git
           commit: 579c643
       - id: m3
-        software_environment: "python"
+        software_environment: "zlib_new"
         repository:
           url: https://github.com/omnibenchmark-example/metric.git
           commit: 579c643

--- a/tests/data/envs/zlib-1.2.11.eb
+++ b/tests/data/envs/zlib-1.2.11.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.11'
+
+homepage = 'https://www.zlib.net/'
+
+description = """
+ zlib is designed to be a free, general-purpose, legally unencumbered -- that
+ is, not covered by any patents -- lossless data-compression library for use
+ on virtually any computer hardware and operating system.
+"""
+
+toolchain = SYSTEM
+toolchainopts = {'pic': True}
+
+source_urls = ['https://zlib.net/fossils/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1']
+
+# need to take care of $CFLAGS ourselves with SYSTEM toolchain
+# we need to add -fPIC, but should also include -O* option to avoid
+# compiling with -O0 (default for GCC)
+buildopts = 'CFLAGS="-O2 -fPIC"'
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a',
+              'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/tests/data/envs/zlib-1.3.1.eb
+++ b/tests/data/envs/zlib-1.3.1.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.3.1'
+
+homepage = 'https://www.zlib.net/'
+
+description = """
+ zlib is designed to be a free, general-purpose, legally unencumbered -- that
+ is, not covered by any patents -- lossless data-compression library for use
+ on virtually any computer hardware and operating system.
+"""
+
+toolchain = SYSTEM
+toolchainopts = {'pic': True}
+
+source_urls = ['https://zlib.net/fossils/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23']
+
+# need to take care of $CFLAGS ourselves with SYSTEM toolchain
+# we need to add -fPIC, but should also include -O* option to avoid
+# compiling with -O0 (default for GCC)
+buildopts = 'CFLAGS="-O2 -fPIC"'
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a',
+              'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/tests/data/envs/zlib_1.2.11.yaml
+++ b/tests/data/envs/zlib_1.2.11.yaml
@@ -1,0 +1,6 @@
+name: zlib_1.2.11
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - conda-forge::zlib=1.2.11

--- a/tests/data/envs/zlib_1.3.1.yaml
+++ b/tests/data/envs/zlib_1.3.1.yaml
@@ -1,0 +1,6 @@
+name: zlib_1.3.1
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - conda-forge::zlib=1.3.1

--- a/tests/software/04_easybuild_build_envmodules/Snakefile
+++ b/tests/software/04_easybuild_build_envmodules/Snakefile
@@ -61,7 +61,8 @@ for eb in easyconfigs:
         input:
             flag = op.join(WD, '{easyconfig}_flag')
         envmodules:
-            op.join('all', easy.get_envmodule_name_from_easyconfig(eb))
+            #op.join('all', easy.get_envmodule_name_from_easyconfig(eb))
+            easy.get_envmodule_name_from_easyconfig(eb)
         params:
             env = easy.get_envmodule_name_from_easyconfig(eb)
         output:


### PR DESCRIPTION
Food for thought re: the software backends.

Mainly, the issue is that module names are not files but just words (e.g. R/latest) checked against an index typically stored as a set of lua module files inside the $MODULEPATH dir. So some validations do not work. 

We could address this in several ways:
- Check whether the module file (lua, inside the $MODULEPATH) exists, which only will happen if the module is available
- Check whether the module is available/loadable instead (e.g. using `module` commands, for instance `module avail`)
- Check whether the easyconfig is available instead (this proposal)

As for the easyconfig, they're normally not full paths neither, but rather files within the [robot search path](https://docs.easybuild.io/using-easybuild/#robot_search_path). I understand the advantages of having them in `env` folders next to the benchmarking YAML. So I've tried to circunvent this updating the searchpath / robotspath to both the "default" and the `os.path.getcwd()` but this is not ideal.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [ ] I have documented the CLI method accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a CHANGELOG entry.