### PR TITLE
feat: allow `describe topology` to produce simpler outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This document records all notable changes to `omnibenchmark`.
 This project adheres to [Semantic Versioning](https://semver.org/) and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+ 
+## 0.5.0 UNRELEASED
+
+- feat: add `--compact-params` and `--no-show-params` options to `ob describe topology` (#299)
 
 ## [0.4.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.4.0) (Jan 27th 2026)
 

--- a/omnibenchmark/benchmark/_mermaid.py
+++ b/omnibenchmark/benchmark/_mermaid.py
@@ -1,8 +1,10 @@
 """Mermaid diagram generation utilities for omnibenchmark."""
 
-from typing import Dict, Any, List
+from typing import Dict, List
 from omnibenchmark.model import Benchmark as BenchmarkModel
+from omnibenchmark.model.benchmark import Parameter
 from omnibenchmark.benchmark._graph import get_nodes_by_module_id
+from omnibenchmark.benchmark.params import Params
 
 
 class MermaidDiagramGenerator:
@@ -12,7 +14,9 @@ class MermaidDiagramGenerator:
         self.model = model
         self.graph = graph
 
-    def generate_diagram(self, show_params: bool = True) -> str:
+    def generate_diagram(
+        self, show_params: bool = True, compact_params: bool = False
+    ) -> str:
         """Generate a complete Mermaid flowchart diagram.
 
         Args:
@@ -29,7 +33,9 @@ class MermaidDiagramGenerator:
         ]
 
         if show_params:
-            diagram_parts.append(self._generate_parameter_subgraphs())
+            diagram_parts.append(
+                self._generate_parameter_subgraphs(compact_params=compact_params)
+            )
 
         return "\n".join(diagram_parts)
 
@@ -81,36 +87,44 @@ class MermaidDiagramGenerator:
 
         return connections
 
-    def _generate_parameter_subgraphs(self) -> str:
+    def _generate_parameter_subgraphs(self, compact_params: bool) -> str:
         """Generate parameter subgraphs and their connections to modules."""
         param_subgraphs = []
         module_id_params_dict = self._collect_module_parameters()
 
-        for module_id, params in module_id_params_dict.items():
-            # Create parameter subgraph
+        for module_id, parameters in module_id_params_dict.items():
             subgraph_lines = [f"\tsubgraph params_{module_id}"]
 
-            for param in params:
-                param_node = f"{param.hash()}{param.to_cli_args()}"
-                subgraph_lines.append(f"\t\t{param_node}")
+            if compact_params:
+                # One node per Parameter before expansion (dict-format only)
+                for paramset, parameter in enumerate(parameters):
+                    if parameter.params is None:
+                        continue
+                    comp_str = " ".join(f"{k}:{v}" for k, v in parameter.params.items())
+                    paramset_node = f"{module_id}_paramset{paramset}"
+                    subgraph_lines.append(f"\t\t{paramset_node}[{comp_str}]")
+            else:
+                # Expand each Parameter and render one node per combination
+                for parameter in parameters:
+                    for param in Params.expand_from_parameter(parameter):
+                        param_node = f"{param.hash()}{param.to_cli_args()}"
+                        subgraph_lines.append(f"\t\t{param_node}")
 
             subgraph_lines.extend(
                 ["\tend", f"\tparams_{module_id}:::param --o {module_id}"]
             )
-
             param_subgraphs.append("\n".join(subgraph_lines))
 
         return "\n".join(param_subgraphs)
 
-    def _collect_module_parameters(self) -> Dict[str, Any]:
-        """Collect parameters for all modules that have them."""
+    def _collect_module_parameters(self) -> Dict[str, List[Parameter]]:
+        """Collect raw Parameter objects for all modules that have them."""
         module_id_params_dict = {}
 
         for stage_id, stage in self.model.get_stages().items():
             for module_id, module in self.model.get_modules_by_stage(stage).items():
-                module_parameters = self.model.get_module_parameters(module)
-                if module_parameters:
-                    module_id_params_dict[module_id] = module_parameters
+                if module.parameters:
+                    module_id_params_dict[module_id] = module.parameters
 
         return module_id_params_dict
 
@@ -120,7 +134,7 @@ class MermaidDiagramGenerator:
 
 
 def generate_mermaid_diagram(
-    model: BenchmarkModel, graph, show_params: bool = True
+    model: BenchmarkModel, graph, show_params: bool = True, compact_params: bool = False
 ) -> str:
     """Generate a Mermaid diagram for a benchmark workflow.
 
@@ -133,4 +147,4 @@ def generate_mermaid_diagram(
         A string containing the complete Mermaid diagram syntax
     """
     generator = MermaidDiagramGenerator(model, graph)
-    return generator.generate_diagram(show_params)
+    return generator.generate_diagram(show_params, compact_params)

--- a/omnibenchmark/benchmark/benchmark.py
+++ b/omnibenchmark/benchmark/benchmark.py
@@ -247,7 +247,7 @@ class BenchmarkExecution:
 
         return environment_path
 
-    def export_to_mermaid(self, show_params: bool = True) -> str:
+    def export_to_mermaid(self, show_params: bool = True, compact_params: bool = False) -> str:
         """Export the benchmark workflow as a Mermaid diagram.
 
         Args:
@@ -256,7 +256,7 @@ class BenchmarkExecution:
         Returns:
             A string containing the complete Mermaid diagram syntax
         """
-        return generate_mermaid_diagram(self.model, self.G, show_params)
+        return generate_mermaid_diagram(self.model, self.G, show_params, compact_params)
 
     def __str__(self):
         return f"Benchmark({self.get_definition})"

--- a/omnibenchmark/benchmark/params.py
+++ b/omnibenchmark/benchmark/params.py
@@ -161,6 +161,18 @@ class Params:
                     args.append(f"--{key}={value}")
         return args
 
+    def to_compact_args(self):
+        """
+        Convert parameters to compact representation for mermaid.
+
+        Returns:
+            list: List of command line argument strings
+        """
+        args = []
+        for key, value in self._params.items():
+            args.extend([f"{key}:", str(value)])
+        return args
+
     @classmethod
     def from_cli_args(cls, args: List[str]) -> "Params":
         """

--- a/omnibenchmark/cli/describe.py
+++ b/omnibenchmark/cli/describe.py
@@ -49,16 +49,27 @@ def snakemake_graph(ctx, benchmark: str):
     "benchmark",
     type=click.Path(exists=True),
 )
+@click.option(
+    "--show-params/--no-show-params",
+    default=True,
+    help="Whether to write parameters to the mermaid output.",
+)
+@click.option(
+    "--compact-params/--no-compact-params",
+    default=False,
+    help="Whether to write parameters compactly (only used if --show-params).",
+)
+
 @click.pass_context
-def plot_topology(ctx, benchmark: str):
-    """Export benchmark topology to mermaid diagram format.
+def plot_topology(ctx, benchmark, show_params, compact_params):
+    """Export benchmark topology to MERMAID diagram format.
 
     BENCHMARK: Path to benchmark YAML file.
     """
     b = BenchmarkExecution(benchmark_yaml=Path(benchmark))
     if b is None:
         return
-    mermaid = b.export_to_mermaid()
+    mermaid = b.export_to_mermaid(show_params, compact_params)
     click.echo(mermaid)
 
 

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -72,6 +72,37 @@ def test_benchmark_topology_plot(tmp_path):
         assert strip(expected_methods) in strip(result.stdout)
 
 
+def test_topology_no_show_params():
+    with OmniCLISetup() as omni:
+        result = omni.call(
+            [
+                "describe",
+                "topology",
+                str(benchmark_data_path / "Benchmark_001.yaml"),
+                "--no-show-params",
+            ],
+        )
+
+        assert result.returncode == 0
+        assert "subgraph params_" not in result.stdout
+
+
+def test_topology_compact_params():
+    with OmniCLISetup() as omni:
+        result = omni.call(
+            [
+                "describe",
+                "topology",
+                str(benchmark_data_path / "Benchmark_dict_params.yaml"),
+                "--compact-params",
+            ],
+        )
+
+        assert result.returncode == 0
+        assert "M1_paramset0" in result.stdout
+        assert "M1_paramset1" in result.stdout
+
+
 def test_describe_status_with_out_dir(tmp_path):
     """Test that describe status command respects --out-dir parameter."""
     import shutil

--- a/tests/data/Benchmark_dict_params.yaml
+++ b/tests/data/Benchmark_dict_params.yaml
@@ -1,0 +1,39 @@
+id: Benchmark_dict_params
+description: minimal benchmark with dict-format parameters for testing compact_params
+version: "1.0"
+benchmarker: "test"
+software_backend: host
+api_version: "0.3.0"
+software_environments:
+  env1:
+    description: "test env"
+stages:
+  - id: data
+    modules:
+      - id: D1
+        software_environment: env1
+        repository:
+          url: https://github.com/example/data.git
+          commit: abc1234
+    outputs:
+      - id: data.out
+        path: "data.txt"
+
+  - id: methods
+    modules:
+      - id: M1
+        software_environment: env1
+        repository:
+          url: https://github.com/example/method.git
+          commit: abc1234
+        parameters:
+          - alpha: 0.1
+            beta: 1
+          - alpha: 0.5
+            beta: 2
+    inputs:
+      - entries:
+          - data.out
+    outputs:
+      - id: methods.out
+        path: "result.txt"


### PR DESCRIPTION
## Ticket

Provide a link to the [project](https://github.com/orgs/omnibenchmark/projects/1) ticket. --> not a ticket there.

## Description

cosmetic changes to the output of ob describe topology

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

## Remarks for the reviewer:

Purely cosmetic changes to the output of `ob describe topology` .. by adding 2 params:
```
(omnibenchmark) mark@MLS-M-MAROBI scrna-bench % ob describe topology --help 
Usage: ob describe topology [OPTIONS] BENCHMARK

  Export benchmark topology to MERMAID diagram format.

  BENCHMARK: Path to benchmark YAML file.

Options:
  --debug / --no-debug            Enable debug mode
  --show-params / --no-show-params
                                  Whether to write parameters to the mermaid
                                  output.
  --compact-params / --no-compact-params
                                  Whether to write parameters compactly (only
                                  used if --show-params).
  --help                          Show this message and exit.
```