### PR TITLE
install datrie explicitely

### DIFF
--- a/test-environment.yml
+++ b/test-environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - conda-forge::mamba >=1.5.8
   - conda-forge::lmod >= 8.7.25
   - conda-forge::pip >= 24.1.2
+  - conda-forge::datrie >= 0.8.2 # dep for snakemake, workaround for https://github.com/astral-sh/uv/issues/7525
   - pip:
      - "."


### PR DESCRIPTION
This is a workaround for https://github.com/astral-sh/uv/issues/7525 when installing on an up-to-date arch system