### PR TITLE
Fix software tests failing on MacOS

### DIFF
--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -171,13 +171,23 @@ jobs:
           CI: true
         shell: bash -el {0}
         run: |
+          export
+          echo "--------------"
 
+          cat ~/.bashrc
+
+          echo "------------"
+          
           module --version
 
-          ## eval "$(micromamba shell hook --shell bash)"
+          # eval "$(micromamba shell hook --shell bash)"
           micromamba activate
           micromamba activate omnibenchmark
 
+          conda --version
+          export
+          echo "-------------------------"
+          
           cd tests/software
 
           mkdir -p "$HOME"/.local/easybuild/modules/all

--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -167,11 +167,8 @@ jobs:
            EOF
            
            cat <<'EOF' >>~/.bash_profile
-           [ -r ~/.bashrc ] && source ~/.bashrc
+           source ~/.bashrc
            EOF
-
-           tail "$HOME"/.bashrc
-           tail "$HOME"/.bash_profile
 
       - name: Test
         env:
@@ -186,9 +183,7 @@ jobs:
           micromamba activate
           micromamba activate omnibenchmark
 
-          export
-          conda --version
-
+          ls -la /Users/runner/micromamba/envs/omnibenchmark/bin
           
           cd tests/software
 

--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -156,7 +156,7 @@ jobs:
           CI: true
         shell: bash -el {0}
         run: |
-           cat <<'EOF' >>"$HOME"/.bashrc
+           cat <<'EOF' >>~/.bashrc
            if [ -f /opt/homebrew/opt/lmod/init/bash ]; then
                 source /opt/homebrew/opt/lmod/init/profile
            fi
@@ -165,14 +165,19 @@ jobs:
            fi
            eval "$(micromamba shell hook --shell bash)"
            EOF
+           
+           cat <<'EOF' >>~/.bash_profile
+           [ -r ~/.bashrc ] && source ~/.bashrc
+           EOF
+
+           tail "$HOME"/.bashrc
+           tail "$HOME"/.bash_profile
 
       - name: Test
         env:
           CI: true
         shell: bash -el {0}
         run: |
-          source "$HOME"/.bashrc
-
           export
           
           module --version

--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -182,9 +182,7 @@ jobs:
           # eval "$(micromamba shell hook --shell bash)"
           micromamba activate
           micromamba activate omnibenchmark
-
-          ls -la /Users/runner/micromamba/envs/omnibenchmark/bin
-          
+                    
           cd tests/software
 
           mkdir -p "$HOME"/.local/easybuild/modules/all

--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -175,14 +175,11 @@ jobs:
           CI: true
         shell: bash -el {0}
         run: |
-          export
-          
-          module --version
 
           # eval "$(micromamba shell hook --shell bash)"
           micromamba activate
           micromamba activate omnibenchmark
-                    
+          
           cd tests/software
 
           mkdir -p "$HOME"/.local/easybuild/modules/all

--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -171,12 +171,7 @@ jobs:
           CI: true
         shell: bash -el {0}
         run: |
-          export
-          echo "--------------"
-
-          cat ~/.bashrc
-
-          echo "------------"
+          source ~/.bashrc
           
           module --version
 
@@ -184,9 +179,9 @@ jobs:
           micromamba activate
           micromamba activate omnibenchmark
 
-          conda --version
           export
-          echo "-------------------------"
+          conda --version
+
           
           cd tests/software
 

--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -156,7 +156,7 @@ jobs:
           CI: true
         shell: bash -el {0}
         run: |
-           cat <<'EOF' >>~/.bashrc
+           cat <<'EOF' >>"$HOME"/.bashrc
            if [ -f /opt/homebrew/opt/lmod/init/bash ]; then
                 source /opt/homebrew/opt/lmod/init/profile
            fi
@@ -171,7 +171,9 @@ jobs:
           CI: true
         shell: bash -el {0}
         run: |
-          source ~/.bashrc
+          source "$HOME"/.bashrc
+
+          export
           
           module --version
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 
-
 [Omnibenchmark](https://omnibenchmark.org), a continuous benchmarking tool.
 
 ## Install
@@ -16,6 +15,8 @@
 With poetry or pip. With micromamba if handling software with conda. See [the tutorial](https://omnibenchmark.org/tutorial/).
 
 ## Developer notes
+
+### omni-schema
 
 Please note the [omni-schema](https://github.com/omnibenchmark/omni-schema) dependency. Benchmark YAML schemas are updated by:
 
@@ -25,6 +26,19 @@ Please note the [omni-schema](https://github.com/omnibenchmark/omni-schema) depe
 - Consider `make deploy`
 ```
 
+And that omni-schema versions are tagged and pinned at the pytoml level ([example](https://github.com/omnibenchmark/omnibenchmark/blob/2ce768bb2cfb693f3e555f751979093964eef63b/pyproject.toml#L38)), so omni-schema changes must precede omnibenchmark changes.
+
+### Docs
+
+Docs are served at https://omnibenchmark.org as generated on [Renku's GitLab](https://gitlab.renkulab.io/omnibenchmark/omni_site) with a [review/staging -> production flow](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/.gitlab-ci.yml?ref_type=heads). 
+
+Docs contain a CLI reference. This reference is generated/automated [via mkdocs-clic](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/docs/reference.md?ref_type=heads) and extracts the current CLI commands from [omnibenchmark's `main` head](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/requirements.txt?ref_type=heads#L7). Hence, changes to omnibenchmark must be merged to `main` and precede changes to omnibenchmark's documentation.
+
 ## Acknowledgements
 
 Omnibenchmark incorporates great FOSS components, including but not limited to: Snakemake, easybuild, apptainer, lmod, LinkML, git. Thank you!
+
+## Preprints
+
+- [Omnibenchmark (alpha) for continuous and open benchmarking in bioinformatics](https://arxiv.org/abs/2409.17038) (2024)
+- [Building a continuous benchmarking ecosystem in bioinformatics](https://arxiv.org/abs/2409.15472) (2024)

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Please note the [omni-schema](https://github.com/omnibenchmark/omni-schema) depe
 
 And that omni-schema versions are tagged and pinned at the pytoml level ([example](https://github.com/omnibenchmark/omnibenchmark/blob/2ce768bb2cfb693f3e555f751979093964eef63b/pyproject.toml#L38)), so omni-schema changes must precede omnibenchmark changes.
 
-### Docs
+### Documentation
 
-Docs are served at https://omnibenchmark.org as generated on [Renku's GitLab](https://gitlab.renkulab.io/omnibenchmark/omni_site) with a [review/staging -> production flow](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/.gitlab-ci.yml?ref_type=heads). 
+Omnibenchmark docs are served at https://omnibenchmark.org as generated on [Renku's GitLab](https://gitlab.renkulab.io/omnibenchmark/omni_site) with a [review/staging -> production flow](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/.gitlab-ci.yml?ref_type=heads). 
 
-Docs contain a CLI reference. This reference is generated/automated [via mkdocs-clic](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/docs/reference.md?ref_type=heads) and extracts the current CLI commands from [omnibenchmark's `main` head](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/requirements.txt?ref_type=heads#L7). Hence, changes to omnibenchmark must be merged to `main` and precede changes to omnibenchmark's documentation.
+Documentation includes a CLI reference. This reference is generated/automated [via mkdocs-click](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/docs/reference.md?ref_type=heads) and extracts the current CLI commands from [omnibenchmark's `main` head](https://gitlab.renkulab.io/omnibenchmark/omni_site/-/blob/master/requirements.txt?ref_type=heads#L7). Hence, changes to omnibenchmark must be merged to `main` and precede changes to omnibenchmark's documentation.
 
 ## Acknowledgements
 

--- a/mac-test-environment.yml
+++ b/mac-test-environment.yml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - conda-forge::python >=3.12
   - conda-forge::mamba >=1.5.8

--- a/mac-test-environment.yml
+++ b/mac-test-environment.yml
@@ -7,5 +7,6 @@ dependencies:
   - conda-forge::mamba >=1.5.8
   - conda-forge::pip >= 24.1.2
   - conda-forge::graphviz >= 0.20.3
+  - conda-forge::conda >= 24.9.1 # this is not a typo, we install conda with micromamba
   - pip:
      - "."

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - conda-forge::python >=3.12
   - conda-forge::mamba >=1.5.8


### PR DESCRIPTION
CI/CD and documentation fixes. No changes to the codebase.

1. Switched to an explicit `conda-forge::conda` installation to fix the `conda not found / 127` when running software tests on MacOS. For some reason, `conda` is not under the micromamba-managed `omnibenchmark` env there. Works on linux as it should, so this fix was only applied to the macos-specific software tests.
2. Also added `nodefaults` as channel to both linux and macos software testing environments, to rely solely on conda-forge and bioconda.
3. Also updated the global README to list preprints and documentation generation procedures.
