### PR TITLE
docs(design): add module contributor spec for discussion

### DIFF
--- a/docs/design/000-template.md
+++ b/docs/design/000-template.md
@@ -1,0 +1,87 @@
+# 000: A new awesome feature
+
+[![Status: Draft](https://img.shields.io/badge/Status-Draft-yellow.svg)](https://github.com/omnibenchmark/docs/design)
+[![Version: 0.1](https://img.shields.io/badge/Version-0.1-blue.svg)](https://github.com/omnibenchmark/docs/design)
+
+**Authors**: [your name], ...
+**Date**: [YYYY-MM-DD]
+**Status**: Draft
+**Version**: 0.1
+**Supersedes**: N/A
+**Reviewed-by**: TBD
+**Related Issues**: [Links to related GitHub issues]
+
+## Changes
+
+| Version | Date | Description | Author |
+|---------|------|-------------|--------|
+| 0.1 | [YYYY-MM-DD] | Initial draft | [your name] |
+
+## 1. Problem Statement
+
+Clearly describe the problem or need this design addresses. What issue are we trying to solve? Why is it important? What are the limitations of the current approach (if one exists)?
+
+## 2. Design Goals
+
+List specific objectives this design aims to achieve:
+
+- Goal 1: [Description]
+- Goal 2: [Description]
+- ...
+
+### Non-Goals
+
+Explicitly state what this design is *not* trying to address (to clarify scope):
+
+- Non-Goal 1: [Description]
+- ...
+
+## 3. Proposed Solution
+
+Describe your proposed solution in detail. Include:
+
+- Key components and their interactions
+- Data flow diagrams (if applicable)
+- API specifications (if applicable)
+- Changes to existing systems
+
+### Implementation Details
+
+Provide technical specifics about how the solution would be implemented:
+
+```yaml
+# Example code, configuration, or schema if applicable
+key: value
+```
+
+## 4. Alternatives Considered
+
+Discuss alternative approaches that were considered and why they were not chosen:
+
+### Alternative 1: [Brief Name]
+- **Description**: [What this approach would entail]
+- **Pros**: [Advantages]
+- **Cons**: [Disadvantages]
+- **Reason for rejection**: [Why this approach wasn't selected]
+
+## 5. Implementation Plan
+
+Outline how this design will be implemented:
+
+1. Phase 1: [Description, timeline]
+2. Phase 2: [Description, timeline]
+3. ...
+
+### Testing Strategy
+
+Describe how the implementation will be tested:
+
+- Unit tests: [Approach]
+- Integration tests: [Approach]
+- Validation metrics: [How success will be measured]
+
+## 6. References
+
+1. [Reference 1](URL)
+2. [Reference 2](URL)
+3. ...

--- a/docs/design/001-module-metadata.md
+++ b/docs/design/001-module-metadata.md
@@ -1,0 +1,156 @@
+# 001: Module Metadata
+
+[![Status: Approved](https://img.shields.io/badge/Status-Approved-green.svg)](https://github.com/omnibenchmark/docs/design)
+[![Version: 0.1](https://img.shields.io/badge/Version-0.1-blue.svg)](https://github.com/omnibenchmark/docs/design)
+
+**Authors**: ben, ...
+**Date**: 2025-06-18
+**Status**: Approved
+**Version**: 0.1.0
+**Supersedes**: N/A
+**Reviewed-by**: dincicau, csoneson, imallona
+**Related Issues**: #145
+
+## Changes
+
+| Version | Date | Description | Author |
+|---------|------|-------------|--------|
+| 0.1 | 2025-06-13 | Initial draft | ben |
+
+
+## 1. Problem statement
+
+Previous [spec for module metadata](https://github.com/omnibenchmark/internal_docs/blob/master/architecture/method_contributor_design.md) suggested to expose attribution fields (for citation) and execution details (entrypoints, environment specs) in a single YAML file.
+
+We also rely on a `config.cfg` file to be [present at the root of a valid omnibenchmark module](https://github.com/imallona/clustbench_fcps/blob/main/config.cfg). As of today, this file only contains information about the module entrypoint:
+
+```
+[DEFAULT]
+SCRIPT=run_fcps.R
+```
+
+It has also been noted in the past that the `1:1` relation between module and entrypoint leads to a perhaps unnecessary proliferation of repos. As a secondary goal, being able to expose more than one entrypoint could allow to reuse a repo for different benchmark stage (it's just a namespace.)
+
+
+### Design Goals
+
+- Leverage existing tooling (GitHub, Zenodo) for citation.
+- Lower the barrier to entry for new contributors.
+- Keep execution metadata concise, clearly separated.
+- Support extensions (new entrypoints, env types) without bloating either file.
+
+## 2. File Roles
+
+Current spec expose both citation (attribution) metadata and execution details (entrypoints, environment specs) in a single YAML. We propose moving to a hybrid spec:
+
+1. `omnibenchmark.yaml` for module execution semantics (entrypoints, named stages, environment specs: conda, easyconfig).
+
+```YAML
+entrypoints:
+  default: shuffler.run
+environments:
+  conda: this-environment.yaml
+  easybuild: https://…/AMGX-2.4.0.eb
+```
+
+2. Adopt a `CITATION.cff` alongside it for all citation/attribution fields (title, authors, abstract, references, license).
+
+```YAML
+cff-version: 1.2.0
+message: "If you use this module in your publication, please cite as below."
+title: "Shuffler"
+abstract: |
+  Shuffles (per row) a rectangular gz-compressed, tab-separated text file.
+  Known to break on embedded quotes. Reruns with the same seed are identical.
+authors:
+  - family-names: Turtle
+    given-names: John
+date-released: 2025-06-13
+version: 1.0.0
+license: GPL-3.0-or-later
+references:
+  - title: “Original code”
+    authors:
+      - family-names: Bird
+        given-names: John
+    url: http://stolensnippets.com/shuffler
+  - title: “Patch and data”
+    authors:
+      - family-names: Fish
+        given-names: John
+    doi: 10.1038/s41586-024-07042-7
+```
+
+
+It remains to be defined what omnibenchmark execution should do with the provided environments. One conservative option is to use the benchmark YAML environments, but make use of the contributor provided environment (if any) as references of known, good working environments (in terms of version compativbility, it's understood that module contributors only provide assurances about the tested list of explicit and implicit dependencies.)
+
+### Semantic Fields
+
+| File | Purpose | Key Fields |
+|------|---------|------------|
+| CITATION.cff | Attribution metadata | title, abstract, authors, date-released, version, license, references |
+| omnibenchmark.yaml | Module execution & environment specification | entrypoints (default & named), environments (conda, easyconfig, etc.) |
+
+## 3. Analysis & Alternatives
+
+After evaluating multiple approaches to module metadata, we've identified three main alternatives with distinct trade-offs. The hybrid approach offers the best balance between standardization and flexibility.
+
+### All-in-one YAML
+- **Pros**:
+  - Single source.
+- **Cons**:
+  - Duplicates CFF logic.
+  - Ignores ecosystem tools.
+  - Harder to extend citation features.
+
+### Pure CITATION.cff
+- **Pros**:
+  - Standard citation.
+- **Cons**:
+  - Lacks entrypoint/env semantics.
+  - No tool support for runtime keys.
+  - Risks misusing CFF for execution details.
+
+### Hybrid (proposed)
+- **Pros**:
+  - Clear separation of concerns.
+  - Each file plays to its strengths.
+  - Extensible via custom keys in omnibenchmark.yaml.
+  - Minimal learning curve.
+- **Cons**:
+  - Two files, slight overhead.
+  - Requires documenting the split.
+
+## 4. Implementation details
+
+In omnibenchmark, one or more commands should:
+
+- Recursively descend all contributed modules
+- Validate `CITATION.cff` and `omnibenchmark.yaml`:
+
+    - Must include required execution keys (e.g., default entrypoint)
+    - Must contain valid free software license (can be a warning, validate SPDX as we're doing now)
+- Generate a joint citation file for the benchmark (concatenated .cff, for Zenodo export or ob cite)
+
+## 5. Extensibility & Future Work
+
+- `omnibenchmark.yaml` can adopt new environments types as they are needed (e.g. Docker, Singularity).
+- `omnibenchmark.yaml` can define new entrypoints as they are needed.
+
+
+## 6. Recommendations and next steps
+
+- Adopt the hybrid approach.
+- Make a bare minimum of fields mandatory (entrypoint, URL, author, LICENSE)
+- Update docs to guide module contributors, including best practices for generating citation metadata (e.g. using online tools).
+- Explicitely address differences between metadata about code, algorithms, datasets and publications.
+- Provide templates for both files in module scaffolding generation.
+- Consider adding a tool to guide module contributers to generate CITATION.cff via a text-wizard.
+- Watch the ecosystem in case new CFF spec are released that we want to incorporate.
+
+## 7. References
+
+1. [Citation File Format (CFF) Specification](https://github.com/citation-file-format/citation-file-format)
+2. [Previous Module Metadata Specification](https://github.com/omnibenchmark/internal_docs/blob/master/architecture/method_contributor_design.md)
+3. [Zenodo Metadata Documentation](https://developers.zenodo.org/#representation)
+4. [Example Omnibenchmark Module: clustbench_fcps](https://github.com/imallona/clustbench_fcps)

--- a/docs/design/001-module-metadata.md
+++ b/docs/design/001-module-metadata.md
@@ -5,17 +5,24 @@
 
 **Authors**: ben, ...
 **Date**: 2025-06-18
+<<<<<<< HEAD
 **Status**: Approved
 **Version**: 0.1.0
 **Supersedes**: N/A
 **Reviewed-by**: dincicau, csoneson, imallona
+=======
+**Status**: Review
+**Version**: 0.1.0
+**Supersedes**: N/A
+**Reviewed-by**: dincicau, csoneson
+>>>>>>> dffe4e6 (docs: add template and README for design docs)
 **Related Issues**: #145
 
 ## Changes
 
 | Version | Date | Description | Author |
 |---------|------|-------------|--------|
-| 0.1 | 2025-06-13 | Initial draft | ben |
+| 0.1.0 | 2025-06-18 | Initial draft | ben |
 
 
 ## 1. Problem statement
@@ -29,7 +36,9 @@ We also rely on a `config.cfg` file to be [present at the root of a valid omnibe
 SCRIPT=run_fcps.R
 ```
 
-It has also been noted in the past that the `1:1` relation between module and entrypoint leads to a perhaps unnecessary proliferation of repos. As a secondary goal, being able to expose more than one entrypoint could allow to reuse a repo for different benchmark stage (it's just a namespace.)
+### Non-Goals
+
+Tangentially related, it has also been noted in the past that the `1:1` relation between module and entrypoint leads to a perhaps unnecessary proliferation of repos. I'm noting in here that allowing more than one entry point could allow to reuse a repo for different benchmark stages, since it's just a namespace that can be selected in the benchmark yaml. But objections were raised to "breaking the atomicity paradigm", so we'll not consider the multiple entrypoints in scope for this design document.
 
 
 ### Design Goals
@@ -47,6 +56,7 @@ Current spec expose both citation (attribution) metadata and execution details (
 
 ```YAML
 entrypoints:
+  # just a default entrypoint is permitted for the time being
   default: shuffler.run
 environments:
   conda: this-environment.yaml
@@ -143,7 +153,7 @@ In omnibenchmark, one or more commands should:
 - Adopt the hybrid approach.
 - Make a bare minimum of fields mandatory (entrypoint, URL, author, LICENSE)
 - Update docs to guide module contributors, including best practices for generating citation metadata (e.g. using online tools).
-- Explicitely address differences between metadata about code, algorithms, datasets and publications.
+- Explicitely address differences, if any found relevant after further analysis, between metadata about code, algorithms, datasets and publications. Separating attribution for distinct named entities might be relevant to automate, e.g. download or discovery of datasets or code (just to mention a plausible use case.)
 - Provide templates for both files in module scaffolding generation.
 - Consider adding a tool to guide module contributers to generate CITATION.cff via a text-wizard.
 - Watch the ecosystem in case new CFF spec are released that we want to incorporate.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,46 @@
+# Omnibenchmark Design Documents
+
+This directory contains design documents for the Omnibenchmark project. Design documents (or "design docs") are technical specifications that describe major features, architectural decisions, and system changes.
+
+## Purpose
+
+Design docs serve several important purposes:
+- Document architectural decisions and their rationales
+- Provide a framework for technical discussion before implementation
+- Serve as reference material for contributors and maintainers
+- Create a historical record of the project's evolution
+
+## Document Lifecycle
+
+1. **Draft**: Initial proposal, open for discussion
+2. **Review**: Under active review by team members
+3. **Accepted**: Approved for implementation
+4. **Implemented**: Changes have been implemented
+5. **Superseded**: Replaced by a newer design doc
+
+## Creating a New Design Document
+
+1. Copy `000-template.md` to a new file named with the next available number and a descriptive title (e.g., `002-feature-name.md`)
+2. Fill in all the metadata fields
+3. Write your proposal following the template structure
+4. Submit for review via pull request
+
+## Document Structure
+
+Each design document should follow a consistent structure:
+- **Preamble**: Document metadata (authors, status, date, etc.)
+- **Problem Statement**: What issue or need is being addressed
+- **Design Goals**: What the solution aims to achieve
+- **Solution Details**: The proposed implementation approach
+- **Alternatives Considered**: Other approaches and why they weren't chosen
+- **Implementation Plan**: How and when the solution will be implemented
+- **References**: Related documents, issues, and external resources
+
+## Existing Design Documents
+
+- [001-module-metadata.md](./001-module-metadata.md): Module metadata specification
+
+## Resources
+
+For guidance on writing effective design docs, see:
+- [How to Write a Good Design Doc](https://www.industrialempathy.com/posts/design-docs-at-google/)


### PR DESCRIPTION
## Ticket

- https://github.com/omnibenchmark/omnibenchmark/issues/140
- https://github.com/omnibenchmark/omnibenchmark/issues/104

## Description

Please read [the design document in the PR](https://github.com/omnibenchmark/omnibenchmark/pull/145/files?short_path=07689e8#diff-07689e8bd64b764eb602edf1e4a0016c7874a681b707e36c093e045915154763) for the full details. Feel free to react to this issue with emojis for loose agreement, add a proper issue review, and/or use the comments. 

## TLDR: Split Module Metadata into Two Files

We propose using a hybrid metadata layout for contributed modules:

- `CITATION.cff`— for all attribution/citation metadata (see #104). The plan would be to expose this functionality in a `omnibenchmark generate-citations` command in the future (it would simply recursively collect all the contributed citations. Benchmark validators can also hook into checking of metadata (e.g. valid licenses, valid authorship).
- rename `config.cfg` to `omnibenchmark.yaml` — for _execution_ _semantics_: entrypoints, environments, etc. and any further extensibility on the side of module execution environments.

## Why this split?

- `CITATION.cff` is widely supported by GitHub, Zenodo, and citation tooling. No need to reinvent attribution.
- Keeping a module-level `omnibenchmark.yaml` focused on execution (entrypoints, conda, EasyBuild, etc.) avoids overloading the CFF schema

This separation mirrors best practices (e.g. pyproject.toml + CITATION.cff for python packages), even if some level of duplication exists between the packaging metadata and the cff format (but they serve different purposes).