### PR TITLE
Write generated Snakefile in temporary files for execution

### DIFF
--- a/omni/workflow/snakemake/snakemake.py
+++ b/omni/workflow/snakemake/snakemake.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from pathlib import Path
 from typing import TextIO, List, Optional
 
@@ -50,7 +51,7 @@ class SnakemakeEngine(WorkflowEngine):
         """
 
         # Serialize Snakefile for workflow
-        snakefile = self.serialize_workflow(benchmark, work_dir)
+        snakefile = self.serialize_workflow(benchmark, work_dir, write_to_disk=False)
 
         # Prepare the argv list
         argv = self._prepare_argv(
@@ -64,7 +65,10 @@ class SnakemakeEngine(WorkflowEngine):
         return success
 
     def serialize_workflow(
-        self, benchmark: Benchmark, output_dir: Path = Path(os.getcwd())
+        self,
+        benchmark: Benchmark,
+        output_dir: Path = Path(os.getcwd()),
+        write_to_disk=True,
     ) -> Path:
         """
         Serializes a Snakefile for the benchmark.
@@ -72,6 +76,7 @@ class SnakemakeEngine(WorkflowEngine):
         Args:
             benchmark (Benchmark): benchmark to serialize
             output_dir (str): output directory for the Snakefile
+            write_to_disk (bool): if write_to_disk is True, create Snakefile on disk, else create an in-memory temp file
 
         Returns:
         - Snakefile path.
@@ -83,8 +88,15 @@ class SnakemakeEngine(WorkflowEngine):
         version = benchmark.get_benchmark_version()
         author = benchmark.get_benchmark_author()
 
+        if write_to_disk:
+            snakefile_path = Path(os.path.join(output_dir, "Snakefile"))
+        else:
+            temp_file = tempfile.NamedTemporaryFile(
+                delete=False, mode="w+", suffix=".smk", encoding="utf-8"
+            )
+            snakefile_path = Path(temp_file.name)
+
         # Serialize Snakemake file
-        snakefile_path = Path(os.path.join(output_dir, "Snakefile"))
         with open(snakefile_path, "w", encoding="utf-8") as f:
             self._write_snakefile_header(f, name, version, author)
             self._write_includes(f, INCLUDES)
@@ -136,7 +148,7 @@ class SnakemakeEngine(WorkflowEngine):
         os.makedirs(work_dir, exist_ok=True)
 
         # Serialize Snakefile for node workflow
-        snakefile = self.serialize_node_workflow(node, work_dir)
+        snakefile = self.serialize_node_workflow(node, work_dir, write_to_disk=False)
 
         # Prepare the argv list
         argv = self._prepare_argv(
@@ -158,7 +170,10 @@ class SnakemakeEngine(WorkflowEngine):
         return success
 
     def serialize_node_workflow(
-        self, node: BenchmarkNode, output_dir: Path = Path(os.getcwd())
+        self,
+        node: BenchmarkNode,
+        output_dir: Path = Path(os.getcwd()),
+        write_to_disk=True,
     ) -> Path:
         """
         Serializes a Snakefile for a benchmark node.
@@ -166,6 +181,7 @@ class SnakemakeEngine(WorkflowEngine):
         Args:
             node (BenchmarkNode): benchmark node to serialize
             output_dir (str): output directory for the Snakefile
+            write_to_disk (bool): if write_to_disk is True, create Snakefile on disk, else create an in-memory temp file
 
         Returns:
         - Snakefile path.
@@ -177,8 +193,15 @@ class SnakemakeEngine(WorkflowEngine):
         version = node.get_benchmark_version()
         author = node.get_benchmark_author()
 
+        if write_to_disk:
+            snakefile_path = Path(os.path.join(output_dir, "Snakefile"))
+        else:
+            temp_file = tempfile.NamedTemporaryFile(
+                delete=False, mode="w+", suffix=".smk", encoding="utf-8"
+            )
+            snakefile_path = Path(temp_file.name)
+
         # Serialize Snakemake file
-        snakefile_path = Path(os.path.join(output_dir, "Snakefile"))
         with open(snakefile_path, "w") as f:
             self._write_snakefile_header(f, name, version, author)
             self._write_includes(f, INCLUDES)


### PR DESCRIPTION
## Ticket

No reference ticket.

## Description

Instead of writing a permanent Snakefile when using the `ob benchmark run` command, serialize the workflow in temporary files that are later automatically deleted.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My CLI method respects the signature defined in the task.
- [ ] I have documented the CLI method accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a CHANGELOG entry.

## Remarks for the reviewer:
-