### PR TITLE
Do not require input_dir when the node is an entrypoint module

### DIFF
--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -101,7 +101,7 @@ jobs:
           pytest -v -x --show-capture=stderr \
               --splits 2 --group ${{ matrix.test_group }} --splitting-algorithm=least_duration \
               cli_conda_tests.py cli_singularity_tests.py cli_envmodules_tests.py \
-              conda_tests.py singularity_tests.py envmodules_tests.py
+              conda_tests.py singularity_tests.py envmodules_tests.py test_run_with_software.py
 
   software_testing_mac:
     strategy:
@@ -191,5 +191,5 @@ jobs:
           # pip install --user --force-reinstall --ignore-installed --no-binary :all: boto3
           pytest -v -x --show-capture=stderr \
                --splits 2 --group ${{ matrix.test_group }} \
-               conda_tests.py envmodules_tests.py cli_envmodules_tests.py cli_conda_tests.py \
+               conda_tests.py envmodules_tests.py cli_envmodules_tests.py cli_conda_tests.py test_run_with_software.py \
                -k 'not test_easybuild_sys_toolchain_build'

--- a/omni/benchmark/benchmark_node.py
+++ b/omni/benchmark/benchmark_node.py
@@ -26,6 +26,9 @@ class BenchmarkNode:
         self.module_id = module.id
         self.param_id = f"param_{param_id}" if parameters else "default"
 
+    def is_entrypoint(self):
+        return not self.inputs or len(self.inputs) == 0
+
     def get_id(self):
         return BenchmarkNode.to_id(
             self.stage_id, self.module_id, self.param_id, self.after

--- a/omni/cli/run.py
+++ b/omni/cli/run.py
@@ -117,21 +117,12 @@ def run_module(ctx, benchmark, module, input_dir, dry, update):
     """
     Run a specific module on inputs present at a given folder.
     """
-    example = False
-    all = False
     behaviours = {"input": input_dir, "example": None, "all": None}
 
     non_none_behaviours = {
         key: value for key, value in behaviours.items() if value is not None
     }
-    if len(non_none_behaviours) == 0:
-        click.echo(
-            "Error: At least one option must be specified. Use '--input_dir', '--example', or '--all'.",
-            err=True,
-        )
-        sys.exit(1)  # raise click.Exit(code=1)
-
-    elif len(non_none_behaviours) >= 2:
+    if len(non_none_behaviours) >= 2:
         click.echo(
             "Error: Only one of '--input_dir', '--example', or '--all' should be set. Please choose only one option.",
             err=True,
@@ -139,7 +130,7 @@ def run_module(ctx, benchmark, module, input_dir, dry, update):
         sys.exit(1)  # raise click.Exit(code=1)
     else:
         # Construct a message specifying which option is set
-        behaviour = list(non_none_behaviours)[0]
+        behaviour = list(non_none_behaviours)[0] if non_none_behaviours else None
 
         if behaviour == "example" or behaviour == "all":
             if behaviour == "example":
@@ -158,18 +149,24 @@ def run_module(ctx, benchmark, module, input_dir, dry, update):
             click.echo(f"Running module on a dataset provided in a custom directory.")
             benchmark = validate_benchmark(benchmark)
 
-            # if update and not dry:
-            #     update_prompt = click.confirm(
-            #         "Are you sure you want to re-run the entire workflow?", abort=True
-            #     )
-            #     if not update_prompt:
-            #         raise click.Abort()
-
             benchmark_nodes = benchmark.get_nodes_by_module_id(module_id=module)
+            is_entrypoint_module = all(
+                [node.is_entrypoint() for node in benchmark_nodes]
+            )
             if len(benchmark_nodes) > 0:
                 click.echo(
                     f"Found {len(benchmark_nodes)} workflow nodes for module {module}."
                 )
+
+                if not is_entrypoint_module and len(non_none_behaviours) == 0:
+                    click.echo(
+                        "Error: At least one option must be specified. Use '--input_dir', '--example', or '--all'.",
+                        err=True,
+                    )
+                    sys.exit(1)  # raise click.Exit(code=1)
+                elif input_dir is None:
+                    input_dir = os.getcwd()
+
                 click.echo("Running module benchmark...")
 
                 # Check if input path exists and is a directory

--- a/omni/cli/run.py
+++ b/omni/cli/run.py
@@ -115,7 +115,7 @@ def run_benchmark(ctx, benchmark, threads, update, dry, local):
 )
 def run_module(ctx, benchmark, module, input_dir, dry, update):
     """
-    Run a specific module on inputs present at a given folder.
+    Run a specific module that is part of the benchmark.
     """
     behaviours = {"input": input_dir, "example": None, "all": None}
 
@@ -146,7 +146,7 @@ def run_module(ctx, benchmark, module, input_dir, dry, update):
             )
             sys.exit(1)  # raise click.Exit(code=1)
         else:
-            click.echo(f"Running module on a dataset provided in a custom directory.")
+            click.echo(f"Running module on a local dataset.")
             benchmark = validate_benchmark(benchmark)
 
             benchmark_nodes = benchmark.get_nodes_by_module_id(module_id=module)

--- a/tests/cli/test_run_module.py
+++ b/tests/cli/test_run_module.py
@@ -9,7 +9,7 @@ benchmark_data_path = benchmark_path / "data"
 
 def test_default_entry_module():
     expected_output = """
-        Running module on a dataset provided in a custom directory.
+        Running module on a local dataset.
         Benchmark YAML file integrity check passed.
         Found 1 workflow nodes for module D1.
         Running module benchmark...
@@ -31,7 +31,7 @@ def test_default_entry_module():
 
 def test_default_nonentry_module():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Benchmark YAML file integrity check passed.
     Found 2 workflow nodes for module P1.
     Error: At least one option must be specified. Use '--input_dir', '--example', or '--all'.
@@ -135,7 +135,7 @@ def test_benchmark_not_found():
 
 def test_benchmark_format_incorrect():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Error: Failed to parse YAML as a valid OmniBenchmark: software_backend must be supplied.
     """
     with OmniCLISetup() as omni:
@@ -155,7 +155,7 @@ def test_benchmark_format_incorrect():
 
 def test_module_not_found():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Benchmark YAML file integrity check passed.
     Error: Could not find module with id `not-existing` in benchmark definition
     """
@@ -178,7 +178,7 @@ def test_module_not_found():
 
 def test_behaviour_input():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Benchmark YAML file integrity check passed.
     Found 1 workflow nodes for module D1.
     Running module benchmark...
@@ -200,7 +200,7 @@ def test_behaviour_input():
 
 def test_behaviour_input_dry():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Benchmark YAML file integrity check passed.
     Found 1 workflow nodes for module D1.
     Running module benchmark...
@@ -223,7 +223,7 @@ def test_behaviour_input_dry():
 
 def test_behaviour_input_update_true():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Benchmark YAML file integrity check passed.
     Found 1 workflow nodes for module D1.
     Running module benchmark...
@@ -247,7 +247,7 @@ def test_behaviour_input_update_true():
 
 # def test_behaviour_input_update_false():
 #     expected_output = """
-#     Running module on a dataset provided in a custom directory.
+#     Running module on a local dataset.
 #     Benchmark YAML file integrity check passed.
 #     """
 #     with OmniCLISetup() as omni:
@@ -269,7 +269,7 @@ def test_behaviour_input_update_true():
 
 def test_behaviour_input_update_dry():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Benchmark YAML file integrity check passed.
     Found 1 workflow nodes for module D1.
     Running module benchmark...
@@ -316,7 +316,7 @@ def test_behaviour_input_missing_input_dir():
 
 def test_behaviour_input_missing_input_files():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Benchmark YAML file integrity check passed.
     Found 2 workflow nodes for module M1.
     Running module benchmark...
@@ -342,7 +342,7 @@ def test_behaviour_input_missing_input_files():
 
 def test_behaviour_input_nested_module_dry():
     expected_output = """
-    Running module on a dataset provided in a custom directory.
+    Running module on a local dataset.
     Benchmark YAML file integrity check passed.
     Found 2 workflow nodes for module M1.
     Running module benchmark...

--- a/tests/cli/test_run_module.py
+++ b/tests/cli/test_run_module.py
@@ -7,8 +7,33 @@ benchmark_path = Path(__file__).parent / ".."
 benchmark_data_path = benchmark_path / "data"
 
 
-def test_default():
+def test_default_entry_module():
     expected_output = """
+        Running module on a dataset provided in a custom directory.
+        Benchmark YAML file integrity check passed.
+        Found 1 workflow nodes for module D1.
+        Running module benchmark...
+        """
+    with OmniCLISetup() as omni:
+        result = omni.call(
+            [
+                "run",
+                "module",
+                "--benchmark",
+                str(benchmark_data_path / "mock_benchmark.yaml"),
+                "--module",
+                "D1",
+            ]
+        )
+        assert result.exit_code == 0
+        assert clean(result.output).startswith(clean(expected_output))
+
+
+def test_default_nonentry_module():
+    expected_output = """
+    Running module on a dataset provided in a custom directory.
+    Benchmark YAML file integrity check passed.
+    Found 2 workflow nodes for module P1.
     Error: At least one option must be specified. Use '--input_dir', '--example', or '--all'.
     """
     with OmniCLISetup() as omni:
@@ -19,7 +44,7 @@ def test_default():
                 "--benchmark",
                 str(benchmark_data_path / "mock_benchmark.yaml"),
                 "--module",
-                "D1",
+                "P1",
             ]
         )
         assert result.exit_code == 1
@@ -102,8 +127,6 @@ def test_benchmark_not_found():
                 str(benchmark_data_path / "does_not_exist.yaml"),
                 "--module",
                 "D1",
-                "--input_dir",
-                str(benchmark_path),
             ]
         )
         assert result.exit_code == 2
@@ -124,8 +147,6 @@ def test_benchmark_format_incorrect():
                 str(benchmark_data_path / "benchmark_format_incorrect.yaml"),
                 "--module",
                 "D1",
-                "--input_dir",
-                str(benchmark_path),
             ]
         )
         assert result.exit_code == 1
@@ -171,8 +192,6 @@ def test_behaviour_input():
                 str(benchmark_data_path / "mock_benchmark.yaml"),
                 "--module",
                 "D1",
-                "--input_dir",
-                str(benchmark_path),
             ]
         )
         assert result.exit_code == 0
@@ -195,8 +214,6 @@ def test_behaviour_input_dry():
                 str(benchmark_data_path / "mock_benchmark.yaml"),
                 "--module",
                 "D1",
-                "--input_dir",
-                str(benchmark_path),
                 "--dry",
             ]
         )
@@ -220,8 +237,6 @@ def test_behaviour_input_update_true():
                 str(benchmark_data_path / "mock_benchmark.yaml"),
                 "--module",
                 "D1",
-                "--input_dir",
-                str(benchmark_path),
                 "--update",
             ],
             input="y",
@@ -244,8 +259,6 @@ def test_behaviour_input_update_true():
 #                 str(benchmark_data_path / "mock_benchmark.yaml"),
 #                 "--module",
 #                 "D1",
-#                 "--input_dir",
-#                 str(benchmark_path),
 #                 "--update",
 #             ],
 #             input="N",
@@ -270,8 +283,6 @@ def test_behaviour_input_update_dry():
                 str(benchmark_data_path / "mock_benchmark.yaml"),
                 "--module",
                 "D1",
-                "--input_dir",
-                str(benchmark_path),
                 "--update",
                 "--dry",
             ],

--- a/tests/data/mock_benchmark.yaml
+++ b/tests/data/mock_benchmark.yaml
@@ -23,3 +23,24 @@ stages:
         repository:
           url: https://github.com/omnibenchmark-example/data.git
           commit: 63b7b36
+    outputs:
+      - id: data.counts
+        path: "{input}/{stage}/{module}/{params}/{dataset}.txt.gz"
+      - id: data.meta
+        path: "{input}/{stage}/{module}/{params}/{dataset}.meta.json"
+      - id: data.data_specific_params
+        path: "{input}/{stage}/{module}/{params}/{dataset}_params.txt"
+  - id: process
+    modules:
+      - id: P1
+        software_environment: "python"
+        parameters:
+          - values: [ "-a 0", "-b 0.1" ]
+          - values: [ "-a 1", "-b 0.1" ]
+        repository:
+          url: https://github.com/omnibenchmark-example/process.git
+          commit: aeec1db
+    inputs:
+      - entries:
+          - data.counts
+          - data.meta

--- a/tests/data/mock_benchmark.yaml
+++ b/tests/data/mock_benchmark.yaml
@@ -6,7 +6,7 @@ storage: https://storage.github.com/
 storage_api: S3
 storage_bucket_name: mock_benchmark
 benchmark_yaml_spec: 0.01
-software_backend: conda
+software_backend: envmodules
 software_environments:
   python:
     description: "Ppython3.12.0 with gfbf-2023 toolchain"

--- a/tests/software/test_run_with_software.py
+++ b/tests/software/test_run_with_software.py
@@ -1,6 +1,10 @@
+import sys
 from pathlib import Path
+import os.path as op
 
 from tests.workflow.Snakemake_setup import SnakemakeSetup
+
+sys.path.insert(0, op.dirname(__file__))
 
 benchmark_data = Path("..") / "data"
 benchmark_data_path = Path(__file__).parent / benchmark_data

--- a/tests/software/test_run_with_software.py
+++ b/tests/software/test_run_with_software.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from tests.workflow.Snakemake_setup import SnakemakeSetup
+
+benchmark_data = Path("..") / "data"
+benchmark_data_path = Path(__file__).parent / benchmark_data
+
+
+def test_run_benchmark_with_software():
+    benchmark_file = benchmark_data_path / "mock_benchmark.yaml"
+    benchmark_file_path = Path(__file__).parent / benchmark_file
+
+    with SnakemakeSetup(benchmark_file_path) as setup:
+        benchmark = setup.benchmark
+        assert benchmark.get_benchmark_name() == "mock_benchmark"
+
+        backend = benchmark.get_benchmark_software_backend()
+
+        # First run the whole workflow
+        success = setup.workflow.run_workflow(benchmark, backend=backend)
+
+        assert success

--- a/tests/software/utils/run.py
+++ b/tests/software/utils/run.py
@@ -2,10 +2,14 @@
 ##
 ## Izaskun Mallona
 ## 22th July 2024
+from pathlib import Path
 
 import pytest
 import subprocess
 import os
+
+from omni.benchmark import Benchmark
+from omni.workflow.snakemake import SnakemakeEngine
 
 
 def check_cmd_zero_exit(cmd_string):

--- a/tests/workflow/test_run_workflow.py
+++ b/tests/workflow/test_run_workflow.py
@@ -30,19 +30,3 @@ def test_run_workflow_002():
 
         success = setup.workflow.run_workflow(benchmark)
         assert success
-
-
-def test_run_mock_benchmark_with_software():
-    benchmark_file = Path("..") / "data" / "mock_benchmark.yaml"
-    benchmark_file_path = Path(__file__).parent / benchmark_file
-
-    with SnakemakeSetup(benchmark_file_path) as setup:
-        benchmark = setup.benchmark
-        assert benchmark.get_benchmark_name() == "mock_benchmark"
-
-        backend = benchmark.get_benchmark_software_backend()
-
-        # First run the whole workflow
-        success = setup.workflow.run_workflow(benchmark, backend=backend)
-
-        assert success


### PR DESCRIPTION
## Ticket

## Description

Instead of having to always add the `--input_dir` flag when running an individual module, skip it when we are referring to entrypoint modules. The default input directory is assumed to be the current work directory.

The following command change:
```
ob run module --benchmark tests/data/Benchmark_001.yaml --module D1 --input_dir .
```
to
```
ob run module --benchmark tests/data/Benchmark_001.yaml --module D1
```

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a CHANGELOG entry.

## Remarks for the reviewer:

Leave here some remarks for the reviewer.