### PR TITLE
docs: add extensions to YAML spec

### DIFF
--- a/docs/design/004-yaml-specification.md
+++ b/docs/design/004-yaml-specification.md
@@ -1,15 +1,15 @@
-# 004: Omnibenchmark YAML Specification (v0.3)
+# 004: Omnibenchmark YAML Specification (v0.1)
 
-[![Status: Accepted](https://img.shields.io/badge/Status-Accepted-green.svg)](https://github.com/omnibenchmark/docs/design)
-[![Version: 0.3](https://img.shields.io/badge/Version-0.3-blue.svg)](https://github.com/omnibenchmark/docs/design)
+[![Status: Under Review](https://img.shields.io/badge/Status-UnderReview-yellow.svg)](https://github.com/omnibenchmark/docs/design)
+[![Version: 0.1](https://img.shields.io/badge/Version-0.3-blue.svg)](https://github.com/omnibenchmark/docs/design)
 
-**Authors**: ben,
+**Authors**: ben
 **Date**: 2025-01-20
 **Status**: Under Review
 **Version**: 0.1
 **Supersedes**: N/A
-**Reviewed-by**: TBD
-**Related Issues**: TBD
+**Reviewed-by**: daninci
+**Related Issues**: #283
 
 ## Changes
 
@@ -189,7 +189,6 @@ Modules MUST NOT declare these in their YAML configuration.
 #### Parameter Values
 
 - **String**: Passed directly (`evaluate: "1+1"` → `--evaluate 1+1`)
-- **List**: Joined with commas (`items: [a, b, c]` → `--items a,b,c`)
 
 #### Wildcard-Based Resolution
 


### PR DESCRIPTION
This PR gathers extensions to the YAML spec that I added while working on the exploratory explicit snakefile feature branch.

This document gathers different, unrelated extension proposals that are made possible by the explicit snakefile:

# 1.   Named Entrypoints (§3.5)

- Modules can now declare multiple entry scripts in their omnibenchmark.yaml via an entrypoints: dict
- Default behavior preserved for backward compatibility (uses "default" key)
- Enables reusing a single repository for multiple pipeline steps without code duplication

# 2. Gather Stages (Section 7)

Problem solved: Previously, metric_collectors could aggregate results but were a dead-end (outputs couldn’t be chained). Gather stages make reduce operations first-class and composable.

# 3. Output Path Templates (§7.7)

Rich templating system for output paths with variables:

* `{label}`: module ID from ancestor providing that label
* `{params.key}`: parameter values
* `{module.id}`, `{module.stage}`, `{module.parent.id}`: structural attributes
* `{dataset}`: backward-compat alias (planned for deprecation)

# 4. Resource Allocation (Section 8)

Explicit resource management for scheduling:

```
resources:
  cores: <integer>
  mem_mb: <integer>
  disk_mb: <integer>
  runtime: <integer>
``` 

* Can be declared at stage, module, or metric collector level
* Module-level overrides stage-level (most-specific-wins)
* Default: cores=2 when unspecified
* Maps directly to Snakemake resources: and threads: directives

The document is presented here for a cohesive reference, but we can discuss each of these points in a different issue. 