### PR TITLE
Improve github actions scripts

### DIFF
--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -29,6 +29,7 @@ concurrency:
 
 jobs:
   software_testing_linux:
+    permissions: write-all
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
@@ -104,6 +105,7 @@ jobs:
               conda_tests.py singularity_tests.py envmodules_tests.py test_run_with_software.py
 
   software_testing_mac:
+    permissions: write-all
     strategy:
       matrix:
         os: [macos-14] # [macos-14, macos-13]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
       #----------------------------------------------
       # Report coverage
       #----------------------------------------------
-      - if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' &&  matrix.poetry-version == '1.8.0' }}
+      - if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.poetry-version == '1.8.0' && github.event.pull_request.head.repo.full_name == github.repository }}
         name: Comment coverage result
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/mac-test-environment.yml
+++ b/mac-test-environment.yml
@@ -1,9 +1,11 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - conda-forge::python >=3.12
   - conda-forge::mamba >=1.5.8
   - conda-forge::pip >= 24.1.2
+  - conda-forge::conda >= 24.9.1 # this is not a typo, we install conda with micromamba
   - pip:
      - "."

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - conda-forge::python >=3.12
   - conda-forge::mamba >=1.5.8


### PR DESCRIPTION
## Ticket

In reference to failing tests on [this](https://github.com/omnibenchmark/omnibenchmark/pull/20) PR, which was opened from a fork.

## Description

The error `Resource not accessible by integration` occurs because GitHub Actions running on pull requests (PRs) from forked repositories have restricted permissions for security reasons. Specifically, these workflows can't access sensitive resources like secrets, write comments, or interact with the GitHub API, unless the `pull_request_target` event is used, which triggers the workflow in the base repository with higher permissions.

However, setting `pull_request_target` opens the backdoor for other security concerns. The simple alternative, which I implemented in this PR, is to simply not comment coverage report (skip step) on PRs opened by non-trusted contributors from forked repositories.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My CLI method respects the signature defined in the task.
- [ ] I have documented the CLI method accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a CHANGELOG entry.

## Remarks for the reviewer: