### PR TITLE
Failed attempt to add extra flag (akin to --keep-going)

### DIFF
--- a/omni/cli/run.py
+++ b/omni/cli/run.py
@@ -149,6 +149,13 @@ def run_benchmark(
     default=False,
 )
 @click.option(
+    "-k",
+    "--continue-on-error",
+    help="Go on with independent jobs if a job fails (--keep-going in snakemake).",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--keep-module-logs/--no-keep-module-logs",
     default=False,
     help="Keep module-specific log files after execution.",

--- a/omni/cli/run.py
+++ b/omni/cli/run.py
@@ -44,6 +44,7 @@ def run(ctx):
     default=False,
 )
 @click.option("-d", "--dry", help="Dry run.", is_flag=True, default=False)
+@click.option("-k", "--continue-on-error", help="Go on with independent jobs if a job fails (--keep-going in snakemake).", is_flag=True, default=False)
 @click.option(
     "-l",
     "--local",
@@ -57,7 +58,7 @@ def run(ctx):
     help="Keep module-specific log files after execution.",
 )
 @click.pass_context
-def run_benchmark(ctx, benchmark, threads, update, dry, local, keep_module_logs):
+def run_benchmark(ctx, benchmark, threads, update, dry, local, keep_module_logs, continue_on_error):
     """Run a benchmark as specified in the yaml."""
     ctx.ensure_object(dict)
 
@@ -68,6 +69,13 @@ def run_benchmark(ctx, benchmark, threads, update, dry, local, keep_module_logs)
     benchmark = validate_benchmark(benchmark)
     workflow: WorkflowEngine = SnakemakeEngine()
 
+    ## it is as --continue_on_error originally
+    if continue_on_error:
+        keepgoing_prompt = click.confirm(
+            "Are you sure you want to run the full benchmark even if some jobs fail?", abort=True
+        )
+        if not keepgoing_prompt:
+            raise click.Abort()
     if update and not dry:
         update_prompt = click.confirm(
             "Are you sure you want to re-run the entire workflow?", abort=True
@@ -92,6 +100,7 @@ def run_benchmark(ctx, benchmark, threads, update, dry, local, keep_module_logs)
         cores=threads,
         update=update,
         dryrun=dry,
+        continue_on_error=continue_on_error,
         keep_module_logs=keep_module_logs,
         backend=benchmark.get_benchmark_software_backend(),
         **storage_options,
@@ -136,7 +145,7 @@ def run_benchmark(ctx, benchmark, threads, update, dry, local, keep_module_logs)
     help="Keep module-specific log files after execution.",
 )
 @click.pass_context
-def run_module(ctx, benchmark, module, input_dir, dry, update, keep_module_logs):
+def run_module(ctx, benchmark, module, input_dir, dry, update, keep_module_logs, continue_on_error):
     """
     Run a specific module that is part of the benchmark.
     """
@@ -241,6 +250,7 @@ def run_module(ctx, benchmark, module, input_dir, dry, update, keep_module_logs)
                                     cores=1,
                                     update=update,
                                     dryrun=dry,
+                                    continue_on_error=continue_on_error,
                                     keep_module_logs=keep_module_logs,
                                     backend=benchmark.get_benchmark_software_backend(),
                                 )

--- a/omni/cli/run.py
+++ b/omni/cli/run.py
@@ -44,7 +44,13 @@ def run(ctx):
     default=False,
 )
 @click.option("-d", "--dry", help="Dry run.", is_flag=True, default=False)
-@click.option("-k", "--continue-on-error", help="Go on with independent jobs if a job fails (--keep-going in snakemake).", is_flag=True, default=False)
+@click.option(
+    "-k",
+    "--continue-on-error",
+    help="Go on with independent jobs if a job fails (--keep-going in snakemake).",
+    is_flag=True,
+    default=False,
+)
 @click.option(
     "-l",
     "--local",
@@ -58,7 +64,9 @@ def run(ctx):
     help="Keep module-specific log files after execution.",
 )
 @click.pass_context
-def run_benchmark(ctx, benchmark, threads, update, dry, local, keep_module_logs, continue_on_error):
+def run_benchmark(
+    ctx, benchmark, threads, update, dry, local, keep_module_logs, continue_on_error
+):
     """Run a benchmark as specified in the yaml."""
     ctx.ensure_object(dict)
 
@@ -72,7 +80,8 @@ def run_benchmark(ctx, benchmark, threads, update, dry, local, keep_module_logs,
     ## it is as --continue_on_error originally
     if continue_on_error:
         keepgoing_prompt = click.confirm(
-            "Are you sure you want to run the full benchmark even if some jobs fail?", abort=True
+            "Are you sure you want to run the full benchmark even if some jobs fail?",
+            abort=True,
         )
         if not keepgoing_prompt:
             raise click.Abort()
@@ -145,7 +154,9 @@ def run_benchmark(ctx, benchmark, threads, update, dry, local, keep_module_logs,
     help="Keep module-specific log files after execution.",
 )
 @click.pass_context
-def run_module(ctx, benchmark, module, input_dir, dry, update, keep_module_logs, continue_on_error):
+def run_module(
+    ctx, benchmark, module, input_dir, dry, update, keep_module_logs, continue_on_error
+):
     """
     Run a specific module that is part of the benchmark.
     """

--- a/omni/workflow/snakemake/snakemake.py
+++ b/omni/workflow/snakemake/snakemake.py
@@ -58,17 +58,16 @@ class SnakemakeEngine(WorkflowEngine):
 
         # Serialize Snakefile for workflow
         snakefile = self.serialize_workflow(benchmark, work_dir, write_to_disk=False)
-
         # Prepare the argv list
         argv = self._prepare_argv(
-            snakefile,
-            cores,
-            update,
-            dryrun,
-            continue_on_error,
-            keep_module_logs,
-            backend,
-            work_dir,
+            snakefile=snakefile,
+            cores=cores,
+            update=update,
+            dryrun=dryrun,
+            continue_on_error=continue_on_error,
+            keep_module_logs=keep_module_logs,
+            backend=backend,
+            work_dir=work_dir,
             **snakemake_kwargs,
         )
 
@@ -186,16 +185,16 @@ class SnakemakeEngine(WorkflowEngine):
 
         # Prepare the argv list
         argv = self._prepare_argv(
-            snakefile,
-            cores,
-            update,
-            dryrun,
-            continue_on_error,
-            keep_module_logs,
-            backend,
-            work_dir,
-            input_dir,
-            dataset,
+            snakefile=snakefile,
+            cores=cores,
+            update=update,
+            dryrun=dryrun,
+            continue_on_error=continue_on_error,
+            keep_module_logs=keep_module_logs,
+            backend=backend,
+            work_dir=work_dir,
+            input_dir=input_dir,
+            dataset=dataset,
             **snakemake_kwargs,
         )
 
@@ -312,7 +311,6 @@ class SnakemakeEngine(WorkflowEngine):
         **snakemake_kwargs,
     ):
         """Prepare arguments to input to the snakemake cli"""
-
         argv = [
             "--snakefile",
             str(snakefile),

--- a/omni/workflow/snakemake/snakemake.py
+++ b/omni/workflow/snakemake/snakemake.py
@@ -30,6 +30,7 @@ class SnakemakeEngine(WorkflowEngine):
         cores: int = 1,
         update: bool = True,
         dryrun: bool = False,
+        continue_on_error: bool = False,
         keep_module_logs: bool = False,
         work_dir: Path = Path(os.getcwd()),
         backend: SoftwareBackendEnum = SoftwareBackendEnum.host,
@@ -44,6 +45,7 @@ class SnakemakeEngine(WorkflowEngine):
             cores (int): number of cores to run. Defaults to 1 core.
             update (bool): run workflow for non-existing outputs / changed nodes only. False means force running workflow from scratch. Default: True
             dryrun (bool): validate the workflow with the benchmark without actual execution. Default: False
+            continue_on_error (bool): continue with independent jobs if a job fails. Default: False
             keep_module_logs (bool): keep module-specific log files after execution. Default: False
             backend (SoftwareBackendEnum): which software backend to use when running the workflow. Available: `host`, `docker`, `apptainer`, `conda`, `envmodules`. Default: `host`
             module_path (str): The path where the `envmodules` are located. This path will be searched during the workflow run using `envmodules` backend.
@@ -63,6 +65,7 @@ class SnakemakeEngine(WorkflowEngine):
             cores,
             update,
             dryrun,
+            continue_on_error,
             keep_module_logs,
             backend,
             work_dir,
@@ -148,6 +151,7 @@ class SnakemakeEngine(WorkflowEngine):
         cores: int = 1,
         update: bool = True,
         dryrun: bool = False,
+        continue_on_error: bool = False,
         keep_module_logs: bool = False,
         backend: SoftwareBackendEnum = SoftwareBackendEnum.host,
         module_path: str = os.environ.get("MODULEPATH", None),
@@ -164,6 +168,7 @@ class SnakemakeEngine(WorkflowEngine):
             cores (int): number of cores to run. Defaults to 1 core.
             update (bool): run workflow for non-existing outputs / changed nodes only. False means force running workflow from scratch. Default: True
             dryrun (bool): validate the workflow with the benchmark without actual execution. Default: False
+            continue_on_error (bool): continue with independent jobs if a job fails. Default: False
             keep_module_logs (bool): keep module-specific log files after execution. Default: False
             backend (SoftwareBackendEnum): which software backend to use when running the workflow. Available: `host`, `docker`, `apptainer`, `conda`, `envmodules`. Default: `host`
             module_path (str): The path where the `envmodules` are located. This path will be searched during the workflow run using `envmodules` backend.
@@ -185,6 +190,7 @@ class SnakemakeEngine(WorkflowEngine):
             cores,
             update,
             dryrun,
+            continue_on_error,
             keep_module_logs,
             backend,
             work_dir,
@@ -298,6 +304,7 @@ class SnakemakeEngine(WorkflowEngine):
         update: bool,
         dryrun: bool,
         keep_module_logs: bool,
+        continue_on_error: bool,
         backend: SoftwareBackendEnum,
         work_dir: Path,
         input_dir: Optional[Path] = None,
@@ -324,6 +331,9 @@ class SnakemakeEngine(WorkflowEngine):
 
         if dryrun:
             argv.append("--dryrun")
+
+        if continue_on_error:
+            argv.append("--keep-going")
 
         if (
             backend == SoftwareBackendEnum.docker

--- a/omni/workflow/workflow.py
+++ b/omni/workflow/workflow.py
@@ -17,6 +17,7 @@ class WorkflowEngine(metaclass=ABCMeta):
         cores: int = 1,
         update: bool = True,
         dryrun: bool = False,
+        continue_on_error: bool = False,
         keep_module_logs: bool = False,
         backend: SoftwareBackendEnum = SoftwareBackendEnum.host,
         module_path: str = os.environ.get("MODULEPATH", None),
@@ -31,6 +32,7 @@ class WorkflowEngine(metaclass=ABCMeta):
             cores (int): number of cores to run. Defaults to 1 core.
             update (bool): run workflow for non-existing outputs / changed nodes only. False means force running workflow from scratch. Default: True
             dryrun (bool): validate the workflow with the benchmark without actual execution. Default: False
+            continue_on_error (bool): continue with independent jobs if a job fails. Default: False
             keep_module_logs (bool): keep module-specific log files after execution. Default: False
             backend (SoftwareBackendEnum): which software backend to use when running the workflow. Available: `host`, `docker`, `apptainer`, `conda`, `envmodules`. Default: `host`
             module_path (str): The path where the `envmodules` are located. This path will be searched during the workflow run using `envmodules` backend.
@@ -67,6 +69,7 @@ class WorkflowEngine(metaclass=ABCMeta):
         cores: int = 1,
         update: bool = True,
         dryrun: bool = False,
+        continue_on_error: bool = False,
         keep_module_logs: bool = False,
         backend: SoftwareBackendEnum = SoftwareBackendEnum.host,
         module_path: str = os.environ.get("MODULEPATH", None),
@@ -83,6 +86,7 @@ class WorkflowEngine(metaclass=ABCMeta):
             cores (int): number of cores to run. Defaults to 1 core.
             update (bool): run workflow for non-existing outputs / changed nodes only. False means force running workflow from scratch. Default: True
             dryrun (bool): validate the workflow with the benchmark without actual execution. Default: False
+            continue_on_error (bool): continue with independent jobs if a job fails. Default: False
             keep_module_logs (bool): keep module-specific log files after execution. Default: False
             backend (SoftwareBackendEnum): which software backend to use when running the workflow. Available: `host`, `docker`, `apptainer`, `conda`, `envmodules`. Default: `host`
             module_path (str): The path where the `envmodules` are located. This path will be searched during the workflow run using `envmodules` backend.


### PR DESCRIPTION
This is an "understanding the codebase" question. I'm trying to add a `--keep-going` snakemake flag when the CLI has it (well, `--continue-on-error`). What I am missing to be able to make it run? The snakemake call does not recognize `keep_going` as being `True` even after passing the CLI command.