### PR TITLE
Fix race condition when cloning github repos

### DIFF
--- a/omni/workflow/snakemake/scripts/run_module.py
+++ b/omni/workflow/snakemake/scripts/run_module.py
@@ -44,10 +44,12 @@ def clone_module(output_dir: Path, repository_url: str, commit_hash: str) -> Pat
         repo = git.Repo.clone_from(repository_url, module_dir.as_posix())
         repo.git.checkout(commit_hash)
 
+        return repo
+
     lock = module_dir.with_suffix(".lock")
     with FileLock(lock):
         if not module_dir.exists():
-            clone()
+            repo = clone()
         else:
             repo = git.Repo(module_dir.as_posix())
             if repo.bare:
@@ -55,7 +57,7 @@ def clone_module(output_dir: Path, repository_url: str, commit_hash: str) -> Pat
                     f"Removing incomplete repo {module_dir} and retrying..."
                 )
                 shutil.rmtree(module_dir)
-                clone()
+                repo = clone()
 
         if repo.head.commit.hexsha[:7] != commit_hash:
             logging.error(

--- a/omni/workflow/snakemake/scripts/run_module.py
+++ b/omni/workflow/snakemake/scripts/run_module.py
@@ -4,12 +4,14 @@
 import hashlib
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import List
 
 from snakemake.script import Snakemake
+from filelock import FileLock
 
 from omni.workflow.snakemake.scripts.execution import execution
 
@@ -26,7 +28,7 @@ def clone_module(output_dir: Path, repository_url: str, commit_hash: str) -> Pat
     try:
         import git  # Check if gitpython is available
     except ImportError:
-        print("gitpython is not installed. Installing now...")
+        logging.info("gitpython is not installed. Installing now...")
         subprocess.check_call(
             [sys.executable, "-m", "pip", "install", "gitpython==3.1.43"]
         )
@@ -35,23 +37,36 @@ def clone_module(output_dir: Path, repository_url: str, commit_hash: str) -> Pat
     module_name = generate_unique_repo_folder_name(repository_url, commit_hash)
     module_dir = output_dir / module_name
 
-    if not module_dir.exists():
+    def clone():
         logging.info(
             f"Cloning module `{repository_url}:{commit_hash}` to `{module_dir.as_posix()}`"
         )
         repo = git.Repo.clone_from(repository_url, module_dir.as_posix())
         repo.git.checkout(commit_hash)
-    else:
-        repo = git.Repo(module_dir.as_posix())
 
-    if repo.head.commit.hexsha[:7] != commit_hash:
-        logging.error(
-            f"ERROR: Failed while cloning module `{repository_url}:{commit_hash}`"
-        )
-        logging.error(f"{commit_hash} does not match {repo.head.commit.hexsha[:7]}`")
-        raise RuntimeError(
-            f"ERROR: {commit_hash} does not match {repo.head.commit.hexsha[:7]}"
-        )
+    lock = module_dir.with_suffix(".lock")
+    with FileLock(lock):
+        if not module_dir.exists():
+            clone()
+        else:
+            repo = git.Repo(module_dir.as_posix())
+            if repo.bare:
+                logging.warning(
+                    f"Removing incomplete repo {module_dir} and retrying..."
+                )
+                shutil.rmtree(module_dir)
+                clone()
+
+        if repo.head.commit.hexsha[:7] != commit_hash:
+            logging.error(
+                f"ERROR: Failed while cloning module `{repository_url}:{commit_hash}`"
+            )
+            logging.error(
+                f"{commit_hash} does not match {repo.head.commit.hexsha[:7]}`"
+            )
+            raise RuntimeError(
+                f"ERROR: {commit_hash} does not match {repo.head.commit.hexsha[:7]}"
+            )
 
     return module_dir
 


### PR DESCRIPTION
## Ticket

No reference ticket.

## Description

When a benchmark includes the same repository as different modules, the current implementation attempts to clone it multiple times. This is not problematic in a single-threaded environment. However, when running with multiple threads, concurrent cloning of the same repository by different threads can lead to race conditions and inconsistent repository states.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My CLI method respects the signature defined in the task.
- [ ] I have documented the CLI method accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a CHANGELOG entry.

## Remarks for the reviewer:
- Solved using a file lock on the module directory.