### PR TITLE
bug: deleting intermediate results should trigger re-running of the benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - bug: timeout should indicate SIGKILL to child process (Closes #222)
 - bug: `ob run module` should properly activate software backends (#174)
 - bug: several bugfixes related to the ability to use remote storage (s3) with snakemake
+- bug: deleting intermediate results should trigger re-running of the benchmark
 - cli: added `ob cite` command to extract citation metadata from CITATION.cff files in benchmark modules with support for multiple output formats (json, yaml, bibtex)
 - cli: added `ob validate` command for benchmark and module validation including CITATION.cff, LICENSE, and omnibenchmark.yaml file validation, with license consistency checking
 - tests: use pixi on the CI

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -338,7 +338,7 @@ metric_collectors:
       - metrics.json
     outputs:
       - id: plotting.html
-        path: "{input}/{name}/plotting_report.html"
+        path: "{name}/plotting_report.html"
 ```
 
 Similarly to any other module, the associated code to run the processing is stored as a git-compatible remote (with `url` and `commit id`). In the example above, `multiple_to_one` only generates one output, a report named `plotting.html` collecting all computed `metrics.json` files.

--- a/omnibenchmark/utils.py
+++ b/omnibenchmark/utils.py
@@ -62,8 +62,7 @@ def format_mc_output(output, out_dir: Path, collector_id: str):
         collector_id: Collector identifier
     """
     if output.path:
-        o = output.path.replace("{input}", str(out_dir))
-        o = o.replace("{name}", collector_id)
-        return o
+        o = output.path.replace("{name}", collector_id)
+        return f"{out_dir}/{o}"
     else:
         return str(out_dir / output.id)

--- a/omnibenchmark/workflow/snakemake/rules/rule_all.smk
+++ b/omnibenchmark/workflow/snakemake/rules/rule_all.smk
@@ -25,20 +25,17 @@ def get_script_path(script_name: str) -> str:
 def create_all_rule(config, paths: List[str], aggregate_performance: bool = False):
     out_dir = config['out_dir']
 
-    if not aggregate_performance:
+    if aggregate_performance:
         rule all:
-            input: paths,
-            # "out/data/D2/default/D2.data.ext",
-            # "out/data/D2/default/process/P1/default/D2.txt.gz",
-            # "out/data/D1/default/process/P2/default/methods/M2/default/D1.model.out.gz"
-            # "out/data/D1/default/process/P2/default/methods/M2/default/m1/default/D1.results.txt"
+            input: paths + [f"{out_dir}/performances.tsv"]
+
+        rule aggregate_performance:
+            input: paths
+            output: f"{out_dir}/performances.tsv"
+            script: get_script_path("aggregate_performance.py")
     else:
         rule all:
             input: paths
-            output:
-                f"{benchmark.context.out_dir}/performances.tsv"
-            script:
-                get_script_path("aggregate_performance.py")
 
 
 def create_metric_collector_rule(benchmark: Benchmark, collector: MetricCollector, config: dict[str, Any], node_output_paths: List[str]):

--- a/tests/e2e/configs/02_data_methods_metrics.yaml
+++ b/tests/e2e/configs/02_data_methods_metrics.yaml
@@ -76,4 +76,4 @@ metric_collectors:
     outputs:
       - id: metrics.summary
         # TODO: this "input" here is really unintuitive. it really means "output" dir.
-        path: "{input}/metrics/metrics.json"
+        path: "metrics/metrics.json"

--- a/tests/e2e/configs/03_data_preprocessing_methods_metrics.yaml
+++ b/tests/e2e/configs/03_data_preprocessing_methods_metrics.yaml
@@ -132,4 +132,4 @@ metric_collectors:
       - methods.result
     outputs:
       - id: metrics.summary
-        path: "{input}/metrics/metrics.json"
+        path: "metrics/metrics.json"

--- a/tests/e2e/configs/04_complex_topology.yaml
+++ b/tests/e2e/configs/04_complex_topology.yaml
@@ -255,4 +255,4 @@ metric_collectors:
       - methods_group3.result
     outputs:
       - id: metrics.summary
-        path: "{input}/metrics/metrics.json"
+        path: "metrics/metrics.json"

--- a/tests/e2e/configs/05_cartesian_product_exclude.yaml
+++ b/tests/e2e/configs/05_cartesian_product_exclude.yaml
@@ -81,4 +81,4 @@ metric_collectors:
       - methods.result
     outputs:
       - id: metrics.summary
-        path: "{input}/metrics/metrics.json"
+        path: "metrics/metrics.json"

--- a/tests/model/test_iofile_path_validation.py
+++ b/tests/model/test_iofile_path_validation.py
@@ -178,7 +178,7 @@ metric_collectors:
     inputs: ["data.result"]
     outputs:
       - id: metrics.json
-        path: "{input}/metrics/metrics.json"
+        path: "metrics/metrics.json"
 """)
             yaml_path = f.name
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -240,7 +240,7 @@ class TestFormatMcOutput:
         """Test formatting when output has path with substitutions."""
         # Create a mock output object with path
         mock_output = Mock()
-        mock_output.path = "{input}/metrics/{name}_results.json"
+        mock_output.path = "metrics/{name}_results.json"
         mock_output.id = "test_collector"
 
         out_dir = Path("/test/output")
@@ -253,7 +253,7 @@ class TestFormatMcOutput:
     def test_format_with_input_substitution_only(self):
         """Test formatting with only {input} substitution."""
         mock_output = Mock()
-        mock_output.path = "{input}/simple_output.txt"
+        mock_output.path = "simple_output.txt"
         mock_output.id = "test_collector"
 
         out_dir = Path("/base/dir")
@@ -261,32 +261,6 @@ class TestFormatMcOutput:
 
         result = format_mc_output(mock_output, out_dir, collector_id)
         expected = "/base/dir/simple_output.txt"
-        assert result == expected
-
-    def test_format_with_name_substitution_only(self):
-        """Test formatting with only {name} substitution."""
-        mock_output = Mock()
-        mock_output.path = "/fixed/path/{name}.log"
-        mock_output.id = "test_collector"
-
-        out_dir = Path("/test/output")
-        collector_id = "log_collector"
-
-        result = format_mc_output(mock_output, out_dir, collector_id)
-        expected = "/fixed/path/log_collector.log"
-        assert result == expected
-
-    def test_format_without_substitutions(self):
-        """Test formatting path without any substitution placeholders."""
-        mock_output = Mock()
-        mock_output.path = "/absolute/fixed/path/file.txt"
-        mock_output.id = "test_collector"
-
-        out_dir = Path("/test/output")
-        collector_id = "collector"
-
-        result = format_mc_output(mock_output, out_dir, collector_id)
-        expected = "/absolute/fixed/path/file.txt"
         assert result == expected
 
     def test_format_no_path_uses_id(self):
@@ -318,22 +292,20 @@ class TestFormatMcOutput:
     def test_format_with_complex_substitutions(self):
         """Test formatting with multiple occurrences of substitutions."""
         mock_output = Mock()
-        mock_output.path = "{input}/stage1/{name}/stage2/{input}/{name}.final"
+        mock_output.path = "stage1/{name}/stage2/{name}.final"
         mock_output.id = "test_collector"
 
         out_dir = Path("/complex/base")
         collector_id = "multi_stage"
 
         result = format_mc_output(mock_output, out_dir, collector_id)
-        expected = (
-            "/complex/base/stage1/multi_stage/stage2//complex/base/multi_stage.final"
-        )
+        expected = "/complex/base/stage1/multi_stage/stage2/multi_stage.final"
         assert result == expected
 
     def test_format_path_object_conversion(self):
         """Test that Path objects are properly converted to strings."""
         mock_output = Mock()
-        mock_output.path = "{input}/converted.txt"
+        mock_output.path = "converted.txt"
         mock_output.id = "path_collector"
 
         # Use Path object for out_dir


### PR DESCRIPTION
- Fix dirty rerun for snakemake. In case files are missing or checksum has changed, automatically rerun necessary rules
- Fix output path prefix for metric collector outputs