### PR TITLE
Fix macOS software testing R segfault

### DIFF
--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -162,6 +162,8 @@ jobs:
 
       - name: Install R packages
         run: |
+          mkdir -p ~/work/Rlib
+          export R_LIBS_USER=~/work/Rlib
           Rscript -e "install.packages(c('argparse', 'readr', 'dplyr', 'mclust', 'caret'))"
 
       - name: Modify python version in test env
@@ -197,7 +199,14 @@ jobs:
            
            cat <<'EOF' >>~/.bash_profile
            source ~/.bashrc
+           ls -l ~/.bashrc
            EOF
+
+           echo 'bashrc and bash_profile permissions:'
+           head ~/.bash*
+           stat -c "%a %n" ~/.bash*
+           echo $(whoami)
+         
 
       - name: Test
         env:
@@ -223,7 +232,8 @@ jobs:
           
           ## install required Python dependenices
           pip install numpy pandas scikit-learn scipy
-          
+
+          export R_LIBS_USER=~/work/Rlib
           # pip install --user --force-reinstall --ignore-installed --no-binary :all: boto3
           pytest -v -x --show-capture=stderr \
                --splits 2 --group ${{ matrix.test_group }} \

--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -195,18 +195,12 @@ jobs:
                 source /usr/local/opt/lmod/init/profile
            fi
            eval "$(micromamba shell hook --shell bash)"
+           export R_LIBS=~/work/Rlib
            EOF
            
            cat <<'EOF' >>~/.bash_profile
            source ~/.bashrc
-           ls -l ~/.bashrc
-           EOF
-
-           echo 'bashrc and bash_profile permissions:'
-           head ~/.bash*
-           ls -la ~/.bash*
-           echo $(whoami)
-         
+           EOF         
 
       - name: Test
         env:
@@ -232,8 +226,7 @@ jobs:
           
           ## install required Python dependenices
           pip install numpy pandas scikit-learn scipy
-
-          export R_LIBS=~/work/Rlib
+          
           # pip install --user --force-reinstall --ignore-installed --no-binary :all: boto3
           pytest -v -x --show-capture=stderr \
                --splits 2 --group ${{ matrix.test_group }} \

--- a/.github/workflows/software_tests.yml
+++ b/.github/workflows/software_tests.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install R packages
         run: |
           mkdir -p ~/work/Rlib
-          export R_LIBS_USER=~/work/Rlib
+          export R_LIBS=~/work/Rlib
           Rscript -e "install.packages(c('argparse', 'readr', 'dplyr', 'mclust', 'caret'))"
 
       - name: Modify python version in test env
@@ -204,7 +204,7 @@ jobs:
 
            echo 'bashrc and bash_profile permissions:'
            head ~/.bash*
-           stat -c "%a %n" ~/.bash*
+           ls -la ~/.bash*
            echo $(whoami)
          
 
@@ -233,7 +233,7 @@ jobs:
           ## install required Python dependenices
           pip install numpy pandas scikit-learn scipy
 
-          export R_LIBS_USER=~/work/Rlib
+          export R_LIBS=~/work/Rlib
           # pip install --user --force-reinstall --ignore-installed --no-binary :all: boto3
           pytest -v -x --show-capture=stderr \
                --splits 2 --group ${{ matrix.test_group }} \


### PR DESCRIPTION
Fixes the software tests in [macOS with R segfaulting](https://github.com/omnibenchmark/omnibenchmark/actions/runs/12142454509/job/33960662377) with: 

```bash
RuntimeError: ERROR: Executing ward.R failed with exit code -11:  
 *** caught segfault ***
address 0x0, cause 'invalid permissions'

Traceback:
 1: dyn.load(file, DLLpath = DLLpath, ...)
 2: library.dynam(lib, package, package.lib)
 3: loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]])
 4: namespaceImport(ns, loadNamespace(i, c(lib.loc, .libPaths()),     versionCheck = vI[[i]]), from = package)
 5: loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]])
 6: asNamespace(ns)
 7: namespaceImportFrom(ns, loadNamespace(j <- i[[1L]], c(lib.loc,     .libPaths()), versionCheck = vI[[j]]), i[[2L]], from = package)
 8: loadNamespace(package, lib.loc)
 9: doTryCatch(return(expr), name, parentenv, handler)
10: tryCatchOne(expr, names, parentenv, handlers[[1L]])
11: tryCatchList(expr, classes, parentenv, handlers)
12: tryCatch({    attr(package, "LibPath") <- which.lib.loc    ns <- loadNamespace(package, lib.loc)    env <- attachNamespace(ns, pos = pos, deps, exclude, include.only)}, error = function(e) {    P <- if (!is.null(cc <- conditionCall(e)))         paste(" in", deparse(cc)[1L])    else ""    msg <- gettextf("package or namespace load failed for %s%s:\n %s",         sQuote(package), P, conditionMessage(e))    if (logical.return && !quietly)         message(paste("Error:", msg), domain = NA)    else stop(msg, call. = FALSE, domain = NA)})
13: library(readr)
An irrecoverable exception occurred. R is aborting now ...
```

In short this is an library path problem so I've added an explicit R_LIBS declaration to solve the issue.

Minor and related to the same software tests action file: also fixed the `.bash_profile`, which tried to `ls` the `.bashrc` and couldn't - and was not needed.