### PR TITLE
wip: add a timeout resource annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,9 +162,16 @@ cython_debug/
 # tildes
 *~
 
+# pixi environments (not using it officially yet)
+.pixi
+pixi.lock
+pixi.toml
+
+# snakemake stuff
+Snakefile
+.snakemake/
+
 # Custom omni-benchmark specific folders
 out/
 log/
-.snakemake/
 output_dag.png
-Snakefile

--- a/omni/benchmark/constants.py
+++ b/omni/benchmark/constants.py
@@ -1,0 +1,5 @@
+from typing import Final
+
+# DEFAULT_TIMEOUT_SECONDS is the max value we'll try to enforce as a timeout for the spawned task.
+# This is currently only enforced on local environments (but we can pass the same value to job queues)
+DEFAULT_TIMEOUT_SECONDS: Final[int] = 8 * 60 * 60  # Default is 4 hours

--- a/omni/workflow/snakemake/rules/rule_node.smk
+++ b/omni/workflow/snakemake/rules/rule_node.smk
@@ -2,6 +2,7 @@ import os
 
 from omni_schema.datamodel.omni_schema import SoftwareBackendEnum, Benchmark
 
+from omni.benchmark import constants
 from omni.benchmark import Validator, BenchmarkNode
 from omni.workflow.snakemake import scripts
 from omni.workflow.snakemake.format import formatter
@@ -21,6 +22,8 @@ def _create_initial_node(benchmark, node, config):
     repository = node.get_repository()
     repository_url = repository.url if repository else None
     commit_hash = repository.commit if repository else None
+
+    timeout = config.get("timeout", constants.DEFAULT_TIMEOUT_SECONDS)
 
     rule:
         name: f"{{stage}}_{{module}}_{{param}}".format(stage=stage_id,module=module_id,param=param_id)
@@ -49,6 +52,8 @@ def _create_initial_node(benchmark, node, config):
             parameters = node.get_parameters(),
             dataset = module_id,
             keep_module_logs=config['keep_module_logs']
+        resources:
+            timeout=timeout
         script: os.path.join(os.path.dirname(os.path.realpath(scripts.__file__)), 'run_module.py')
 
 


### PR DESCRIPTION
## Ticket

#65 

## Description

Adds a timeout annotation onto the node rule, and enforces the same timeout (in seconds) in the first child process spawned.

In the future, the same parameter can be passed to the cluster executor.

This PR is missing to expose the timeout either in the cli (as a global max) or in the yaml Spec (I'd rather not touch that). Thoughts are welcome.

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My CLI method respects the signature defined in the task.
- [ ] I have documented the CLI method accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a CHANGELOG entry.
