### PR TITLE
ci: use main branch for clustering_example

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -248,7 +248,7 @@ jobs:
 
       - name: Clone clustering example repo
         run: |
-          git clone --branch update-to-0.4 https://github.com/omnibenchmark/clustering_example.git
+          git clone --branch main https://github.com/omnibenchmark/clustering_example.git
           cd clustering_example
           ls -la
 
@@ -326,7 +326,7 @@ jobs:
 
       - name: Clone clustering example repo
         run: |
-          git clone --branch update-to-0.4 https://github.com/omnibenchmark/clustering_example.git
+          git clone --branch main https://github.com/omnibenchmark/clustering_example.git
           cd clustering_example
           ls -la
 


### PR DESCRIPTION
We have already updated the clustering_example for 0.4