### PR TITLE
Update installation docs in line with #143

### DIFF
--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -63,35 +63,11 @@ software_environments:
 
 ## Choosing the right software backend (lmod, singularity, conda)
 
-Omnibenchmark is written in python and depends only on pypi packages. Some of its dependencies, namely those related to (reproducible) software stack management, are OS-specific.
+Omnibenchmark itself is a python package. Some of its dependencies, namely those related to (reproducible) software stack management, are OS-specific.
 
-
-| OS                 |  `envmodules`           | `singularity`          |      `conda`          |      `cernvmfs`        |
-| -----------        |  -------------------    | ----------------       |  ----------------     | ---------------        |
-| `Linux`            |  :material-check-all:   | :material-check-all:   |  :material-check-all: | (:material-check-all:) |
-| `MacOS`            |  :material-check:       | :material-close:       |  :material-check-all: | (:material-check-all:) |
-| `Windows`          |  :material-close:       | :material-close:       |    :material-help:    |   :material-help:     |
-
-
-
-On Linux, software can be managed:
+Software can be managed:
 
 - Using the host's binaries. If relevant interpreters/software are in your $PATH (perhaps using a virtual environment, or directly), they're accessible to omnibenchmark.
-- Using conda. For that [mamba](https://github.com/mamba-org/mamba) is required. We provide an `environment.yaml` to help building the environment. 
-- Using singularity. For that, apptainer is needed.
+- Using conda. For that `conda` is required. We provide a conda environment YAML to help installing all dependencies. 
+- Using apptainer. For that, apptainer is needed.
 - Using environment modules (lmod). For that, lmod is needed.
-
-Similarly, on MacOS:
-
-- Using the host's binaries. If relevant interpreters/software are in your $PATH (perhaps using a virtual environment, or directly), they're accessible to omnibenchmark.
-- Using conda. For that [mamba](https://github.com/mamba-org/mamba) is required. We provide an `environment.yaml` to help building the environment. 
-- Using singularity. It won't work unless using a virtual machine to provide a Linux-friendly host to singularity.
-- Using environment modules (lmod). For that, lmod needs to be installed.
-
-We haven't fully tested omnibenchmark on Windows, but we would recommend using the  Windows Subsystem for Linux (WSL).
-
-
-
-## Enabling networking in singularity containers
-
-(Updating)

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,13 +1,10 @@
 ## Install omnibenchmark
 
-Omnibenchmark runs on different operating systems (OS) and architectures. The installation procedure impacts omnibenchmark capabilities to manage software during benchmarking. We recommend installing using micromamba.
+Omnibenchmark is a pip-installable python package ([PyPI](https://pypi.org/project/omnibenchmark/), [source code](https://github.com/omnibenchmark/omnibenchmark)). However, omnibenchmark aims to facilitate benchmarking using different software backends, including `conda`, `apptainer` (formerly `singularity`), or `easybuild`-built envmodules. Hence, extra steps to install some requirements (e.g., `apptainer`, `envmodules`, and so on) are required.
 
+Omnibenchmark has been tested under GNU/Linux.
 
-| capabilities              |  `system`           | `singularity`      |     `lmod`        |      `conda`         |
-| -----------               |  -------------------| ----------------   | ----------------- |  ----------------    |
-| `pip`                     |  :material-check:   | :material-close:   | :material-close:  | :material-close:     |
-| `mamba (e.g. micromamba)` |  :material-check:   | :material-check:   | :material-check:  | :material-check:     |
-
+We recommend installing omnibenchmark using conda, because it also enables using conda-managed workflows. Similarly, we provide a conda environment YAML to help installing other dependencies, such as `lmod` or `easybuild`.  We recommend managing `conda` with [miniforge](https://conda-forge.org/download/) or [micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html). Omnibenchmark expects a `conda` command to be available in the PATH, root environment or in the same environment as omnibenchmark itself.
 
 
 ### Full install (micromamba)
@@ -55,7 +52,7 @@ First, install [micromamba](https://mamba.readthedocs.io/en/latest/installation/
     source ~/.bashrc (or ~/.zshrc, ~/.xonshrc, ~/.config/fish/config.fish, ...)
     ```
 
-Then, clone omnibenchmark and install it in a new micromamba environment.
+Then, clone the omnibenchmark source code and install it in a new conda environment.
 
 === "Shell"
 
@@ -111,10 +108,6 @@ Before proceeding, make sure to install [apptainer](https://apptainer.org/docs/a
 After checking that apptainer is available, you should ensure **debootstrap** is available for building debian-based containers, and make sure to configure **fakeroot** with [`singularity config fakeroot`](https://docs.sylabs.io/guides/3.5/admin-guide/user_namespace.html#config-fakeroot) to allow non-root users to simulate root privileges while managing containers.
 
 Do note that you will need `debootstrap` even if you're using a non-debian based linux.
-
-The following should get you covered:
-
-Finally, install [apptainer](https://apptainer.org/docs/admin/main/installation.html) (singularity) and further system dependencies. If apptainer is already installed, make sure **debootstrap** is also installed and **fakeroot** configured with [`singularity config fakeroot`](https://docs.sylabs.io/guides/3.5/admin-guide/user_namespace.html#config-fakeroot).
 
 ```shell
 sudo apt install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev wget debootstrap software-properties-common


### PR DESCRIPTION
See #143.

Mind this still recommends cloning this very repo (main), use the testing conda environment file, and hence `pip .` without using PyPI.