### PR TITLE
Add benchmark directives to rules (without collection)

### DIFF
--- a/omni/workflow/snakemake/format/formatter.py
+++ b/omni/workflow/snakemake/format/formatter.py
@@ -2,6 +2,7 @@ import re
 from itertools import takewhile
 from pathlib import Path
 from typing import List, Set, Tuple, Union, NamedTuple
+import os.path as op
 
 from omni.benchmark import BenchmarkNode, Benchmark
 
@@ -10,6 +11,14 @@ class Wildcards(NamedTuple):
     pre: str
     post: str
     dataset: str
+
+
+def format_performance_file(node: BenchmarkNode) -> str:
+    """Provides a benchmark performance path for a node"""
+
+    outputs = format_output_templates_to_be_expanded(node)
+
+    return op.join(op.dirname(outputs[0]), "{dataset}_performance.txt")
 
 
 def format_output_templates_to_be_expanded(node: BenchmarkNode) -> List[str]:

--- a/omni/workflow/snakemake/rules/rule_node.smk
+++ b/omni/workflow/snakemake/rules/rule_node.smk
@@ -41,6 +41,8 @@ def _create_initial_node(benchmark, node, config):
             _get_environment_path(benchmark, node, SoftwareBackendEnum.envmodules) or "module/not_provided/0.0.0"
         container:
             _get_environment_path(benchmark, node, SoftwareBackendEnum.apptainer) or "container_not_provided.sif"
+        benchmark:
+            formatter.format_performance_file(node)
         params:
             repository_url = repository_url,
             commit_hash = commit_hash,
@@ -87,6 +89,8 @@ def _create_intermediate_node(benchmark, node, config):
             _get_environment_path(benchmark, node, SoftwareBackendEnum.envmodules) or "module/not_provided/0.0.0"
         container:
             _get_environment_path(benchmark, node, SoftwareBackendEnum.apptainer) or "container_not_provided.sif"
+        benchmark:
+            formatter.format_performance_file(node)
         params:
             inputs_map = inputs_map,
             repository_url = repository_url,


### PR DESCRIPTION
This is a slim variant of #45

## Ticket

No ticket.

## Description

Collect benchmarks per rule/node, i.e.

```
$ cat ./out/data/clustbench/param_0/clustering/fastcluster/param_1/metrics/partition_metrics/param_7/clustbench_performance.txt
s       h:m:s   max_rss max_vms max_uss max_pss io_in   io_out  mean_load       cpu_time
3.6763  0:00:03 70.93   79.91   59.22   64.69   24.13   0.01    0.00    1.04
```

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My CLI method respects the signature defined in the task.
- [ ] I have documented the CLI method accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a CHANGELOG entry.

## Remarks for the reviewer:

Collection/aggregation is still pending, this generates one file per rule (run).