### PR TITLE
ci: simplify linter check

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -7,45 +7,26 @@ jobs:
   code-style:
     runs-on: ubuntu-latest
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Set up python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
-      - name: Install library
-        run: poetry install --no-interaction
-      #----------------------------------------------
-      # Check coding style using black
-      #----------------------------------------------
+          python-version: "3.12"
+
+      - name: Install Linters
+        run: pip install black ruff
+
+      # For the time being, let's keep the black check as the
+      # only mandatory step.
       - name: Check coding style
-        run: poetry run black --check .
+        run: black --check .
+
+      # Optional Ruff check (allowed to fail)
+      # Ruff if faster, but it's throwing a wider variety of errors that still need
+      # work to be fixed.
+      - name: Lint with Ruff (optional)
+        continue-on-error: true # 👈 This makes the job pass even if Ruff fails
+        run: |
+          ruff check .
+          echo "Note: Ruff failures are non-blocking for now"

--- a/omni/software/common.py
+++ b/omni/software/common.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Common omniblock software management logics, regardless of conda/easybuild/system. 
+Common omniblock software management logics, regardless of conda/easybuild/system.
 Calls workflow capabilities to reuse schema / yaml parsing logics
 """
 

--- a/omni/utils.py
+++ b/omni/utils.py
@@ -1,4 +1,4 @@
-""" General utils functions"""
+"""General utils functions"""
 
 import os
 

--- a/tests/io/MinIOStorage_setup.py
+++ b/tests/io/MinIOStorage_setup.py
@@ -54,12 +54,11 @@ class TmpMinIOStorage:
             del self.auth_options_readonly["access_key"]
             del self.auth_options_readonly["secret_key"]
 
-            self.auth_options_readonly[
-                "endpoint"
-            ] = "http://" + self.auth_options_readonly["endpoint"].replace(
-                "http://", ""
-            ).replace(
-                "https://", ""
+            self.auth_options_readonly["endpoint"] = (
+                "http://"
+                + self.auth_options_readonly["endpoint"]
+                .replace("http://", "")
+                .replace("https://", "")
             )
 
             self.bucket_name = testcontainer.bucket_names.pop()


### PR DESCRIPTION
There's no need to install poetry or dependencies to run a linter. this change makes for a faster check time, and solves cacheing issues while fixing linting during PRs.

since I was there, I added an optional step for linting with ruff, which is usually preferred nowadays. ruff has ~100x faster linting/formatting, and catches a wider range of code problems.

since it needs some fixing in the codebase (many unused imports, for instance) I left the ruff validation as non-blocking.
