### PR TITLE
feat: storage module refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 ## 0.5.0 UNRELEASED
 
 - feat: add `--compact-params` and `--no-show-params` options to `ob describe topology` (#299)
+- refactor: migrate S3 storage from `minio` client to `boto3`, rename `MinIOStorage` → `S3CompatibleStorage`, and introduce `StorageFactory` for backend-agnostic storage setup (#302)
 
 ## [0.4.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.4.0) (Jan 27th 2026)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,5 @@ mkdocs-git-revision-date-localized-plugin==1.2.6
 mkdocs-bibtex>=2.16.0
 mkdocs-click
 boto3
-minio
 mike
 . # that is, this very omnibenchmark version

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -103,7 +103,7 @@ Check Omnibenchmark has successfully installed.
 === "Output"
 
     ```
-    S3 storage not available. You might want to install the 'minio' and 'boto3' packages.
+    S3 storage not available. You might want to install the 'boto3' packages.
     OmniBenchmark CLI, version 0.4.0
     ```
 

--- a/examples/storage_usage.py
+++ b/examples/storage_usage.py
@@ -1,56 +1,55 @@
-import io
 import json
 
-from omnibenchmark.remote.MinIOStorage import MinIOStorage
+from omnibenchmark.remote.RemoteStorage import StorageOptions
+from omnibenchmark.remote.S3Storage import S3CompatibleStorage
 
 with open("<CONFIG>.json", "r") as file:
     auth_options = json.load(file)
 
 ########################################################
-### Example step-by-step usage of the MinIOStorage class
+### Example step-by-step usage of the S3CompatibleStorage class
 ########################################################
 
-# setup object, existing benchmark or new benchmark
-ms = MinIOStorage(auth_options, benchmark="obob")
+storage_options = StorageOptions(out_dir="out")
 
-# upload objects to benchmark
-_ = ms.client.put_object(ms.benchmark, "out/f1.txt", io.BytesIO(b"f1"), 2)
-_ = ms.client.put_object(ms.benchmark, "out/f2.txt", io.BytesIO(b"f2"), 2)
+# Setup object — connects to an existing benchmark bucket or creates a new one
+ms = S3CompatibleStorage(
+    auth_options, benchmark="obob", storage_options=storage_options
+)
 
-# util: get available benchmark versions
+# Upload objects to the benchmark bucket (boto3 keyword-argument style)
+ms.client.put_object(Bucket=ms.benchmark, Key="out/f1.txt", Body=b"f1")
+ms.client.put_object(Bucket=ms.benchmark, Key="out/f2.txt", Body=b"f2")
+
+# Refresh the list of available benchmark versions
 ms._get_versions()
 
-# set version (latest)
+# Set the version to create (None → auto-increment from latest)
 ms.set_version()
-# version to create
-print(f"{ms.version}")
-# set version (manual)
+print(f"Next version: {ms.version}")
+
+# Or set a specific version manually
 ms.set_version("0.1")
-# version to create
-print(f"{ms.version}")
+print(f"Version: {ms.version}")
 
-# create version
+# Create version 0.1 (tags current objects and writes the manifest)
 ms.create_new_version()
-# list versions of benchmark
-ms.versions
+print(f"Available versions: {ms.versions}")
 
-# update object
-_ = ms.client.put_object(ms.benchmark, "out/f1.txt", io.BytesIO(b"f1v2"), 4)
-# prepare new version
-ms.set_version()
-# create version
+# Update an object and create the next version
+ms.client.put_object(Bucket=ms.benchmark, Key="out/f1.txt", Body=b"f1v2")
+ms.set_version()  # auto-increments to 0.2
 ms.create_new_version()
 
-# list objects of version 0.2
-ms._get_objects()
-ms.files
+# Load and inspect objects for version 0.2
+ms.load_objects()
+print(ms.files)
 
-# list objects of version 0.1
+# Load and inspect objects for version 0.1
 ms.set_version("0.1")
-ms._get_objects()
-ms.files
+ms.load_objects()
+print(ms.files)
 
-
-# download object to file (tmp.txt)
+# Download an object to a local file
 object_name = list(ms.files.keys())[0]
 ms.download_object(object_name, "tmp.txt")

--- a/omnibenchmark/benchmark/benchmark.py
+++ b/omnibenchmark/benchmark/benchmark.py
@@ -116,7 +116,7 @@ class BenchmarkExecution:
     def get_benchmark_name(self):
         return self.model.get_name()
 
-    def get_benchmark_version(self):
+    def get_benchmark_version(self) -> str:
         return self.model.get_version()
 
     def get_benchmark_author(self):
@@ -247,7 +247,9 @@ class BenchmarkExecution:
 
         return environment_path
 
-    def export_to_mermaid(self, show_params: bool = True, compact_params: bool = False) -> str:
+    def export_to_mermaid(
+        self, show_params: bool = True, compact_params: bool = False
+    ) -> str:
         """Export the benchmark workflow as a Mermaid diagram.
 
         Args:

--- a/omnibenchmark/cli/archive.py
+++ b/omnibenchmark/cli/archive.py
@@ -5,7 +5,6 @@ import zipfile
 from pathlib import Path
 
 from omnibenchmark.benchmark import BenchmarkExecution
-from omnibenchmark.cli.remote import StorageAuth
 from omnibenchmark.archive import archive_benchmark
 from omnibenchmark.constants import COMPRESSION_GZIP, DEFAULT_COMPRESSION
 from omnibenchmark.remote.tree import tree_string_from_list
@@ -148,14 +147,7 @@ def archive(
                 f"Valid combinations: {' | '.join(all_combinations)}"
             )
 
-    # Load benchmark differently based on whether we need storage authentication
-    if use_remote_storage:
-        # For remote storage, we need full storage authentication
-        storage_auth = StorageAuth(benchmark)
-        benchmark_obj = storage_auth.benchmark
-    else:
-        # For local-only archiving, we can load benchmark without storage requirements
-        benchmark_obj = BenchmarkExecution(Path(benchmark))
+    benchmark_obj = BenchmarkExecution(Path(benchmark))
 
     # Convert compression string to constant
     # For gzip, we use a string marker since it uses tarfile instead of zipfile

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -174,6 +174,12 @@ def list_all_files(
     if type != "all":
         logger.error("--type is not implemented")
         sys.exit(1)
+    if stage is not None:
+        logger.error("--stage is not implemented")
+        sys.exit(1)
+    if module is not None:
+        logger.error("--module is not implemented")
+        sys.exit(1)
 
     objectnames, etags = list_files(benchmark, type, stage, module, file_id)
     if len(objectnames) > 0:
@@ -227,7 +233,13 @@ def download_all_files(
         logger.error("--file_id is not implemented")
         raise click.Abort()
     if type != "all":
-        logger.info("--type is not implemented")
+        logger.error("--type is not implemented")
+        raise click.Abort()
+    if stage is not None:
+        logger.error("--stage is not implemented")
+        raise click.Abort()
+    if module is not None:
+        logger.error("--module is not implemented")
         raise click.Abort()
 
     download_files(

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -29,8 +29,6 @@ class StorageAuth:
     """Convenience class for handling storage authentication and validation."""
 
     def __init__(self, benchmark_path: str, require_credentials: bool = True):
-        from omnibenchmark.remote.storage import remote_storage_args
-
         self.benchmark_path = benchmark_path
         try:
             self.benchmark = BenchmarkExecution(Path(benchmark_path))
@@ -38,42 +36,20 @@ class StorageAuth:
             formatted_error = pretty_print_parse_error(e)
             logger.error(f"Failed to load benchmark:\n{formatted_error}")
             sys.exit(1)
-        self.auth_options = remote_storage_args(
-            self.benchmark, required=require_credentials
-        )
 
-        # Validate required storage components
-        api = self.benchmark.get_storage_api()
-        bucket = self.benchmark.get_storage_bucket_name()
+        try:
+            from omnibenchmark.remote.service import StorageService
 
-        if api is None:
-            logger.error(
-                click.style("[ERROR]", fg="red", bold=True)
-                + " No storage API configured. Set 'storage.api' in your benchmark YAML."
+            self._service = StorageService(
+                self.benchmark, require_credentials=require_credentials
             )
+        except ValueError as e:
+            logger.error(click.style("[ERROR]", fg="red", bold=True) + f" {e}")
             sys.exit(1)
-        if bucket is None:
-            logger.error(
-                click.style("[ERROR]", fg="red", bold=True)
-                + " No storage bucket configured. Set 'storage.bucket_name' in your benchmark YAML."
-            )
-            sys.exit(1)
-
-        # Store validated non-null values
-        self.api: str = api
-        self.bucket: str = bucket
 
     def get_storage_instance(self) -> "MinIOStorage":
         """Get validated storage instance."""
-        from omnibenchmark.remote.storage import get_storage
-
-        ss = get_storage(self.api, self.auth_options, self.bucket)
-        if ss is None:
-            logger.error("Error: No storage found.")
-            sys.exit(1)
-        # Type assertion since we know ss is not None after the exit check
-        assert ss is not None
-        return ss
+        return self._service.storage
 
 
 @click.group(name="remote")

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -32,18 +32,19 @@ def _make_storage(
     from omnibenchmark.remote.service import StorageService
 
     try:
-        bm = BenchmarkExecution(Path(benchmark_path))
+        service = StorageService.from_path(
+            benchmark_path,
+            full_model=True,
+            require_credentials=require_credentials,
+        )
     except BenchmarkParseError as e:
         logger.error(f"Failed to load benchmark:\n{pretty_print_parse_error(e)}")
         sys.exit(1)
-
-    try:
-        service = StorageService(bm, require_credentials=require_credentials)
     except ValueError as e:
         logger.error(click.style("[ERROR]", fg="red", bold=True) + f" {e}")
         sys.exit(1)
 
-    return bm, service.storage
+    return service._benchmark_model, service.storage
 
 
 @click.group(name="remote")
@@ -123,6 +124,9 @@ def create_benchmark_version(benchmark: str):
 )
 @click.option("-s", "--stage", help="Stage to list files for.", type=str, default=None)
 @click.option(
+    "-m", "--module", help="Module to list files for.", type=str, default=None
+)
+@click.option(
     "-i", "--id", "file_id", help="File id/type to list.", type=str, default=None
 )
 def list_all_files(
@@ -138,16 +142,16 @@ def list_all_files(
     """
     if file_id is not None:
         logger.error("--file_id is not implemented")
-        sys.exit(1)
+        raise click.Abort()
     if type != "all":
         logger.error("--type is not implemented")
-        sys.exit(1)
+        raise click.Abort()
     if stage is not None:
         logger.error("--stage is not implemented")
-        sys.exit(1)
+        raise click.Abort()
     if module is not None:
         logger.error("--module is not implemented")
-        sys.exit(1)
+        raise click.Abort()
 
     objectnames, etags = list_files(benchmark, type, stage, module, file_id)
     if len(objectnames) > 0:

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -43,8 +43,6 @@ class StorageAuth:
         )
 
         # Validate required storage components
-        import click
-
         api = self.benchmark.get_storage_api()
         bucket = self.benchmark.get_storage_bucket_name()
 
@@ -306,7 +304,6 @@ def create_policy(benchmark: str, bucket_name: str):
     - Provide the bucket name directly (--bucket)
     """
     from omnibenchmark.remote.S3config import benchmarker_access_token_policy
-    import click
 
     # Get bucket name from either parameter or benchmark YAML
     if bucket_name:

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -20,7 +20,7 @@ from difflib import unified_diff
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from omnibenchmark.remote.MinIOStorage import MinIOStorage
+    from omnibenchmark.remote.S3Storage import S3CompatibleStorage
 
 from .debug import add_debug_option
 
@@ -47,7 +47,7 @@ class StorageAuth:
             logger.error(click.style("[ERROR]", fg="red", bold=True) + f" {e}")
             sys.exit(1)
 
-    def get_storage_instance(self) -> "MinIOStorage":
+    def get_storage_instance(self) -> "S3CompatibleStorage":
         """Get validated storage instance."""
         return self._service.storage
 

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -105,10 +105,10 @@ def version(ctx):
 remote.add_command(version)
 
 
-@click.group(name="policy")
+@click.group(name="policy", deprecated=True)
 @click.pass_context
 def policy(ctx):
-    """Manage storage policies."""
+    """Manage storage policies. DEPRECATED: use your cloud provider's IAM tooling directly."""
     ctx.ensure_object(dict)
 
 
@@ -394,7 +394,7 @@ def diff_benchmark(ctx, benchmark: str, version1, version2):
         f"Found the following differences in {benchmark} for {version1} and {version2}."
     )
     b = BenchmarkExecution(Path(benchmark))
-    auth_options = remote_storage_args(benchmark)
+    auth_options = remote_storage_args(b)
 
     api = b.get_storage_api()
     bucket = b.get_storage_bucket_name()

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -405,7 +405,7 @@ def diff_benchmark(ctx, benchmark: str, version1, version2):
 
     # get objects for first version
     ss.set_version(version1)
-    ss._get_objects()
+    ss.load_objects()
     files_v1 = [
         f"{f[0]}   {f[1]['size']}   {datetime.fromisoformat(f[1]['last_modified']).strftime('%Y-%m-%d %H:%M:%S')}\n"
         for f in ss.files.items()
@@ -418,7 +418,7 @@ def diff_benchmark(ctx, benchmark: str, version1, version2):
 
     # get objects for second version
     ss.set_version(version2)
-    ss._get_objects()
+    ss.load_objects()
     files_v2 = [
         f"{f[0]}   {f[1]['size']}   {datetime.fromisoformat(f[1]['last_modified']).strftime('%Y-%m-%d %H:%M:%S')}\n"
         for f in ss.files.items()

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -388,52 +388,38 @@ def diff_benchmark(ctx, benchmark: str, version1, version2):
 
     BENCHMARK: Path to benchmark YAML file.
     """
-    from omnibenchmark.remote.storage import get_storage, remote_storage_args
-
     logger.info(
         f"Found the following differences in {benchmark} for {version1} and {version2}."
     )
-    b = BenchmarkExecution(Path(benchmark))
-    auth_options = remote_storage_args(b)
+    storage_auth = StorageAuth(benchmark, require_credentials=False)
+    ss = storage_auth.get_storage_instance()
 
-    api = b.get_storage_api()
-    bucket = b.get_storage_bucket_name()
-    if api is None or bucket is None:
-        raise (ValueError)
-    # setup storage
-    #
-    # TODO: use walrus
-    ss = get_storage(api, auth_options, bucket)
-    if ss is not None:
-        # get objects for first version
-        ss.set_version(version1)
-        ss._get_objects()
-        files_v1 = [
-            f"{f[0]}   {f[1]['size']}   {datetime.fromisoformat(f[1]['last_modified']).strftime('%Y-%m-%d %H:%M:%S')}\n"
-            for f in ss.files.items()
-        ]
-        if f"versions/{version1}.csv" in ss.files.keys():
-            creation_time_v1 = datetime.fromisoformat(
-                ss.files[f"versions/{version1}.csv"]["last_modified"]
-            ).strftime("%Y-%m-%d %H:%M:%S")
-        else:
-            creation_time_v1 = ""
+    # get objects for first version
+    ss.set_version(version1)
+    ss._get_objects()
+    files_v1 = [
+        f"{f[0]}   {f[1]['size']}   {datetime.fromisoformat(f[1]['last_modified']).strftime('%Y-%m-%d %H:%M:%S')}\n"
+        for f in ss.files.items()
+    ]
+    creation_time_v1 = ""
+    if f"versions/{version1}.csv" in ss.files.keys():
+        creation_time_v1 = datetime.fromisoformat(
+            ss.files[f"versions/{version1}.csv"]["last_modified"]
+        ).strftime("%Y-%m-%d %H:%M:%S")
 
-        # get objects for second version
-        ss.set_version(version2)
-        ss._get_objects()
-        files_v2 = [
-            f"{f[0]}   {f[1]['size']}   {datetime.fromisoformat(f[1]['last_modified']).strftime('%Y-%m-%d %H:%M:%S')}\n"
-            for f in ss.files.items()
-        ]
-        if f"versions/{version2}.csv" in ss.files.keys():
-            creation_time_v2 = datetime.fromisoformat(
-                ss.files[f"versions/{version2}.csv"]["last_modified"]
-            ).strftime("%Y-%m-%d %H:%M:%S")
-        else:
-            creation_time_v2 = ""
+    # get objects for second version
+    ss.set_version(version2)
+    ss._get_objects()
+    files_v2 = [
+        f"{f[0]}   {f[1]['size']}   {datetime.fromisoformat(f[1]['last_modified']).strftime('%Y-%m-%d %H:%M:%S')}\n"
+        for f in ss.files.items()
+    ]
+    creation_time_v2 = ""
+    if f"versions/{version2}.csv" in ss.files.keys():
+        creation_time_v2 = datetime.fromisoformat(
+            ss.files[f"versions/{version2}.csv"]["last_modified"]
+        ).strftime("%Y-%m-%d %H:%M:%S")
 
-    # diff the two versions
     click.echo(
         "".join(
             list(
@@ -462,24 +448,10 @@ def list_versions(ctx, benchmark: str):
 
     BENCHMARK: Path to benchmark YAML file.
     """
-    from omnibenchmark.remote.storage import get_storage, remote_storage_args
-
     logger.info(f"Available versions of {benchmark}:")
 
-    b = BenchmarkExecution(Path(benchmark))
-    auth_options = remote_storage_args(b)
-    api = b.get_storage_api()
-    bucket = b.get_storage_bucket_name()
-
-    if api is None:
-        raise ValueError("No storage API found")
-    if bucket is None:
-        raise ValueError("No storage bucket found")
-
-    # setup storage
-    ss = get_storage(api, auth_options, bucket)
-    if ss is None:
-        raise ValueError("No storage found")
+    storage_auth = StorageAuth(benchmark, require_credentials=False)
+    ss = storage_auth.get_storage_instance()
 
     if len(ss.versions) > 0:
         if len(ss.versions) > 1:

--- a/omnibenchmark/cli/remote.py
+++ b/omnibenchmark/cli/remote.py
@@ -25,31 +25,25 @@ if TYPE_CHECKING:
 from .debug import add_debug_option
 
 
-class StorageAuth:
-    """Convenience class for handling storage authentication and validation."""
+def _make_storage(
+    benchmark_path: str, require_credentials: bool = True
+) -> "tuple[BenchmarkExecution, S3CompatibleStorage]":
+    """Load a benchmark and return (benchmark, storage), exiting on any error."""
+    from omnibenchmark.remote.service import StorageService
 
-    def __init__(self, benchmark_path: str, require_credentials: bool = True):
-        self.benchmark_path = benchmark_path
-        try:
-            self.benchmark = BenchmarkExecution(Path(benchmark_path))
-        except BenchmarkParseError as e:
-            formatted_error = pretty_print_parse_error(e)
-            logger.error(f"Failed to load benchmark:\n{formatted_error}")
-            sys.exit(1)
+    try:
+        bm = BenchmarkExecution(Path(benchmark_path))
+    except BenchmarkParseError as e:
+        logger.error(f"Failed to load benchmark:\n{pretty_print_parse_error(e)}")
+        sys.exit(1)
 
-        try:
-            from omnibenchmark.remote.service import StorageService
+    try:
+        service = StorageService(bm, require_credentials=require_credentials)
+    except ValueError as e:
+        logger.error(click.style("[ERROR]", fg="red", bold=True) + f" {e}")
+        sys.exit(1)
 
-            self._service = StorageService(
-                self.benchmark, require_credentials=require_credentials
-            )
-        except ValueError as e:
-            logger.error(click.style("[ERROR]", fg="red", bold=True) + f" {e}")
-            sys.exit(1)
-
-    def get_storage_instance(self) -> "S3CompatibleStorage":
-        """Get validated storage instance."""
-        return self._service.storage
+    return bm, service.storage
 
 
 @click.group(name="remote")
@@ -102,10 +96,8 @@ def create_benchmark_version(benchmark: str):
     """
     assert benchmark is not None
 
-    storage_auth = StorageAuth(benchmark)
-    ss = storage_auth.get_storage_instance()
-
-    ss.set_version(storage_auth.benchmark.get_benchmark_version())
+    bm, ss = _make_storage(benchmark)
+    ss.set_version(bm.get_benchmark_version())
 
     if ss.version in ss.versions:
         logger.error(
@@ -113,7 +105,7 @@ def create_benchmark_version(benchmark: str):
         )
         sys.exit(1)
     logger.info("Create a new benchmark version")
-    ss.create_new_version(storage_auth.benchmark)
+    ss.create_new_version(bm)
 
 
 @add_debug_option
@@ -376,8 +368,7 @@ def diff_benchmark(ctx, benchmark: str, version1, version2):
     logger.info(
         f"Found the following differences in {benchmark} for {version1} and {version2}."
     )
-    storage_auth = StorageAuth(benchmark, require_credentials=False)
-    ss = storage_auth.get_storage_instance()
+    _, ss = _make_storage(benchmark, require_credentials=False)
 
     # get objects for first version
     ss.set_version(version1)
@@ -435,8 +426,7 @@ def list_versions(ctx, benchmark: str):
     """
     logger.info(f"Available versions of {benchmark}:")
 
-    storage_auth = StorageAuth(benchmark, require_credentials=False)
-    ss = storage_auth.get_storage_instance()
+    _, ss = _make_storage(benchmark, require_credentials=False)
 
     if len(ss.versions) > 0:
         if len(ss.versions) > 1:

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -155,6 +155,7 @@ class StorageAPIEnum(str, Enum):
     """Storage API types. Currently only S3 is supported."""
 
     s3 = "S3"
+    minio = "MinIO"  # Deprecated: MinIO is S3-compatible; use api: S3 with a custom endpoint.
 
 
 # Base models
@@ -208,6 +209,19 @@ class Storage(BaseModel):
     bucket_name: Optional[str] = Field(
         None, description="Storage bucket name (only needed if using S3)"
     )
+
+    @field_validator("api", mode="after")
+    @classmethod
+    def warn_minio_deprecated(cls, v: "StorageAPIEnum") -> "StorageAPIEnum":
+        if v == StorageAPIEnum.minio:
+            import warnings
+
+            warnings.warn(
+                "Storage api 'MinIO' is deprecated. Use api: S3 with a custom endpoint instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return v
 
 
 class Parameter(BaseModel):

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -155,7 +155,7 @@ class StorageAPIEnum(str, Enum):
     """Storage API types. Currently only S3 is supported."""
 
     s3 = "S3"
-    minio = "MinIO"  # Deprecated: MinIO is S3-compatible; use api: S3 with a custom endpoint.
+    minio = "MINIO"  # Deprecated: MinIO is S3-compatible; use api: S3 with a custom endpoint.
 
 
 # Base models

--- a/omnibenchmark/remote/MinIOStorage.py
+++ b/omnibenchmark/remote/MinIOStorage.py
@@ -612,19 +612,8 @@ class MinIOStorage(RemoteStorage):
         # TODO: upload the zip archive
         _ = archive_version(benchmark, outdir, config, code, software, results)
 
-    def upload_version(
-        self,
-        benchmark: BenchmarkExecution,
-        outdir: Path = Path(),
-        config: bool = True,
-        code: bool = False,
-        software: bool = False,
-        results: bool = False,
-    ):
-        from omnibenchmark.remote.archive import archive_version
-
-        # TODO: upload the zip archive, we're not doing anything with the result!
-        _ = archive_version(benchmark, outdir, config, code, software, results)
+    def upload_version(self, *args, **kwargs):
+        raise NotImplementedError("upload_version is not yet implemented")
 
     def delete_version(self, version):
         raise NotImplementedError

--- a/omnibenchmark/remote/MinIOStorage.py
+++ b/omnibenchmark/remote/MinIOStorage.py
@@ -175,25 +175,6 @@ class MinIOStorage(RemoteStorage):
         super().__init__(auth_options, benchmark, storage_options)
         assert "endpoint" in self.auth_options.keys()
 
-        # ARCHITECTURAL NOTE: Version Manager Coupling
-        # Storage directly instantiates version managers, creating tight coupling.
-        # During the LinkML → Pydantic migration, this pattern emerged to handle
-        # version validation within storage operations.
-        #
-        # Future consideration: Inject version manager as a dependency rather
-        # than creating it here. This would improve testability and separation of concerns,
-        # and allow for more flexibility in managing versions (monotonic, etc)
-        from omnibenchmark.versioning import BenchmarkVersionManager
-
-        from omnibenchmark.config import get_temp_dir
-
-        temp_dir = get_temp_dir()
-        self.version_manager = BenchmarkVersionManager(
-            benchmark_path=temp_dir / f"{benchmark}.yaml",
-            lock_dir=temp_dir / "locks",
-            lock_timeout=30.0,
-        )
-
         if "access_key" in self.auth_options.keys():
             self.client = self.connect()
             self.roclient = self.connect(readonly=True)
@@ -327,8 +308,6 @@ class MinIOStorage(RemoteStorage):
             if re.match("(\\d+).(\\d+)", version):
                 versions.append(Version(version))
         self.versions = versions
-        # Sync with version manager (in-memory tracking only)
-        self.version_manager.set_known_versions([str(v) for v in versions])
 
     def create_new_version(
         self, benchmark: Optional[BenchmarkExecution] = None
@@ -346,7 +325,7 @@ class MinIOStorage(RemoteStorage):
         # Refresh versions from storage
         self._get_versions()
 
-        # Initialize version manager based on whether benchmark is provided
+        # Build a version manager local to this call (no persistent instance state).
         from omnibenchmark.config import get_temp_dir
 
         temp_dir = get_temp_dir()
@@ -354,34 +333,33 @@ class MinIOStorage(RemoteStorage):
         if benchmark is not None:
             # Try git-aware version manager first, fall back to basic if git not available
             try:
-                self.version_manager = GitAwareBenchmarkVersionManager(
+                version_manager = GitAwareBenchmarkVersionManager(
                     benchmark_path=benchmark.get_definition_file(),
                     git_repo_path=benchmark.context.directory,
                     lock_dir=temp_dir / "locks",
                     lock_timeout=30.0,
                 )
-                # Sync known versions from storage
-                self.version_manager.set_known_versions([str(v) for v in self.versions])
+                version_manager.set_known_versions([str(v) for v in self.versions])
             except Exception:
                 # Fall back to basic version manager if git not available
                 from omnibenchmark.versioning import BenchmarkVersionManager
 
-                self.version_manager = BenchmarkVersionManager(
+                version_manager = BenchmarkVersionManager(
                     benchmark_path=benchmark.get_definition_file(),
                     lock_dir=temp_dir / "locks",
                     lock_timeout=30.0,
                 )
-                self.version_manager.set_known_versions([str(v) for v in self.versions])
+                version_manager.set_known_versions([str(v) for v in self.versions])
         else:
             # Use basic version manager for validation only (testing scenarios)
             from omnibenchmark.versioning import BenchmarkVersionManager
 
-            self.version_manager = BenchmarkVersionManager(
+            version_manager = BenchmarkVersionManager(
                 benchmark_path=temp_dir / f"{self.benchmark}.yaml",
                 lock_dir=temp_dir / "locks",
                 lock_timeout=30.0,
             )
-            self.version_manager.set_known_versions([str(v) for v in self.versions])
+            version_manager.set_known_versions([str(v) for v in self.versions])
 
         # Track uploaded objects for rollback on failure
         uploaded_objects = []
@@ -390,35 +368,31 @@ class MinIOStorage(RemoteStorage):
         try:
             # First: Create version with persistence (VersionManager updates YAML and commits to git)
             if benchmark is not None and hasattr(
-                self.version_manager, "create_version_with_persistence"
+                version_manager, "create_version_with_persistence"
             ):
                 try:
-                    _created_version = (
-                        self.version_manager.create_version_with_persistence(  # type: ignore
-                            benchmark,
-                            str(self.version),
-                            f"Create benchmark version {self.version}",
-                        )
+                    _created_version = version_manager.create_version_with_persistence(  # type: ignore
+                        benchmark,
+                        str(self.version),
+                        f"Create benchmark version {self.version}",
                     )
                 except Exception:
                     # If git-based version creation fails, fall back to basic version manager
                     from omnibenchmark.versioning import BenchmarkVersionManager
 
-                    self.version_manager = BenchmarkVersionManager(
+                    version_manager = BenchmarkVersionManager(
                         benchmark_path=benchmark.get_definition_file(),
                         lock_dir=temp_dir / "locks",
                         lock_timeout=30.0,
                     )
-                    self.version_manager.set_known_versions(
-                        [str(v) for v in self.versions]
-                    )
-                    self.version_manager.set_known_versions(
-                        self.version_manager.get_versions() + [str(self.version)]
+                    version_manager.set_known_versions([str(v) for v in self.versions])
+                    version_manager.set_known_versions(
+                        version_manager.get_versions() + [str(self.version)]
                     )
             else:
                 # Basic version tracking for testing scenarios
-                self.version_manager.set_known_versions(
-                    self.version_manager.get_versions() + [str(self.version)]
+                version_manager.set_known_versions(
+                    version_manager.get_versions() + [str(self.version)]
                 )
 
             # Then: upload the UPDATED benchmark definition file and software files
@@ -523,8 +497,7 @@ class MinIOStorage(RemoteStorage):
         if self.version not in self.versions:
             raise MinIOStorageBucketManipulationException("Version creation failed")
 
-    # TODO(ben): review if we want to make this method public, it's used in tests
-    def _get_objects(self) -> None:
+    def load_objects(self) -> None:
         if self.version is None:
             raise RemoteStorageInvalidInputException(
                 "No version provided, set version first with method 'set_version'"
@@ -585,7 +558,7 @@ class MinIOStorage(RemoteStorage):
                 "No version provided. Set version first with method 'set_version'"
             )
         if self.files is None:
-            self._get_objects()
+            self.load_objects()
         if self.files is None:
             raise RemoteStorageInvalidInputException("No objects found")
         if object_name not in self.files.keys():

--- a/omnibenchmark/remote/RemoteStorage.py
+++ b/omnibenchmark/remote/RemoteStorage.py
@@ -109,7 +109,6 @@ class RemoteStorage(metaclass=ABCMeta):
     - _create_new_version(): Creates a new version of the benchmark.
     - _get_objects(readonly): Retrieves the objects in the storage for the current benchmark.
     - archive_version(version): Archives a specific benchmark version.
-    - delete_version(version): Deletes a specific benchmark version.
     """
 
     def __init__(
@@ -276,22 +275,5 @@ class RemoteStorage(metaclass=ABCMeta):
             code: Include code files.
             software: Include software environment files.
             results: Include result files.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def delete_version(self, version: str) -> None:
-        """
-        Deletes a specific benchmark version and its WORM-protected objects.
-
-        Requires BypassGovernanceRetention permission on the bucket.
-
-        Note: if the same S3 object version is referenced by multiple benchmark
-        versions (i.e. the object was not re-uploaded between versions), deleting
-        one benchmark version will also remove that object version from other
-        benchmark versions that share it.
-
-        Args:
-            version (str): The benchmark version string to delete (e.g. "1.0").
         """
         raise NotImplementedError

--- a/omnibenchmark/remote/RemoteStorage.py
+++ b/omnibenchmark/remote/RemoteStorage.py
@@ -2,7 +2,10 @@
 
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
-from typing import Dict, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
+
+if TYPE_CHECKING:
+    from omnibenchmark.benchmark import BenchmarkExecution
 
 import packaging.version
 from packaging.version import Version
@@ -144,9 +147,12 @@ class RemoteStorage(metaclass=ABCMeta):
         self.storage_options = storage_options
 
     @abstractmethod
-    def connect(self):
+    def connect(self, readonly: bool = False):
         """
         Connects to the storage Service.
+
+        Args:
+            readonly: When True, connect without write credentials.
 
         Returns:
             - Storage Client / Service
@@ -162,24 +168,20 @@ class RemoteStorage(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def _create_benchmark(self, benchmark: str, update: bool = True) -> None:
+    def _create_benchmark(self, benchmark: str) -> None:
         """
         Creates a new benchmark in the remote storage.
 
         Args:
             benchmark: The name of the benchmark.
-            update: Whether to update the list of benchmarks. Defaults to True.
         """
         raise NotImplementedError
 
     @abstractmethod
-    def _get_versions(self, update: bool = True, readonly: bool = False) -> None:
+    def _get_versions(self) -> None:
         """
-        Retrieves the benchmark versions in the remote storage.
-
-        Args:
-            update (bool, optional): Whether to update the versions. Defaults to True.
-            readonly (bool, optional): Whether to retrieve the versions in read-only mode. Defaults to False.
+        Retrieves the benchmark versions in the remote storage and
+        populates ``self.versions``.
         """
         self.versions = []
 
@@ -223,7 +225,9 @@ class RemoteStorage(metaclass=ABCMeta):
         self.version = self._parse_version(version)
 
     @abstractmethod
-    def create_new_version(self, benchmark=None) -> None:
+    def create_new_version(
+        self, benchmark: "Optional[BenchmarkExecution]" = None
+    ) -> None:
         """
         Creates a new version of the benchmark.
 
@@ -255,7 +259,7 @@ class RemoteStorage(metaclass=ABCMeta):
     @abstractmethod
     def archive_version(
         self,
-        benchmark: str,
+        benchmark: "BenchmarkExecution",
         outdir: Path = Path(),
         config: bool = True,
         code: bool = False,
@@ -266,7 +270,12 @@ class RemoteStorage(metaclass=ABCMeta):
         Archives/Freezes a specific benchmark version.
 
         Args:
-            version (str): The version to archive.
+            benchmark: The benchmark execution context.
+            outdir: Local directory for the archive output.
+            config: Include config files.
+            code: Include code files.
+            software: Include software environment files.
+            results: Include result files.
         """
         raise NotImplementedError
 

--- a/omnibenchmark/remote/RemoteStorage.py
+++ b/omnibenchmark/remote/RemoteStorage.py
@@ -271,11 +271,18 @@ class RemoteStorage(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def delete_version(self, version):
+    def delete_version(self, version: str) -> None:
         """
-        Deletes a specific benchmark version.
+        Deletes a specific benchmark version and its WORM-protected objects.
+
+        Requires BypassGovernanceRetention permission on the bucket.
+
+        Note: if the same S3 object version is referenced by multiple benchmark
+        versions (i.e. the object was not re-uploaded between versions), deleting
+        one benchmark version will also remove that object version from other
+        benchmark versions that share it.
 
         Args:
-            version (str): The version to delete.
+            version (str): The benchmark version string to delete (e.g. "1.0").
         """
         raise NotImplementedError

--- a/omnibenchmark/remote/RemoteStorage.py
+++ b/omnibenchmark/remote/RemoteStorage.py
@@ -42,7 +42,7 @@ class RemoteStorage(metaclass=ABCMeta):
     A class representing a remote storage with version-controlled S3 buckets.
 
     This class provides an abstract interface for managing benchmark results in S3-compatible
-    storage (MinIO, AWS S3) with immutable versioning and retention policies for reproducibility.
+    storage (AWS S3, MinIO) with immutable versioning and retention policies for reproducibility.
 
     ## S3 Versioning and Object Protection
 
@@ -235,7 +235,7 @@ class RemoteStorage(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_objects(self):
+    def load_objects(self):
         """
         Retrieves the objects in the storage for the current benchmark version.
         """

--- a/omnibenchmark/remote/RemoteStorage.py
+++ b/omnibenchmark/remote/RemoteStorage.py
@@ -223,9 +223,14 @@ class RemoteStorage(metaclass=ABCMeta):
         self.version = self._parse_version(version)
 
     @abstractmethod
-    def create_new_version(self):
+    def create_new_version(self, benchmark=None) -> None:
         """
         Creates a new version of the benchmark.
+
+        Args:
+            benchmark: Optional BenchmarkExecution object. When provided,
+                uploads the benchmark YAML and software files and uses
+                git-aware version tracking.
         """
         raise NotImplementedError
 

--- a/omnibenchmark/remote/RemoteStorage.py
+++ b/omnibenchmark/remote/RemoteStorage.py
@@ -233,9 +233,6 @@ class RemoteStorage(metaclass=ABCMeta):
     def _get_objects(self):
         """
         Retrieves the objects in the storage for the current benchmark version.
-
-        Args:
-            readonly (bool, optional): Whether to retrieve the objects in read-only mode. Defaults to False.
         """
         raise NotImplementedError
 

--- a/omnibenchmark/remote/RemoteStorage.py
+++ b/omnibenchmark/remote/RemoteStorage.py
@@ -119,10 +119,23 @@ class RemoteStorage(metaclass=ABCMeta):
     ):
         self.version = None
         self.versions = list()
-        self.files = dict()
+        self._files: dict = {}
+        self._files_loaded: bool = False
         self._parse_benchmark(benchmark)
         self._parse_auth_options(auth_options)
         self._parse_storage_options(storage_options)
+
+    @property
+    def files(self) -> dict:
+        """File metadata dict; loaded on first access after each set_version() call."""
+        if not self._files_loaded:
+            self.load_objects()
+        return self._files
+
+    @files.setter
+    def files(self, value: dict) -> None:
+        self._files = value
+        self._files_loaded = True
 
     def _parse_benchmark(self, benchmark: str) -> None:
         if not isinstance(benchmark, str):
@@ -222,6 +235,7 @@ class RemoteStorage(metaclass=ABCMeta):
             RemoteStorageInvalidInputException: If version does not exist in the available versions.
         """
         self.version = self._parse_version(version)
+        self._files_loaded = False
 
     @abstractmethod
     def create_new_version(

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -340,66 +340,6 @@ class S3CompatibleStorage(RemoteStorage):
     def upload_version(self, *args, **kwargs):
         raise NotImplementedError("upload_version is not yet implemented")
 
-    def delete_version(self, version: str) -> None:
-        """Delete a benchmark version and its WORM-protected S3 object versions.
-
-        Uses BypassGovernanceRetention=True to remove objects protected by
-        Governance Mode retention. Requires the s3:BypassGovernanceRetention
-        permission on the bucket.
-
-        Note: if the same S3 object version is referenced by multiple benchmark
-        versions (i.e. the object was not re-uploaded between versions), deleting
-        one benchmark version will also remove that object version from other
-        benchmark versions that share it.
-        """
-        if "access_key" not in self.auth_options:
-            raise RemoteStorageInvalidInputException(
-                "Read-only mode, cannot delete version,"
-                " set access_key and secret_key in auth_options"
-            )
-
-        self._get_versions()
-        target = Version(version)
-        if target not in self.versions:
-            raise RemoteStorageInvalidInputException(
-                f"Version {version} does not exist"
-            )
-
-        self.set_version(version)
-        self.load_objects()
-        objects_to_delete = dict(self.files)
-
-        failed: list = []
-        for obj_name, meta in tqdm.tqdm(
-            objects_to_delete.items(),
-            total=len(objects_to_delete),
-            desc="Deleting objects",
-            unit="obj",
-        ):
-            version_id = meta.get("version_id")
-            try:
-                delete_kwargs: dict = {
-                    "Bucket": self.benchmark,
-                    "Key": obj_name,
-                    "BypassGovernanceRetention": True,
-                }
-                if version_id:
-                    delete_kwargs["VersionId"] = version_id
-                self.client.delete_object(**delete_kwargs)
-            except Exception as e:
-                logger.warning(
-                    f"Could not delete {obj_name} (version {version_id}): {e}"
-                )
-                failed.append(obj_name)
-
-        if failed:
-            raise RemoteStorageInvalidInputException(
-                f"delete_version {version} completed with errors;"
-                f" {len(failed)} object(s) could not be deleted: {failed}"
-            )
-
-        self._get_versions()
-
     # ------------------------------------------------------------------
     # create_new_version helpers
     # ------------------------------------------------------------------

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -15,8 +15,10 @@ from typing import Dict, Optional
 
 try:
     import boto3
+    from boto3 import client as boto3_s3_client
 except ImportError:
     boto3 = None  # type: ignore
+    boto3_s3_client = None  # type: ignore
 
 from omnibenchmark.benchmark import BenchmarkExecution
 from omnibenchmark.remote.exception import (
@@ -132,7 +134,7 @@ class S3CompatibleStorage(RemoteStorage):
             kwargs["aws_access_key_id"] = self.auth_options["access_key"]
             kwargs["aws_secret_access_key"] = self.auth_options["secret_key"]
 
-        return boto3.client("s3", **kwargs)
+        return boto3.client("s3", **kwargs)  # type: ignore[union-attr]
 
     def _bucket_exists(self, bucket_name: str) -> bool:
         """Return True if the bucket exists and is accessible."""

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -239,17 +239,32 @@ class S3CompatibleStorage(RemoteStorage):
         self._validate_for_write()
         self._get_versions()
 
+        # Idempotency: the manifest is the commit point; if it exists the version
+        # is already complete — nothing to do.
+        if self.version in self.versions:
+            logger.info(f"Version {self.version} already exists, skipping.")
+            return
+
         version_manager = self._build_version_manager(benchmark)
+        tagged: list = []
         try:
             self._persist_version(version_manager, benchmark)
             if benchmark is not None:
                 self._upload_benchmark_config(benchmark)
-            self._tag_and_protect_objects(benchmark)
+            # _tag_and_protect_objects returns the full tagged list so we can
+            # roll back here if the subsequent manifest write fails.
+            tagged = self._tag_and_protect_objects(benchmark)
+            # Manifest write is the atomic commit point — inside the try so any
+            # failure triggers a rollback of the tags applied above.
+            self._write_version_manifest()
+        except RemoteStorageInvalidInputException:
+            raise  # already wrapped with context by the inner method
         except Exception as e:
             logger.error(f"Error creating version {self.version}, rolling back: {e}")
+            if tagged:
+                self._rollback_tags(tagged)
             raise RemoteStorageInvalidInputException(f"Failed to create version: {e}")
 
-        self._write_version_manifest()
         self._get_versions()
         if self.version not in self.versions:
             raise S3StorageBucketManipulationException("Version creation failed")
@@ -444,10 +459,14 @@ class S3CompatibleStorage(RemoteStorage):
                 Body=softstr.encode(),
             )
 
-    def _tag_and_protect_objects(self, benchmark: Optional[BenchmarkExecution]) -> None:
+    def _tag_and_protect_objects(self, benchmark: Optional[BenchmarkExecution]) -> list:
         """Tag current objects with the benchmark version and apply WORM retention.
 
-        Rolls back any tags it applied on failure before re-raising.
+        On failure rolls back any tags applied so far and re-raises.
+
+        Returns:
+            List of (name, version_id) tuples for all tagged objects, so the
+            caller can roll back if a subsequent step fails.
         """
         objdic = get_s3_object_versions_and_tags(self.client, self.benchmark)
         names, vids = get_objects_to_tag(objdic, storage_options=self.storage_options)
@@ -490,6 +509,8 @@ class S3CompatibleStorage(RemoteStorage):
         except Exception:
             self._rollback_tags(tagged)
             raise
+
+        return tagged
 
     def _rollback_tags(self, tagged_objects: list) -> None:
         """Best-effort removal of version tags; called on create_new_version failure."""

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -1,4 +1,4 @@
-"""MinIO class for remote storage."""
+"""S3-compatible storage implementation."""
 # pyright: reportCallIssue=false
 # TODO: Fix boto3/minio API call type errors
 # TODO: Migrate from minio library to boto3-only
@@ -79,7 +79,7 @@ def set_bucket_lifecycle_config(
     client.set_bucket_lifecycle(bucket_name, lifecycle_config)
 
 
-class MinIOStorage(RemoteStorage):
+class S3CompatibleStorage(RemoteStorage):
     """
     MinIO/S3-compatible storage implementation with versioning and object protection.
 
@@ -592,4 +592,8 @@ class MinIOStorage(RemoteStorage):
         raise NotImplementedError
 
 
-RemoteStorage.register(MinIOStorage)
+RemoteStorage.register(S3CompatibleStorage)
+
+# Backward-compatibility alias so that existing code importing MinIOStorage
+# continues to work without changes during the deprecation period.
+MinIOStorage = S3CompatibleStorage

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -21,8 +21,8 @@ except ImportError:
 from omnibenchmark.benchmark import BenchmarkExecution
 from omnibenchmark.remote.exception import (
     RemoteStorageInvalidInputException,
-    MinIOStorageConnectionException,
-    MinIOStorageBucketManipulationException,
+    S3StorageConnectionException,
+    S3StorageBucketManipulationException,
 )
 from omnibenchmark.archive.components import prepare_archive_software
 from omnibenchmark.remote.RemoteStorage import RemoteStorage, StorageOptions
@@ -58,8 +58,8 @@ class S3CompatibleStorage(RemoteStorage):
         storage_options (StorageOptions): Configuration for tracked directories.
 
     Raises:
-        MinIOStorageConnectionException: When connection to S3 fails.
-        MinIOStorageBucketManipulationException: When bucket operations fail.
+        S3StorageConnectionException: When connection to S3 fails.
+        S3StorageBucketManipulationException: When bucket operations fail.
         RemoteStorageInvalidInputException: When version operations fail.
     """
 
@@ -150,11 +150,11 @@ class S3CompatibleStorage(RemoteStorage):
         try:
             self.client.list_objects_v2(Bucket=self.benchmark, MaxKeys=1)
         except ClientError as e:
-            raise MinIOStorageConnectionException(str(e)) from e
+            raise S3StorageConnectionException(str(e)) from e
 
     def _create_benchmark(self, benchmark: str) -> None:
         if self._bucket_exists(benchmark):
-            raise MinIOStorageBucketManipulationException(
+            raise S3StorageBucketManipulationException(
                 f"Benchmark {benchmark} already exists."
             )
 
@@ -184,7 +184,7 @@ class S3CompatibleStorage(RemoteStorage):
         )
 
         if not self._bucket_exists(benchmark):
-            raise MinIOStorageBucketManipulationException(
+            raise S3StorageBucketManipulationException(
                 f"Bucket creation for benchmark {benchmark} failed"
             )
 
@@ -199,13 +199,13 @@ class S3CompatibleStorage(RemoteStorage):
             code = e.response["Error"]["Code"]
             if code in ("AccessDenied", "403"):
                 logger.debug("S3 access denied", exc_info=True)
-                raise MinIOStorageConnectionException(
+                raise S3StorageConnectionException(
                     f"Access denied to S3 bucket '{self.benchmark}'."
                     " Check your credentials have the correct permissions."
                 ) from e
             if code in ("NoSuchBucket", "404"):
                 logger.debug("S3 bucket not found", exc_info=True)
-                raise MinIOStorageConnectionException(
+                raise S3StorageConnectionException(
                     f"S3 bucket '{self.benchmark}' does not exist."
                 ) from e
             raise
@@ -238,7 +238,7 @@ class S3CompatibleStorage(RemoteStorage):
         self._write_version_manifest()
         self._get_versions()
         if self.version not in self.versions:
-            raise MinIOStorageBucketManipulationException("Version creation failed")
+            raise S3StorageBucketManipulationException("Version creation failed")
 
     def load_objects(self) -> None:
         if self.version is None:

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -75,13 +75,14 @@ class S3CompatibleStorage(RemoteStorage):
         if "access_key" in self.auth_options.keys():
             self.client = self.connect()
             self.roclient = self.connect(readonly=True)
-            self._test_connect()
 
             if not self._bucket_exists(benchmark):
                 logger.warning(
                     f"Benchmark {benchmark} does not exist, creating new benchmark."
                 )
                 self._create_benchmark(benchmark)
+
+            self._test_connect()
 
             self._get_versions()
         else:
@@ -169,19 +170,30 @@ class S3CompatibleStorage(RemoteStorage):
         policy = bucket_readonly_policy(benchmark)
         self.client.put_bucket_policy(Bucket=benchmark, Policy=json.dumps(policy))
 
-        self.client.put_bucket_lifecycle_configuration(
-            Bucket=benchmark,
-            LifecycleConfiguration={
-                "Rules": [
-                    {
-                        "ID": "rule1",
-                        "Filter": {"Prefix": ""},
-                        "Status": "Enabled",
-                        "NoncurrentVersionExpiration": {"NoncurrentDays": 1},
-                    }
-                ]
-            },
-        )
+        # Lifecycle configuration is best-effort: MinIO requires Content-MD5 for
+        # this operation, which recent boto3 no longer sends by default (it uses
+        # x-amz-checksum-* instead). The policy is non-essential — it only
+        # auto-expires old noncurrent object versions to save storage.
+        try:
+            self.client.put_bucket_lifecycle_configuration(
+                Bucket=benchmark,
+                LifecycleConfiguration={
+                    "Rules": [
+                        {
+                            "ID": "rule1",
+                            "Filter": {"Prefix": ""},
+                            "Status": "Enabled",
+                            "NoncurrentVersionExpiration": {"NoncurrentDays": 1},
+                        }
+                    ]
+                },
+            )
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code in ("MissingContentMD5", "NotImplemented"):
+                logger.debug("Lifecycle configuration not applied (%s): %s", code, e)
+            else:
+                raise
 
         if not self._bucket_exists(benchmark):
             raise S3StorageBucketManipulationException(
@@ -516,6 +528,7 @@ class S3CompatibleStorage(RemoteStorage):
                     Key=n,
                     VersionId=v,
                     Retention={"Mode": "GOVERNANCE", "RetainUntilDate": retain_until},
+                    ChecksumAlgorithm="CRC32",
                 )
         except Exception:
             self._rollback_tags(tagged)
@@ -557,6 +570,7 @@ class S3CompatibleStorage(RemoteStorage):
             Bucket=self.benchmark,
             Key=version_filename,
             Retention={"Mode": "GOVERNANCE", "RetainUntilDate": retain_until},
+            ChecksumAlgorithm="CRC32",
         )
 
 

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -6,6 +6,8 @@ import logging
 import os
 import re
 
+import tqdm
+
 from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -368,7 +370,12 @@ class S3CompatibleStorage(RemoteStorage):
         objects_to_delete = dict(self.files)
 
         failed: list = []
-        for obj_name, meta in objects_to_delete.items():
+        for obj_name, meta in tqdm.tqdm(
+            objects_to_delete.items(),
+            total=len(objects_to_delete),
+            desc="Deleting objects",
+            unit="obj",
+        ):
             version_id = meta.get("version_id")
             try:
                 delete_kwargs: dict = {
@@ -511,7 +518,12 @@ class S3CompatibleStorage(RemoteStorage):
         tag_set = [{"Key": str(self.version), "Value": "1"}]
         tagged: list = []
         try:
-            for n, v in zip(names, vids):
+            for n, v in tqdm.tqdm(
+                zip(names, vids),
+                total=len(names),
+                desc="Tagging objects",
+                unit="obj",
+            ):
                 self.client.put_object_tagging(
                     Bucket=self.benchmark,
                     Key=n,
@@ -522,7 +534,12 @@ class S3CompatibleStorage(RemoteStorage):
             retain_until = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
                 weeks=1000
             )
-            for n, v in zip(names, vids):
+            for n, v in tqdm.tqdm(
+                zip(names, vids),
+                total=len(names),
+                desc="Locking objects",
+                unit="obj",
+            ):
                 self.client.put_object_retention(
                     Bucket=self.benchmark,
                     Key=n,

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -1,36 +1,22 @@
 """S3-compatible storage implementation."""
-# pyright: reportCallIssue=false
-# TODO: Fix boto3/minio API call type errors
-# TODO: Migrate from minio library to boto3-only
-#       The minio Python library is not actively maintained as of late 2025.
-#       Since MinIO servers are S3-compatible, we should migrate to use boto3
-#       exclusively, which is actively maintained by AWS and is the industry
-#       standard. All current minio library operations (bucket management,
-#       versioning, policies, lifecycle) can be done with boto3.
 
 import datetime
-import io
 import json
 import logging
 import os
 import re
 
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.exceptions import ClientError
 from packaging.version import Version
 from pathlib import Path
 from typing import Dict, Optional
-from urllib.parse import urlparse
 
 try:
     import boto3
-    import minio
-    import minio.commonconfig
-    import minio.retention
-    from minio.lifecycleconfig import LifecycleConfig, Rule, NoncurrentVersionExpiration
-    from minio.commonconfig import Filter, Tags
 except ImportError:
-    # perhaps should be handled at a higher level, and advice the user to install the required packages
-    # via pip install minio boto3 or extras['s3'].
-    pass
+    boto3 = None  # type: ignore
 
 from omnibenchmark.benchmark import BenchmarkExecution
 from omnibenchmark.remote.exception import (
@@ -50,120 +36,31 @@ from omnibenchmark.remote.versioning import (
 )
 from omnibenchmark.versioning.git import GitAwareBenchmarkVersionManager
 
-# TODO: set if we have the DEBUG flag set
 logging.getLogger("requests").setLevel(logging.DEBUG)
-logging.getLogger("minio").setLevel(logging.DEBUG)
 logger = logging.getLogger(__name__)
-
-
-def set_bucket_public_readonly(client: "minio.Minio", bucket_name: str):
-    policy = bucket_readonly_policy(bucket_name)
-    client.set_bucket_policy(bucket_name, json.dumps(policy))
-
-
-def set_bucket_lifecycle_config(
-    client: "minio.Minio", bucket_name: str, noncurrent_days: int = 1
-):
-    lifecycle_config = LifecycleConfig(
-        [
-            Rule(
-                minio.commonconfig.ENABLED,
-                rule_filter=Filter(prefix="*"),
-                rule_id="rule1",
-                noncurrent_version_expiration=NoncurrentVersionExpiration(
-                    noncurrent_days=noncurrent_days
-                ),
-            ),
-        ],
-    )
-    client.set_bucket_lifecycle(bucket_name, lifecycle_config)
 
 
 class S3CompatibleStorage(RemoteStorage):
     """
-    MinIO/S3-compatible storage implementation with versioning and object protection.
+    S3-compatible storage implementation with versioning and object protection.
 
-    This class provides concrete implementation of RemoteStorage for MinIO and AWS S3,
-    with automatic versioning, object locking, and retention policies for benchmark
-    result reproducibility.
+    Provides a concrete implementation of RemoteStorage for MinIO and AWS S3,
+    with automatic versioning, object locking, and retention policies for
+    benchmark result reproducibility.
 
-    ## S3 Object Lock and Versioning Implementation
-
-    MinIOStorage automatically enables S3 Object Lock on buckets during creation:
-    - **Bucket Creation**: `object_lock=True` enables versioning and object lock
-    - **Version Tagging**: Objects are tagged with benchmark versions during `create_new_version()`
-    - **Governance Retention**: Tagged objects receive automatic retention policies
-    - **WORM Protection**: Objects become immutable once versioned
-
-    ## Version Creation Workflow
-
-    When `create_new_version()` is called:
-    1. **Object Discovery**: Scans tracked directories (`out/`, `config/`, `versions/`, `software/`)
-    2. **Version Tagging**: Tags current object versions with benchmark version
-    3. **Retention Policy**: Applies S3 Object Lock Governance Mode protection
-    4. **Manifest Creation**: Stores version manifest at `versions/{version}.csv`
-    5. **Git Integration**: Commits version changes to Git repository if available
-
-    ## Object Protection Details
-
-    Protected objects exhibit the following behaviors:
-    - **Immutability**: Cannot be overwritten or deleted without bypass permissions
-    - **Version Preservation**: All historical versions remain accessible
-    - **Error Messages**: Deletion attempts return "Object is WORM protected" errors
-    - **Bypass Required**: Only `BypassGovernanceRetention=True` can override protection
-
-    ## Cleanup Considerations for Tests
-
-    Test environments require special cleanup procedures:
-    ```python
-    # This will fail for versioned objects
-    s3_client.delete_object(Bucket=bucket, Key=key)
-
-    # Required approach for cleanup
-    versions = s3_client.list_object_versions(Bucket=bucket)
-    for version in versions.get('Versions', []):
-        s3_client.delete_object(
-            Bucket=bucket,
-            Key=version['Key'],
-            VersionId=version['VersionId'],
-            BypassGovernanceRetention=True
-        )
-    ```
-
-    ## MinIO vs AWS S3 Differences
-
-    - **MinIO**: Object lock cannot be disabled once enabled (`only 'Enabled' value is allowed`)
-    - **AWS S3**: Supports more granular object lock configuration changes
-    - **Both**: Support governance retention bypass with appropriate permissions
-    - **Both**: Maintain version history and support object tagging
-
-    ## Security and Access Control
-
-    Generated IAM policies automatically exclude dangerous permissions:
-    - ❌ `s3:BypassGovernanceRetention` - Reserved for administrative operations
-    - ❌ `s3:DeleteObjectVersion` - Prevents version history tampering
-    - ❌ `s3:DeleteBucket` - Prevents accidental benchmark deletion
-    - ✅ Standard read/write operations on current object versions
+    Uses boto3 exclusively for all S3 operations, which works with both
+    AWS S3 and S3-compatible services like MinIO (same wire protocol).
 
     Args:
-        auth_options (Dict): Authentication configuration with 'endpoint', 'access_key', 'secret_key'
-        benchmark (str): Benchmark name/identifier used as S3 bucket name
-        storage_options (StorageOptions): Configuration for tracked directories and file patterns
+        auth_options (Dict): Authentication configuration with 'endpoint',
+            and optionally 'access_key', 'secret_key', 'secure'.
+        benchmark (str): Benchmark name/identifier used as S3 bucket name.
+        storage_options (StorageOptions): Configuration for tracked directories.
 
     Raises:
-        MinIOStorageConnectionException: When connection to MinIO/S3 fails
-        MinIOStorageBucketManipulationException: When bucket operations fail
-        RemoteStorageInvalidInputException: When version operations fail due to validation errors
-
-    Example:
-        >>> storage = MinIOStorage(
-        ...     auth_options={'endpoint': 'https://s3.amazonaws.com', 'access_key': 'key', 'secret_key': 'secret'},
-        ...     benchmark='my-benchmark',
-        ...     storage_options=StorageOptions(out_dir='out')
-        ... )
-        >>> storage.set_version('1.0')
-        >>> storage.create_new_version()  # Creates WORM-protected version 1.0
-        >>> storage.versions  # ['1.0']
+        MinIOStorageConnectionException: When connection to S3 fails.
+        MinIOStorageBucketManipulationException: When bucket operations fail.
+        RemoteStorageInvalidInputException: When version operations fail.
     """
 
     def __init__(
@@ -180,7 +77,7 @@ class S3CompatibleStorage(RemoteStorage):
             self.roclient = self.connect(readonly=True)
             self._test_connect()
 
-            if not self.client.bucket_exists(benchmark):
+            if not self._bucket_exists(benchmark):
                 logger.warning(
                     f"Benchmark {benchmark} does not exist, creating new benchmark."
                 )
@@ -191,94 +88,122 @@ class S3CompatibleStorage(RemoteStorage):
             self.roclient = self.connect(readonly=True)
             self._get_versions()
 
-    def connect(self, readonly=False) -> "minio.Minio":
+    # ------------------------------------------------------------------
+    # Connection helpers
+    # ------------------------------------------------------------------
+
+    def _endpoint_url(self) -> str:
+        """Return the endpoint as a full URL (with scheme)."""
+        endpoint = self.auth_options.get("endpoint", "")
+        if endpoint.startswith(("http://", "https://")):
+            return endpoint
+        secure = self.auth_options.get("secure", True)
+        scheme = "https" if secure else "http"
+        return f"{scheme}://{endpoint}"
+
+    @property
+    def _is_aws(self) -> bool:
+        """True when the endpoint is AWS S3 (no custom endpoint_url needed)."""
+        return "amazonaws.com" in self.auth_options.get("endpoint", "")
+
+    def connect(self, readonly: bool = False):
         """
-        Connects to the MinIO storage.
+        Connects to the S3-compatible storage using boto3.
+
+        Args:
+            readonly: When True, connect anonymously (no credentials).
 
         Returns:
-        - A MinIO client object.
+            A boto3 S3 client.
         """
-        if readonly:
-            assert "endpoint" in self.auth_options.keys()
-            tmp_auth_options = self.auth_options.copy()
-            if "access_key" in tmp_auth_options.keys():
-                del tmp_auth_options["access_key"]
-            if "secret_key" in tmp_auth_options.keys():
-                del tmp_auth_options["secret_key"]
+        assert "endpoint" in self.auth_options
+
+        kwargs: dict = {}
+        if not self._is_aws:
+            kwargs["endpoint_url"] = self._endpoint_url()
+            kwargs["region_name"] = "us-east-1"
+
+        if readonly or "access_key" not in self.auth_options:
+            kwargs["config"] = Config(signature_version=UNSIGNED)
         else:
             assert (
-                "endpoint" in self.auth_options.keys()
-                and "access_key" in self.auth_options.keys()
-                and "secret_key" in self.auth_options.keys()
+                "access_key" in self.auth_options and "secret_key" in self.auth_options
             )
-            tmp_auth_options = self.auth_options.copy()
-        try:
-            return minio.Minio(
-                endpoint=tmp_auth_options["endpoint"],
-                **{k: v for k, v in tmp_auth_options.items() if k != "endpoint"},
-            )
-        except NameError:
-            import click
-            import sys
+            kwargs["aws_access_key_id"] = self.auth_options["access_key"]
+            kwargs["aws_secret_access_key"] = self.auth_options["secret_key"]
 
-            logger.error(
-                click.style("[ERROR]", fg="red", bold=True)
-                + " S3/MinIO storage libraries not installed. Install with: pip install omnibenchmark[s3]"
-            )
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.exception("Full traceback:")
-            sys.exit(1)
-        except Exception:
-            url = urlparse(tmp_auth_options["endpoint"])
-            tmp_auth_options["endpoint"] = url.netloc
-            return minio.Minio(
-                endpoint=tmp_auth_options["endpoint"],
-                **{k: v for k, v in tmp_auth_options.items() if k != "endpoint"},
-            )
+        return boto3.client("s3", **kwargs)
+
+    def _bucket_exists(self, bucket_name: str) -> bool:
+        """Return True if the bucket exists and is accessible."""
+        try:
+            self.client.head_bucket(Bucket=bucket_name)
+            return True
+        except ClientError:
+            return False
+
+    # ------------------------------------------------------------------
+    # Abstract method implementations
+    # ------------------------------------------------------------------
 
     def _test_connect(self) -> None:
         try:
-            _ = self.client.list_objects(self.benchmark)
-        except MinIOStorageConnectionException as e:
-            raise e
+            self.client.list_objects_v2(Bucket=self.benchmark, MaxKeys=1)
+        except ClientError as e:
+            raise MinIOStorageConnectionException(str(e)) from e
 
     def _create_benchmark(self, benchmark: str) -> None:
-        if self.client.bucket_exists(benchmark):
+        if self._bucket_exists(benchmark):
             raise MinIOStorageBucketManipulationException(
                 f"Benchmark {benchmark} already exists."
             )
-        # create new version
-        self.client.make_bucket(bucket_name=benchmark, object_lock=True)
-        if self.client._base_url.is_aws_host:
-            s3 = boto3.client(
-                "s3",
-                aws_access_key_id=self.auth_options["access_key"],
-                aws_secret_access_key=self.auth_options["secret_key"],
-            )
-            s3.delete_public_access_block(Bucket=benchmark)
-        set_bucket_public_readonly(self.client, benchmark)
-        set_bucket_lifecycle_config(self.client, benchmark, noncurrent_days=1)
-        if not self.client.bucket_exists(benchmark):
+
+        self.client.create_bucket(
+            Bucket=benchmark,
+            ObjectLockEnabledForBucket=True,
+        )
+
+        if self._is_aws:
+            self.client.delete_public_access_block(Bucket=benchmark)
+
+        policy = bucket_readonly_policy(benchmark)
+        self.client.put_bucket_policy(Bucket=benchmark, Policy=json.dumps(policy))
+
+        self.client.put_bucket_lifecycle_configuration(
+            Bucket=benchmark,
+            LifecycleConfiguration={
+                "Rules": [
+                    {
+                        "ID": "rule1",
+                        "Filter": {"Prefix": ""},
+                        "Status": "Enabled",
+                        "NoncurrentVersionExpiration": {"NoncurrentDays": 1},
+                    }
+                ]
+            },
+        )
+
+        if not self._bucket_exists(benchmark):
             raise MinIOStorageBucketManipulationException(
                 f"Bucket creation for benchmark {benchmark} failed"
             )
 
     def _get_versions(self) -> None:
         try:
-            versionobjects = list(
-                self.roclient.list_objects(
-                    self.benchmark, prefix="versions", recursive=True
-                )
-            )
-        except Exception as e:
-            code = getattr(e, "code", None)
-            if code == "AccessDenied":
+            paginator = self.roclient.get_paginator("list_objects_v2")
+            pages = paginator.paginate(Bucket=self.benchmark, Prefix="versions/")
+            versionobjects = []
+            for page in pages:
+                versionobjects.extend(page.get("Contents", []))
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code in ("AccessDenied", "403"):
                 logger.debug("S3 access denied", exc_info=True)
                 raise MinIOStorageConnectionException(
                     f"Access denied to S3 bucket '{self.benchmark}'."
                     " Check your credentials have the correct permissions."
                 ) from e
-            if code == "NoSuchBucket":
+            if code in ("NoSuchBucket", "404"):
                 logger.debug("S3 bucket not found", exc_info=True)
                 raise MinIOStorageConnectionException(
                     f"S3 bucket '{self.benchmark}' does not exist."
@@ -286,13 +211,11 @@ class S3CompatibleStorage(RemoteStorage):
             raise
 
         allversions = [
-            os.path.basename(v.object_name).replace(".csv", "")
-            for v in versionobjects
-            if v.object_name is not None
+            os.path.basename(v["Key"]).replace(".csv", "") for v in versionobjects
         ]
-        versions = list()
+        versions = []
         for version in allversions:
-            if re.match("(\\d+).(\\d+)", version):
+            if re.match(r"(\d+)\.(\d+)", version):
                 versions.append(Version(version))
         self.versions = versions
 
@@ -316,6 +239,147 @@ class S3CompatibleStorage(RemoteStorage):
         self._get_versions()
         if self.version not in self.versions:
             raise MinIOStorageBucketManipulationException("Version creation failed")
+
+    def load_objects(self) -> None:
+        if self.version is None:
+            raise RemoteStorageInvalidInputException(
+                "No version provided, set version first with method 'set_version'"
+            )
+
+        if self.version in self.versions:
+            response = self.roclient.get_object(
+                Bucket=self.benchmark, Key=f"versions/{self.version}.csv"
+            )
+            body = response["Body"].read().decode("utf-8")
+            objls = [line for line in body.split("\n") if line]
+            objdict: dict = {}
+            header = objls[0].split(",")
+            assert header[0] == "name"
+            for obj in objls[1:]:
+                tmpsplit = obj.split(",")
+                objdict[tmpsplit[0]] = {}
+                for i, head in enumerate(header[1:]):
+                    objdict[tmpsplit[0]][head] = tmpsplit[i + 1]
+
+            objdict[f"versions/{self.version}.csv"] = {
+                "version_id": response.get("VersionId"),
+                "last_modified": response["LastModified"],
+                "size": str(response["ContentLength"]),
+                "etag": response["ETag"].strip('"'),
+            }
+        else:
+            objdic = get_s3_object_versions_and_tags(
+                self.roclient, self.benchmark, readonly=True
+            )
+
+            object_names_to_tag, versionid_of_objects_to_tag = get_objects_to_tag(
+                objdic, storage_options=self.storage_options
+            )
+            objdict = {}
+            for obj, vt in zip(object_names_to_tag, versionid_of_objects_to_tag):
+                objdict[obj] = {}
+                objdict[obj]["version_id"] = vt
+                objdict[obj]["etag"] = objdic[obj][vt]["etag"]
+                objdict[obj]["size"] = objdic[obj][vt]["size"]
+                objdict[obj]["last_modified"] = objdic[obj][vt]["last_modified"]
+
+        self.files = objdict
+
+    def download_object(self, object_name: str, local_path: str) -> None:
+        if self.version is None:
+            raise RemoteStorageInvalidInputException(
+                "No version provided. Set version first with method 'set_version'"
+            )
+        if self.files is None:
+            self.load_objects()
+        if self.files is None:
+            raise RemoteStorageInvalidInputException("No objects found")
+        if object_name not in self.files.keys():
+            raise RemoteStorageInvalidInputException(f"Object {object_name} not found")
+
+        version_id = self.files[object_name].get("version_id")
+        extra_args = {"VersionId": version_id} if version_id else {}
+
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        self.roclient.download_file(
+            Bucket=self.benchmark,
+            Key=object_name,
+            Filename=local_path,
+            ExtraArgs=extra_args or None,
+        )
+
+    def archive_version(
+        self,
+        benchmark: BenchmarkExecution,
+        outdir: Path = Path(),
+        config: bool = True,
+        code: bool = False,
+        software: bool = False,
+        results: bool = False,
+    ):
+        from omnibenchmark.remote.archive import archive_version
+
+        # TODO: outdir is in benchmarkExecution
+        # TODO: upload the zip archive
+        _ = archive_version(benchmark, outdir, config, code, software, results)
+
+    def upload_version(self, *args, **kwargs):
+        raise NotImplementedError("upload_version is not yet implemented")
+
+    def delete_version(self, version: str) -> None:
+        """Delete a benchmark version and its WORM-protected S3 object versions.
+
+        Uses BypassGovernanceRetention=True to remove objects protected by
+        Governance Mode retention. Requires the s3:BypassGovernanceRetention
+        permission on the bucket.
+
+        Note: if the same S3 object version is referenced by multiple benchmark
+        versions (i.e. the object was not re-uploaded between versions), deleting
+        one benchmark version will also remove that object version from other
+        benchmark versions that share it.
+        """
+        if "access_key" not in self.auth_options:
+            raise RemoteStorageInvalidInputException(
+                "Read-only mode, cannot delete version,"
+                " set access_key and secret_key in auth_options"
+            )
+
+        self._get_versions()
+        target = Version(version)
+        if target not in self.versions:
+            raise RemoteStorageInvalidInputException(
+                f"Version {version} does not exist"
+            )
+
+        self.set_version(version)
+        self.load_objects()
+        objects_to_delete = dict(self.files)
+
+        failed: list = []
+        for obj_name, meta in objects_to_delete.items():
+            version_id = meta.get("version_id")
+            try:
+                delete_kwargs: dict = {
+                    "Bucket": self.benchmark,
+                    "Key": obj_name,
+                    "BypassGovernanceRetention": True,
+                }
+                if version_id:
+                    delete_kwargs["VersionId"] = version_id
+                self.client.delete_object(**delete_kwargs)
+            except Exception as e:
+                logger.warning(
+                    f"Could not delete {obj_name} (version {version_id}): {e}"
+                )
+                failed.append(obj_name)
+
+        if failed:
+            raise RemoteStorageInvalidInputException(
+                f"delete_version {version} completed with errors;"
+                f" {len(failed)} object(s) could not be deleted: {failed}"
+            )
+
+        self._get_versions()
 
     # ------------------------------------------------------------------
     # create_new_version helpers
@@ -408,19 +472,17 @@ class S3CompatibleStorage(RemoteStorage):
         with open(bmfile, "r") as fh:
             bmstr = fh.read()
         self.client.put_object(
-            self.benchmark,
-            "config/benchmark.yaml",
-            io.BytesIO(bmstr.encode()),
-            len(bmstr),
+            Bucket=self.benchmark,
+            Key="config/benchmark.yaml",
+            Body=bmstr.encode(),
         )
         for software_file in prepare_archive_software(benchmark):
             with open(software_file, "r") as fh:
                 softstr = fh.read()
             self.client.put_object(
-                self.benchmark,
-                f"software/{software_file.name}",
-                io.BytesIO(softstr.encode()),
-                len(softstr),
+                Bucket=self.benchmark,
+                Key=f"software/{software_file.name}",
+                Body=softstr.encode(),
             )
 
     def _tag_and_protect_objects(self, benchmark: Optional[BenchmarkExecution]) -> None:
@@ -434,20 +496,26 @@ class S3CompatibleStorage(RemoteStorage):
             names, vids, self.storage_options, benchmark
         )
 
-        tags = Tags.new_object_tags()
-        tags[str(self.version)] = "1"
+        tag_set = [{"Key": str(self.version), "Value": "1"}]
         tagged: list = []
         try:
             for n, v in zip(names, vids):
-                self.client.set_object_tags(self.benchmark, n, tags, version_id=v)
+                self.client.put_object_tagging(
+                    Bucket=self.benchmark,
+                    Key=n,
+                    VersionId=v,
+                    Tagging={"TagSet": tag_set},
+                )
                 tagged.append((n, v))
-            retention_config = minio.retention.Retention(
-                minio.commonconfig.GOVERNANCE,
-                datetime.datetime.now(datetime.UTC) + datetime.timedelta(weeks=1000),
+            retain_until = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
+                weeks=1000
             )
             for n, v in zip(names, vids):
-                self.client.set_object_retention(
-                    self.benchmark, n, config=retention_config, version_id=v
+                self.client.put_object_retention(
+                    Bucket=self.benchmark,
+                    Key=n,
+                    VersionId=v,
+                    Retention={"Mode": "GOVERNANCE", "RetainUntilDate": retain_until},
                 )
         except Exception:
             self._rollback_tags(tagged)
@@ -457,8 +525,10 @@ class S3CompatibleStorage(RemoteStorage):
         """Best-effort removal of version tags; called on create_new_version failure."""
         for obj_name, version_id in tagged_objects:
             try:
-                self.client.delete_object_tags(
-                    self.benchmark, obj_name, version_id=version_id
+                self.client.delete_object_tagging(
+                    Bucket=self.benchmark,
+                    Key=obj_name,
+                    VersionId=version_id,
                 )
             except Exception:
                 pass
@@ -470,180 +540,24 @@ class S3CompatibleStorage(RemoteStorage):
         vv_str = prepare_csv_remoteversion_from_bmversion(vv_ls)
         version_filename = f"versions/{self.version}.csv"
         self.client.put_object(
-            self.benchmark, version_filename, io.BytesIO(vv_str.encode()), len(vv_str)
+            Bucket=self.benchmark,
+            Key=version_filename,
+            Body=vv_str.encode(),
         )
-        tags = Tags.new_object_tags()
-        tags[str(self.version)] = "1"
-        retention_config = minio.retention.Retention(
-            minio.commonconfig.GOVERNANCE,
-            datetime.datetime.now(datetime.UTC) + datetime.timedelta(weeks=1000),
+        tag_set = [{"Key": str(self.version), "Value": "1"}]
+        retain_until = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
+            weeks=1000
         )
-        self.client.set_object_tags(self.benchmark, version_filename, tags)
-        self.client.set_object_retention(
-            self.benchmark, version_filename, config=retention_config
+        self.client.put_object_tagging(
+            Bucket=self.benchmark,
+            Key=version_filename,
+            Tagging={"TagSet": tag_set},
         )
-
-    def load_objects(self) -> None:
-        if self.version is None:
-            raise RemoteStorageInvalidInputException(
-                "No version provided, set version first with method 'set_version'"
-            )
-
-        if self.version in self.versions:
-            # read overview file
-            response = self.roclient.get_object(
-                self.benchmark, f"versions/{self.version}.csv"
-            )
-            objls = response.data.decode("utf-8")
-            objls = objls.split("\n")
-            objls = [obj for obj in objls if obj]
-            objdict = {}
-            header = objls[0].split(",")
-            assert header[0] == "name"
-            for obj in objls[1:]:
-                tmpsplit = obj.split(",")
-                objdict[tmpsplit[0]] = {}
-                for i, head in enumerate(header[1:]):
-                    objdict[tmpsplit[0]][head] = tmpsplit[i + 1]
-
-            # add overview file to files
-            response_headers = response.headers
-            objdict[f"versions/{self.version}.csv"] = {
-                "version_id": response_headers.get("x-amz-version-id"),
-                # some parsing of date to get to consistent format
-                "last_modified": datetime.datetime.strptime(
-                    response_headers.get("last-modified") or "",
-                    "%a, %d %b %Y %H:%M:%S GMT",
-                ).strftime("%Y-%m-%d %H:%M:%S.%f+00:00"),
-                "size": response_headers.get("content-length"),
-                "etag": (response_headers.get("etag") or "").replace('"', ""),
-            }
-        else:
-            # get all objects
-            objdic = get_s3_object_versions_and_tags(
-                self.roclient, self.benchmark, readonly=True
-            )
-
-            # get objects to tag
-            object_names_to_tag, versionid_of_objects_to_tag = get_objects_to_tag(
-                objdic, storage_options=self.storage_options
-            )
-            objdict = {}
-            for obj, vt in zip(object_names_to_tag, versionid_of_objects_to_tag):
-                objdict[obj] = {}
-                objdict[obj]["version_id"] = vt
-                objdict[obj]["etag"] = objdic[obj][vt]["etag"]
-                objdict[obj]["size"] = objdic[obj][vt]["size"]
-                objdict[obj]["last_modified"] = objdic[obj][vt]["last_modified"]
-
-        self.files = objdict
-
-    def download_object(self, object_name: str, local_path: str) -> None:
-        if self.version is None:
-            raise RemoteStorageInvalidInputException(
-                "No version provided. Set version first with method 'set_version'"
-            )
-        if self.files is None:
-            self.load_objects()
-        if self.files is None:
-            raise RemoteStorageInvalidInputException("No objects found")
-        if object_name not in self.files.keys():
-            raise RemoteStorageInvalidInputException(f"Object {object_name} not found")
-        _ = self.roclient.fget_object(
-            self.benchmark,
-            object_name,
-            local_path,
-            version_id=self.files[object_name]["version_id"],
+        self.client.put_object_retention(
+            Bucket=self.benchmark,
+            Key=version_filename,
+            Retention={"Mode": "GOVERNANCE", "RetainUntilDate": retain_until},
         )
-
-    def archive_version(
-        self,
-        benchmark: BenchmarkExecution,
-        outdir: Path = Path(),
-        config: bool = True,
-        code: bool = False,
-        software: bool = False,
-        results: bool = False,
-    ):
-        from omnibenchmark.remote.archive import archive_version
-
-        # TODO: outdir is in benchmarkExecution
-        # TODO: upload the zip archive
-        _ = archive_version(benchmark, outdir, config, code, software, results)
-
-    def upload_version(self, *args, **kwargs):
-        raise NotImplementedError("upload_version is not yet implemented")
-
-    def delete_version(self, version: str) -> None:
-        """Delete a benchmark version and its WORM-protected S3 object versions.
-
-        Uses boto3 with BypassGovernanceRetention=True to remove objects that
-        are protected by Governance Mode retention. Requires the caller's
-        credentials to have the s3:BypassGovernanceRetention permission.
-
-        The version manifest file (versions/{version}.csv) is deleted last so
-        that the version remains discoverable if a partial failure occurs.
-        """
-        if "access_key" not in self.auth_options:
-            raise RemoteStorageInvalidInputException(
-                "Read-only mode, cannot delete version,"
-                " set access_key and secret_key in auth_options"
-            )
-
-        self._get_versions()
-        target = Version(version)
-        if target not in self.versions:
-            raise RemoteStorageInvalidInputException(
-                f"Version {version} does not exist"
-            )
-
-        # Load the version manifest to find the exact S3 object versions to delete.
-        self.set_version(version)
-        self.load_objects()
-        objects_to_delete = dict(self.files)
-
-        s3 = self._boto3_client()
-
-        failed: list = []
-        for obj_name, meta in objects_to_delete.items():
-            version_id = meta.get("version_id")
-            try:
-                kwargs: dict = {
-                    "Bucket": self.benchmark,
-                    "Key": obj_name,
-                    "BypassGovernanceRetention": True,
-                }
-                if version_id:
-                    kwargs["VersionId"] = version_id
-                s3.delete_object(**kwargs)
-            except Exception as e:
-                logger.warning(
-                    f"Could not delete {obj_name} (version {version_id}): {e}"
-                )
-                failed.append(obj_name)
-
-        if failed:
-            raise RemoteStorageInvalidInputException(
-                f"delete_version {version} completed with errors;"
-                f" {len(failed)} object(s) could not be deleted: {failed}"
-            )
-
-        self._get_versions()
-
-    def _boto3_client(self):
-        """Return a boto3 S3 client built from current auth_options."""
-        endpoint = self.auth_options.get("endpoint", "")
-        secure = self.auth_options.get("secure", True)
-        kwargs: dict = {
-            "aws_access_key_id": self.auth_options["access_key"],
-            "aws_secret_access_key": self.auth_options["secret_key"],
-        }
-        if not self.client._base_url.is_aws_host:
-            if not endpoint.startswith(("http://", "https://")):
-                scheme = "https" if secure else "http"
-                endpoint = f"{scheme}://{endpoint}"
-            kwargs["endpoint_url"] = endpoint
-        return boto3.client("s3", **kwargs)
 
 
 RemoteStorage.register(S3CompatibleStorage)

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -15,10 +15,8 @@ from typing import Dict, Optional
 
 try:
     import boto3
-    from boto3 import client as boto3_s3_client
 except ImportError:
     boto3 = None  # type: ignore
-    boto3_s3_client = None  # type: ignore
 
 from omnibenchmark.benchmark import BenchmarkExecution
 from omnibenchmark.remote.exception import (
@@ -563,7 +561,3 @@ class S3CompatibleStorage(RemoteStorage):
 
 
 RemoteStorage.register(S3CompatibleStorage)
-
-# Backward-compatibility alias so that existing code importing MinIOStorage
-# continues to work without changes during the deprecation period.
-MinIOStorage = S3CompatibleStorage

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -271,32 +271,19 @@ class S3CompatibleStorage(RemoteStorage):
                 )
             )
         except Exception as e:
-            # Catch S3 errors to provide clearer error messages
-            import click
-            import sys
-
-            # Check if debug mode is enabled (logger level is DEBUG)
-            debug_mode = logger.isEnabledFor(logging.DEBUG)
-
-            if hasattr(e, "code") and getattr(e, "code") == "AccessDenied":
-                logger.error(
-                    click.style("[ERROR]", fg="red", bold=True)
-                    + f" Access denied to S3 bucket '{self.benchmark}'. Check your credentials have the correct permissions."
-                )
-                if debug_mode:
-                    logger.exception("Full traceback:")
-                sys.exit(1)
-            elif hasattr(e, "code") and getattr(e, "code") == "NoSuchBucket":
-                logger.error(
-                    click.style("[ERROR]", fg="red", bold=True)
-                    + f" S3 bucket '{self.benchmark}' does not exist."
-                )
-                if debug_mode:
-                    logger.exception("Full traceback:")
-                sys.exit(1)
-            else:
-                # Re-raise other exceptions
-                raise
+            code = getattr(e, "code", None)
+            if code == "AccessDenied":
+                logger.debug("S3 access denied", exc_info=True)
+                raise MinIOStorageConnectionException(
+                    f"Access denied to S3 bucket '{self.benchmark}'."
+                    " Check your credentials have the correct permissions."
+                ) from e
+            if code == "NoSuchBucket":
+                logger.debug("S3 bucket not found", exc_info=True)
+                raise MinIOStorageConnectionException(
+                    f"S3 bucket '{self.benchmark}' does not exist."
+                ) from e
+            raise
 
         allversions = [
             os.path.basename(v.object_name).replace(".csv", "")

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -299,190 +299,189 @@ class S3CompatibleStorage(RemoteStorage):
     def create_new_version(
         self, benchmark: Optional[BenchmarkExecution] = None
     ) -> None:
+        self._validate_for_write()
+        self._get_versions()
+
+        version_manager = self._build_version_manager(benchmark)
+        try:
+            self._persist_version(version_manager, benchmark)
+            if benchmark is not None:
+                self._upload_benchmark_config(benchmark)
+            self._tag_and_protect_objects(benchmark)
+        except Exception as e:
+            logger.error(f"Error creating version {self.version}, rolling back: {e}")
+            raise RemoteStorageInvalidInputException(f"Failed to create version: {e}")
+
+        self._write_version_manifest()
+        self._get_versions()
+        if self.version not in self.versions:
+            raise MinIOStorageBucketManipulationException("Version creation failed")
+
+    # ------------------------------------------------------------------
+    # create_new_version helpers
+    # ------------------------------------------------------------------
+
+    def _validate_for_write(self) -> None:
         if self.version is None:
             raise RemoteStorageInvalidInputException(
                 "No version provided, set version first with method 'set_version'"
             )
-
-        if "access_key" not in self.auth_options.keys():
+        if "access_key" not in self.auth_options:
             raise RemoteStorageInvalidInputException(
-                "Read-only mode, cannot create new version, set access_key and secret_key in auth_options"
+                "Read-only mode, cannot create new version,"
+                " set access_key and secret_key in auth_options"
             )
 
-        # Refresh versions from storage
-        self._get_versions()
-
-        # Build a version manager local to this call (no persistent instance state).
+    def _build_version_manager(self, benchmark: Optional[BenchmarkExecution]):
+        """Return a version manager scoped to this call (not stored on self)."""
         from omnibenchmark.config import get_temp_dir
 
         temp_dir = get_temp_dir()
+        known = [str(v) for v in self.versions]
 
         if benchmark is not None:
-            # Try git-aware version manager first, fall back to basic if git not available
             try:
-                version_manager = GitAwareBenchmarkVersionManager(
+                vm = GitAwareBenchmarkVersionManager(
                     benchmark_path=benchmark.get_definition_file(),
                     git_repo_path=benchmark.context.directory,
                     lock_dir=temp_dir / "locks",
                     lock_timeout=30.0,
                 )
-                version_manager.set_known_versions([str(v) for v in self.versions])
+                vm.set_known_versions(known)
+                return vm
             except Exception:
-                # Fall back to basic version manager if git not available
+                pass  # fall through to basic version manager
+
+            from omnibenchmark.versioning import BenchmarkVersionManager
+
+            vm = BenchmarkVersionManager(
+                benchmark_path=benchmark.get_definition_file(),
+                lock_dir=temp_dir / "locks",
+                lock_timeout=30.0,
+            )
+        else:
+            from omnibenchmark.versioning import BenchmarkVersionManager
+
+            vm = BenchmarkVersionManager(
+                benchmark_path=temp_dir / f"{self.benchmark}.yaml",
+                lock_dir=temp_dir / "locks",
+                lock_timeout=30.0,
+            )
+
+        vm.set_known_versions(known)
+        return vm
+
+    def _persist_version(
+        self, version_manager, benchmark: Optional[BenchmarkExecution]
+    ) -> None:
+        """Record the new version via the version manager (git-aware or basic)."""
+        if benchmark is not None and hasattr(
+            version_manager, "create_version_with_persistence"
+        ):
+            try:
+                version_manager.create_version_with_persistence(  # type: ignore
+                    benchmark,
+                    str(self.version),
+                    f"Create benchmark version {self.version}",
+                )
+                return
+            except Exception:
+                # git-based persistence failed; fall back to in-memory tracking
+                from omnibenchmark.config import get_temp_dir
                 from omnibenchmark.versioning import BenchmarkVersionManager
 
+                temp_dir = get_temp_dir()
                 version_manager = BenchmarkVersionManager(
                     benchmark_path=benchmark.get_definition_file(),
                     lock_dir=temp_dir / "locks",
                     lock_timeout=30.0,
                 )
                 version_manager.set_known_versions([str(v) for v in self.versions])
-        else:
-            # Use basic version manager for validation only (testing scenarios)
-            from omnibenchmark.versioning import BenchmarkVersionManager
 
-            version_manager = BenchmarkVersionManager(
-                benchmark_path=temp_dir / f"{self.benchmark}.yaml",
-                lock_dir=temp_dir / "locks",
-                lock_timeout=30.0,
+        version_manager.set_known_versions(
+            version_manager.get_versions() + [str(self.version)]
+        )
+
+    def _upload_benchmark_config(self, benchmark: BenchmarkExecution) -> None:
+        """Upload the benchmark YAML and its software environment files."""
+        bmfile = Path(benchmark.get_definition_file())
+        with open(bmfile, "r") as fh:
+            bmstr = fh.read()
+        self.client.put_object(
+            self.benchmark,
+            "config/benchmark.yaml",
+            io.BytesIO(bmstr.encode()),
+            len(bmstr),
+        )
+        for software_file in prepare_archive_software(benchmark):
+            with open(software_file, "r") as fh:
+                softstr = fh.read()
+            self.client.put_object(
+                self.benchmark,
+                f"software/{software_file.name}",
+                io.BytesIO(softstr.encode()),
+                len(softstr),
             )
-            version_manager.set_known_versions([str(v) for v in self.versions])
 
-        # Track uploaded objects for rollback on failure
-        uploaded_objects = []
-        tagged_objects = []
+    def _tag_and_protect_objects(self, benchmark: Optional[BenchmarkExecution]) -> None:
+        """Tag current objects with the benchmark version and apply WORM retention.
 
+        Rolls back any tags it applied on failure before re-raising.
+        """
+        objdic = get_s3_object_versions_and_tags(self.client, self.benchmark)
+        names, vids = get_objects_to_tag(objdic, storage_options=self.storage_options)
+        names, vids = filter_objects_to_tag(
+            names, vids, self.storage_options, benchmark
+        )
+
+        tags = Tags.new_object_tags()
+        tags[str(self.version)] = "1"
+        tagged: list = []
         try:
-            # First: Create version with persistence (VersionManager updates YAML and commits to git)
-            if benchmark is not None and hasattr(
-                version_manager, "create_version_with_persistence"
-            ):
-                try:
-                    _created_version = version_manager.create_version_with_persistence(  # type: ignore
-                        benchmark,
-                        str(self.version),
-                        f"Create benchmark version {self.version}",
-                    )
-                except Exception:
-                    # If git-based version creation fails, fall back to basic version manager
-                    from omnibenchmark.versioning import BenchmarkVersionManager
-
-                    version_manager = BenchmarkVersionManager(
-                        benchmark_path=benchmark.get_definition_file(),
-                        lock_dir=temp_dir / "locks",
-                        lock_timeout=30.0,
-                    )
-                    version_manager.set_known_versions([str(v) for v in self.versions])
-                    version_manager.set_known_versions(
-                        version_manager.get_versions() + [str(self.version)]
-                    )
-            else:
-                # Basic version tracking for testing scenarios
-                version_manager.set_known_versions(
-                    version_manager.get_versions() + [str(self.version)]
-                )
-
-            # Then: upload the UPDATED benchmark definition file and software files
-            if benchmark is not None:
-                bmfile = Path(benchmark.get_definition_file())
-                with open(bmfile, "r") as fh:
-                    bmstr = fh.read()
-
-                # upload updated file (now contains the new version)
-                _ = self.client.put_object(
-                    self.benchmark,
-                    "config/benchmark.yaml",
-                    io.BytesIO(bmstr.encode()),
-                    len(bmstr),
-                )
-                uploaded_objects.append("config/benchmark.yaml")
-
-                # read software files
-                software_files = prepare_archive_software(benchmark)
-
-                # upload software files
-                for software_file in software_files:
-                    with open(software_file, "r") as fh:
-                        softstr = fh.read()
-
-                    obj_name = f"software/{software_file.name}"
-                    _ = self.client.put_object(
-                        self.benchmark,
-                        obj_name,
-                        io.BytesIO(softstr.encode()),
-                        len(softstr),
-                    )
-                    uploaded_objects.append(obj_name)
-
-            # get all objects
-            objdic = get_s3_object_versions_and_tags(self.client, self.benchmark)
-
-            # get objects to tag
-            object_names_to_tag, versionid_of_objects_to_tag = get_objects_to_tag(
-                objdic, storage_options=self.storage_options
-            )
-
-            # filter objects based on workflow
-            object_names_to_tag, versionid_of_objects_to_tag = filter_objects_to_tag(
-                object_names_to_tag,
-                versionid_of_objects_to_tag,
-                self.storage_options,
-                benchmark,
-            )
-
-            # Tag all objects with current version
-            tags = Tags.new_object_tags()
-            tags[str(self.version)] = "1"
-            for n, v in zip(object_names_to_tag, versionid_of_objects_to_tag):
+            for n, v in zip(names, vids):
                 self.client.set_object_tags(self.benchmark, n, tags, version_id=v)
-                tagged_objects.append((n, v))
-
-            # set retention policy of objects
+                tagged.append((n, v))
             retention_config = minio.retention.Retention(
                 minio.commonconfig.GOVERNANCE,
                 datetime.datetime.now(datetime.UTC) + datetime.timedelta(weeks=1000),
             )
-            for n, v in zip(object_names_to_tag, versionid_of_objects_to_tag):
+            for n, v in zip(names, vids):
                 self.client.set_object_retention(
                     self.benchmark, n, config=retention_config, version_id=v
                 )
+        except Exception:
+            self._rollback_tags(tagged)
+            raise
 
-        except Exception as e:
-            # Rollback: remove tags from tagged objects
-            logger.error(f"Error creating version {self.version}, rolling back: {e}")
-            for obj_name, version_id in tagged_objects:
-                try:
-                    # Remove the version tag we just added
-                    self.client.delete_object_tags(
-                        self.benchmark, obj_name, version_id=version_id
-                    )
-                except Exception:
-                    pass  # Best effort rollback
+    def _rollback_tags(self, tagged_objects: list) -> None:
+        """Best-effort removal of version tags; called on create_new_version failure."""
+        for obj_name, version_id in tagged_objects:
+            try:
+                self.client.delete_object_tags(
+                    self.benchmark, obj_name, version_id=version_id
+                )
+            except Exception:
+                pass
 
-            # Re-raise the original exception
-            raise RemoteStorageInvalidInputException(f"Failed to create version: {e}")
-
-        # refresh object list
+    def _write_version_manifest(self) -> None:
+        """Write versions/{version}.csv and protect it with a tag and WORM retention."""
         objdic = get_s3_object_versions_and_tags(self.client, self.benchmark)
-
-        # write versions/{{version}}.csv
         vv_ls = get_remoteversion_from_bmversion(objdic, str(self.version))
         vv_str = prepare_csv_remoteversion_from_bmversion(vv_ls)
         version_filename = f"versions/{self.version}.csv"
-        _ = self.client.put_object(
+        self.client.put_object(
             self.benchmark, version_filename, io.BytesIO(vv_str.encode()), len(vv_str)
         )
-
-        # tag and set retention policy of version file
+        tags = Tags.new_object_tags()
+        tags[str(self.version)] = "1"
+        retention_config = minio.retention.Retention(
+            minio.commonconfig.GOVERNANCE,
+            datetime.datetime.now(datetime.UTC) + datetime.timedelta(weeks=1000),
+        )
         self.client.set_object_tags(self.benchmark, version_filename, tags)
         self.client.set_object_retention(
             self.benchmark, version_filename, config=retention_config
         )
-
-        # check if version exists
-        self._get_versions()
-        if self.version not in self.versions:
-            raise MinIOStorageBucketManipulationException("Version creation failed")
 
     def load_objects(self) -> None:
         if self.version is None:

--- a/omnibenchmark/remote/S3Storage.py
+++ b/omnibenchmark/remote/S3Storage.py
@@ -574,8 +574,76 @@ class S3CompatibleStorage(RemoteStorage):
     def upload_version(self, *args, **kwargs):
         raise NotImplementedError("upload_version is not yet implemented")
 
-    def delete_version(self, version):
-        raise NotImplementedError
+    def delete_version(self, version: str) -> None:
+        """Delete a benchmark version and its WORM-protected S3 object versions.
+
+        Uses boto3 with BypassGovernanceRetention=True to remove objects that
+        are protected by Governance Mode retention. Requires the caller's
+        credentials to have the s3:BypassGovernanceRetention permission.
+
+        The version manifest file (versions/{version}.csv) is deleted last so
+        that the version remains discoverable if a partial failure occurs.
+        """
+        if "access_key" not in self.auth_options:
+            raise RemoteStorageInvalidInputException(
+                "Read-only mode, cannot delete version,"
+                " set access_key and secret_key in auth_options"
+            )
+
+        self._get_versions()
+        target = Version(version)
+        if target not in self.versions:
+            raise RemoteStorageInvalidInputException(
+                f"Version {version} does not exist"
+            )
+
+        # Load the version manifest to find the exact S3 object versions to delete.
+        self.set_version(version)
+        self.load_objects()
+        objects_to_delete = dict(self.files)
+
+        s3 = self._boto3_client()
+
+        failed: list = []
+        for obj_name, meta in objects_to_delete.items():
+            version_id = meta.get("version_id")
+            try:
+                kwargs: dict = {
+                    "Bucket": self.benchmark,
+                    "Key": obj_name,
+                    "BypassGovernanceRetention": True,
+                }
+                if version_id:
+                    kwargs["VersionId"] = version_id
+                s3.delete_object(**kwargs)
+            except Exception as e:
+                logger.warning(
+                    f"Could not delete {obj_name} (version {version_id}): {e}"
+                )
+                failed.append(obj_name)
+
+        if failed:
+            raise RemoteStorageInvalidInputException(
+                f"delete_version {version} completed with errors;"
+                f" {len(failed)} object(s) could not be deleted: {failed}"
+            )
+
+        self._get_versions()
+
+    def _boto3_client(self):
+        """Return a boto3 S3 client built from current auth_options."""
+        endpoint = self.auth_options.get("endpoint", "")
+        secure = self.auth_options.get("secure", True)
+        kwargs: dict = {
+            "aws_access_key_id": self.auth_options["access_key"],
+            "aws_secret_access_key": self.auth_options["secret_key"],
+        }
+        if not self.client._base_url.is_aws_host:
+            if not endpoint.startswith(("http://", "https://")):
+                scheme = "https" if secure else "http"
+                endpoint = f"{scheme}://{endpoint}"
+            kwargs["endpoint_url"] = endpoint
+        return boto3.client("s3", **kwargs)
 
 
 RemoteStorage.register(S3CompatibleStorage)

--- a/omnibenchmark/remote/S3config.py
+++ b/omnibenchmark/remote/S3config.py
@@ -7,18 +7,23 @@ from dotenv import load_dotenv
 
 from omnibenchmark.cli.utils.logging import logger
 
+# Sentinel so the .env filesystem walk only runs once per process.
+_dotenv_loaded: bool = False
 
-# Load .env file from the current working directory if it exists
-# This allows users to store S3 credentials in a .env file
-dotenv_path = Path.cwd() / ".env"
-if dotenv_path.exists():
-    load_dotenv(dotenv_path=dotenv_path, override=False)
-else:
-    # Try loading from the project root (in case we're running from a subdirectory)
-    # Walk up the directory tree to find .env
-    current_path = Path.cwd()
-    for parent in [current_path] + list(current_path.parents):
-        dotenv_path = parent / ".env"
+
+def _load_dotenv_once() -> None:
+    """Walk up the directory tree from cwd to find and load the first .env file.
+
+    Called lazily on the first credential lookup so that importing this module
+    has no filesystem side effects.
+    """
+    global _dotenv_loaded
+    if _dotenv_loaded:
+        return
+    _dotenv_loaded = True
+
+    for directory in [Path.cwd()] + list(Path.cwd().parents):
+        dotenv_path = directory / ".env"
         if dotenv_path.exists():
             load_dotenv(dotenv_path=dotenv_path, override=False)
             break
@@ -77,15 +82,17 @@ def bucket_readonly_policy(bucket_name):
 
 
 def S3_access_config_from_env(required: bool = True) -> dict:
-    """Get S3 access config from environment variables or file
+    """Get S3 access config from environment variables or file.
 
     Args:
-        required: If True, raise error when credentials are missing.
-                 If False, return empty dict when credentials are missing.
+        required: If True, exit with an error when credentials are missing.
+                 If False, return an empty dict when credentials are missing.
 
     Returns:
-        dict: Dictionary with access_key and secret_key, or empty dict if not required
+        dict with access_key and secret_key, or empty dict if not required.
     """
+    _load_dotenv_once()
+
     if (
         "OB_STORAGE_S3_ACCESS_KEY" in os.environ
         and "OB_STORAGE_S3_SECRET_KEY" in os.environ

--- a/omnibenchmark/remote/S3versioning.py
+++ b/omnibenchmark/remote/S3versioning.py
@@ -1,76 +1,92 @@
-# pyright: reportCallIssue=false
-# TODO: Fix boto3/minio API call type errors
-from __future__ import annotations
-from itertools import groupby
-from typing import Dict, TYPE_CHECKING
+"""S3 object versioning and tagging helpers (boto3-based)."""
 
-if TYPE_CHECKING:
-    import minio
-else:
-    try:
-        import minio
-    except ImportError:
-        minio = None
+from __future__ import annotations
+
+from typing import Dict
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    ClientError = Exception  # type: ignore
 
 from omnibenchmark.remote.exception import MinIOStorageBucketManipulationException
 from omnibenchmark.remote.RemoteStorage import is_valid_version
 
 
 def get_s3_object_versions_and_tags(
-    client: "minio.Minio", benchmark: str, readonly: bool = False
+    client, benchmark: str, readonly: bool = False
 ) -> Dict:
     """
-    Retrieve the metadata of all objects in a S3 Bucket.
+    Retrieve the metadata of all objects in an S3 bucket.
 
     Args:
-    - client: A MinIO client object.
-    - benchmark: The name of the S3 bucket.
-    - readonly: A boolean indicating whether the client is read-only. Object tags can only be retrieved if the client is not read-only.
+        client: A boto3 S3 client.
+        benchmark: The name of the S3 bucket.
+        readonly: When True, skip fetching object tags (reduces API calls).
 
     Returns:
-    - A dictionary of objects and associated metadata.
+        A nested dict keyed by object name → version_id → metadata dict with
+        keys: tags, size, last_modified, is_delete_marker, etag.
     """
-    if not client.bucket_exists(benchmark):
+    try:
+        client.head_bucket(Bucket=benchmark)
+    except ClientError:
         raise MinIOStorageBucketManipulationException(
             f"Benchmark {benchmark} does not exist."
         )
 
-    object_ls = list(
-        client.list_objects(
-            benchmark, include_version=True, include_user_meta=True, recursive=True
-        )
-    )
+    paginator = client.get_paginator("list_object_versions")
+    di: Dict = {}
 
-    # Group listed objects by their name
-    grouped_objects = groupby(object_ls, key=lambda o: o.object_name)
+    try:
+        for page in paginator.paginate(Bucket=benchmark):
+            for version in page.get("Versions", []):
+                key = version["Key"]
+                vid = version["VersionId"]
+                if key not in di:
+                    di[key] = {}
 
-    di = {}
+                tags_filt: dict = {}
+                if not readonly:
+                    try:
+                        tag_response = client.get_object_tagging(
+                            Bucket=benchmark, Key=key, VersionId=vid
+                        )
+                        tags_filt = {
+                            t["Key"]: t["Value"]
+                            for t in tag_response.get("TagSet", [])
+                            if is_valid_version(t["Key"])
+                        }
+                    except ClientError:
+                        pass
 
-    # Iterate over object groups
-    for object_name, objects in grouped_objects:
-        objects = list(objects)
-        di[object_name] = {}
+                di[key][vid] = {
+                    "tags": tags_filt,
+                    "size": version["Size"],
+                    "last_modified": version["LastModified"],
+                    "is_delete_marker": False,
+                    "etag": version["ETag"].strip('"'),
+                }
 
-        # Extract attributes for the objects group
-        version_ids = [o.version_id for o in objects]
-        sizes = [o.size for o in objects]
-        last_modified = [o.last_modified for o in objects]
-        is_delete_markers = [o.is_delete_marker for o in objects]
-        etags = [o.etag for o in objects]
+            for dm in page.get("DeleteMarkers", []):
+                key = dm["Key"]
+                vid = dm["VersionId"]
+                if key not in di:
+                    di[key] = {}
+                di[key][vid] = {
+                    "tags": {},
+                    "size": 0,
+                    "last_modified": dm["LastModified"],
+                    "is_delete_marker": True,
+                    "etag": "",
+                }
 
-        # Iterate to all versions and create a dictionary entry
-        for i, v in enumerate(version_ids):
-            tags_filt = {}
-            if not readonly and not is_delete_markers[i] and object_name is not None:
-                tags = client.get_object_tags(benchmark, object_name, version_id=v)
-                if tags is not None:
-                    tags_filt = {k: w for k, w in tags.items() if is_valid_version(k)}
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("NoSuchBucket", "404"):
+            raise MinIOStorageBucketManipulationException(
+                f"Benchmark {benchmark} does not exist."
+            )
+        raise
 
-            di[object_name][v] = {
-                "tags": tags_filt,
-                "size": sizes[i],
-                "last_modified": last_modified[i],
-                "is_delete_marker": is_delete_markers[i],
-                "etag": etags[i],
-            }
     return di

--- a/omnibenchmark/remote/S3versioning.py
+++ b/omnibenchmark/remote/S3versioning.py
@@ -7,7 +7,7 @@ from typing import Dict
 try:
     from botocore.exceptions import ClientError
 except ImportError:
-    ClientError = Exception  # type: ignore
+    ClientError = Exception  # type: ignore[assignment,misc]
 
 from omnibenchmark.remote.exception import MinIOStorageBucketManipulationException
 from omnibenchmark.remote.RemoteStorage import is_valid_version
@@ -82,7 +82,7 @@ def get_s3_object_versions_and_tags(
                 }
 
     except ClientError as e:
-        code = e.response["Error"]["Code"]
+        code = getattr(e, "response", {}).get("Error", {}).get("Code", "")
         if code in ("NoSuchBucket", "404"):
             raise MinIOStorageBucketManipulationException(
                 f"Benchmark {benchmark} does not exist."

--- a/omnibenchmark/remote/S3versioning.py
+++ b/omnibenchmark/remote/S3versioning.py
@@ -58,7 +58,8 @@ def get_s3_object_versions_and_tags(
                             if is_valid_version(t["Key"])
                         }
                     except ClientError:
-                        pass
+                        # Tag retrieval failures are non-fatal; keep tags empty and continue.
+                        tags_filt = {}
 
                 di[key][vid] = {
                     "tags": tags_filt,

--- a/omnibenchmark/remote/S3versioning.py
+++ b/omnibenchmark/remote/S3versioning.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     ClientError = Exception  # type: ignore[assignment,misc]
 
-from omnibenchmark.remote.exception import MinIOStorageBucketManipulationException
+from omnibenchmark.remote.exception import S3StorageBucketManipulationException
 from omnibenchmark.remote.RemoteStorage import is_valid_version
 
 
@@ -31,7 +31,7 @@ def get_s3_object_versions_and_tags(
     try:
         client.head_bucket(Bucket=benchmark)
     except ClientError:
-        raise MinIOStorageBucketManipulationException(
+        raise S3StorageBucketManipulationException(
             f"Benchmark {benchmark} does not exist."
         )
 
@@ -85,7 +85,7 @@ def get_s3_object_versions_and_tags(
     except ClientError as e:
         code = getattr(e, "response", {}).get("Error", {}).get("Code", "")
         if code in ("NoSuchBucket", "404"):
-            raise MinIOStorageBucketManipulationException(
+            raise S3StorageBucketManipulationException(
                 f"Benchmark {benchmark} does not exist."
             )
         raise

--- a/omnibenchmark/remote/exception.py
+++ b/omnibenchmark/remote/exception.py
@@ -18,9 +18,9 @@ class RemoteStorageInvalidInputException(RemoteStorageException):
         super().__init__(self.message)
 
 
-class MinIOStorageException(RemoteStorageException):
+class S3StorageException(RemoteStorageException):
     """
-    General Exception for MinIOStorage.
+    General Exception for S3-compatible storage.
     """
 
     def __init__(self, message):
@@ -28,7 +28,7 @@ class MinIOStorageException(RemoteStorageException):
         super().__init__(self.message)
 
 
-class MinIOStorageConnectionException(MinIOStorageException):
+class S3StorageConnectionException(S3StorageException):
     """
     Exception raised for connection issues with S3.
     """
@@ -38,7 +38,7 @@ class MinIOStorageConnectionException(MinIOStorageException):
         super().__init__(self.message)
 
 
-class MinIOStorageBucketManipulationException(MinIOStorageException):
+class S3StorageBucketManipulationException(S3StorageException):
     """
     Exception raised for errors with bucket creation and general bucket manipulations.
     """
@@ -48,7 +48,7 @@ class MinIOStorageBucketManipulationException(MinIOStorageException):
         super().__init__(self.message)
 
 
-class MinIOStorageVersioningCorruptionException(MinIOStorageException):
+class S3StorageVersioningCorruptionException(S3StorageException):
     """
     Exception raised for errors with object versioning.
     """

--- a/omnibenchmark/remote/files.py
+++ b/omnibenchmark/remote/files.py
@@ -2,6 +2,7 @@
 
 import warnings
 from pathlib import Path
+from typing import Optional
 
 import tqdm
 
@@ -13,7 +14,7 @@ from omnibenchmark.remote.versioning import get_expected_benchmark_output_files
 
 def _setup_remote_storage(
     benchmark_path: str,
-    storage_options: StorageOptions = StorageOptions(out_dir="out"),
+    storage_options: Optional[StorageOptions] = None,
 ):
     """Set up remote storage for a benchmark.
 
@@ -25,8 +26,9 @@ def _setup_remote_storage(
     """
     from .storage import get_storage, remote_storage_args
 
+    resolved_options = storage_options or StorageOptions(out_dir="out")
     benchmark = Benchmark(Path(benchmark_path))
-    expected_files = get_expected_benchmark_output_files(benchmark, storage_options)
+    expected_files = get_expected_benchmark_output_files(benchmark, resolved_options)
 
     storage_api = benchmark.get_storage_api()
     bucket_name = benchmark.get_storage_bucket_name()
@@ -39,13 +41,13 @@ def _setup_remote_storage(
         raise ValueError("No storage bucket found")
 
     auth_options = remote_storage_args(benchmark)
-    ss = get_storage(storage_api, auth_options, bucket_name, storage_options)
+    ss = get_storage(storage_api, auth_options, bucket_name, resolved_options)
     if ss is None:
         logger.error("Error: No storage found.")
         raise ValueError("No storage found")
 
     ss.set_version(benchmark.get_benchmark_version())
-    ss._get_objects()
+    ss.load_objects()
 
     return ss, benchmark, expected_files
 
@@ -57,17 +59,20 @@ def list_files(
     module: str,
     file_id: str,
     remote_storage: bool = True,
-    storage_options: StorageOptions = StorageOptions(out_dir="out"),
+    storage_options: Optional[StorageOptions] = None,
 ):
     """List all available files for a certain benchmark, version and stage"""
+    resolved_options = storage_options or StorageOptions(out_dir="out")
     if remote_storage:
-        ss, _, expected_files = _setup_remote_storage(benchmark_path, storage_options)
+        ss, _, expected_files = _setup_remote_storage(benchmark_path, resolved_options)
         files = {k: v for k, v in ss.files.items() if k in expected_files}
         objectnames = list(files.keys())
         etags = [files[objectname]["etag"] for objectname in objectnames]
     else:
         benchmark = Benchmark(Path(benchmark_path))
-        expected_files = get_expected_benchmark_output_files(benchmark, storage_options)
+        expected_files = get_expected_benchmark_output_files(
+            benchmark, resolved_options
+        )
         file_local_is_local = [Path(f).is_file() for f in expected_files]
         if not all(file_local_is_local):
             logger.warning("Not all expected files are available locally")

--- a/omnibenchmark/remote/files.py
+++ b/omnibenchmark/remote/files.py
@@ -26,8 +26,10 @@ def _setup_remote_storage(
     """
     from .service import StorageService
 
-    resolved_options = storage_options or StorageOptions(out_dir="out")
     benchmark = Benchmark(Path(benchmark_path))
+    resolved_options = storage_options or StorageOptions(
+        out_dir=str(benchmark.context.out_dir)
+    )
     expected_files = get_expected_benchmark_output_files(benchmark, resolved_options)
 
     service = StorageService(benchmark, storage_options=resolved_options)

--- a/omnibenchmark/remote/files.py
+++ b/omnibenchmark/remote/files.py
@@ -26,16 +26,13 @@ def _setup_remote_storage(
     """
     from .service import StorageService
 
-    benchmark = Benchmark(Path(benchmark_path))
-    resolved_options = storage_options or StorageOptions(
-        out_dir=str(benchmark.context.out_dir)
-    )
-    expected_files = get_expected_benchmark_output_files(benchmark, resolved_options)
-
-    service = StorageService(benchmark, storage_options=resolved_options)
+    service = StorageService.from_path(benchmark_path, storage_options=storage_options)
     service.load_version()
+    expected_files = get_expected_benchmark_output_files(
+        service._benchmark_model, service.storage.storage_options
+    )
 
-    return service.storage, benchmark, expected_files
+    return service.storage, service._benchmark_model, expected_files
 
 
 def list_files(

--- a/omnibenchmark/remote/files.py
+++ b/omnibenchmark/remote/files.py
@@ -96,7 +96,12 @@ def download_files(
     logger.debug("Checking if files are already downloaded... ")
     do_download_file = []
     for filename, etag in tqdm.tqdm(
-        zip(filenames, etags), delay=5, disable=not verbose
+        zip(filenames, etags),
+        total=len(filenames),
+        desc="Checking local files",
+        unit="file",
+        delay=1,
+        disable=not verbose,
     ):
         if Path(filename).is_file():
             if etag.replace('"', "") == checksum(filename):
@@ -121,18 +126,30 @@ def download_files(
             f"Downloading {sum(do_download_file)} files with a total size of {sizeof_fmt(size)} ... ",
         )
 
-    for objectname, filename, do_download in tqdm.tqdm(
-        zip(objectnames, filenames, do_download_file), delay=5, disable=not verbose
+    pairs_to_download = [
+        (obj, fn) for obj, fn, do in zip(objectnames, filenames, do_download_file) if do
+    ]
+    for objectname, filename in tqdm.tqdm(
+        pairs_to_download,
+        total=len(pairs_to_download),
+        desc="Downloading",
+        unit="file",
+        delay=1,
+        disable=not verbose,
     ):
-        if do_download:
-            ss.download_object(objectname, filename)
+        ss.download_object(objectname, filename)
     if verbose:
         logger.debug("Done")
 
     if verbose:
         logger.debug("Checking MD5 checksums... ")
     for etag, filename in tqdm.tqdm(
-        zip(etags, filenames), delay=5, disable=not verbose
+        zip(etags, filenames),
+        total=len(filenames),
+        desc="Verifying checksums",
+        unit="file",
+        delay=1,
+        disable=not verbose,
     ):
         md5sum_val = checksum(filename)
         if not etag.replace('"', "") == md5sum_val:
@@ -160,7 +177,12 @@ def checksum_files(
 
     failed_checksums = []
     for etag, filename in tqdm.tqdm(
-        zip(etags, filenames), delay=5, disable=not verbose
+        zip(etags, filenames),
+        total=len(filenames),
+        desc="Verifying checksums",
+        unit="file",
+        delay=1,
+        disable=not verbose,
     ):
         md5sum_val = checksum(filename)
         if not etag.replace('"', "") == md5sum_val:

--- a/omnibenchmark/remote/files.py
+++ b/omnibenchmark/remote/files.py
@@ -24,32 +24,16 @@ def _setup_remote_storage(
     Raises:
         ValueError if storage cannot be configured.
     """
-    from .storage import get_storage, remote_storage_args
+    from .service import StorageService
 
     resolved_options = storage_options or StorageOptions(out_dir="out")
     benchmark = Benchmark(Path(benchmark_path))
     expected_files = get_expected_benchmark_output_files(benchmark, resolved_options)
 
-    storage_api = benchmark.get_storage_api()
-    bucket_name = benchmark.get_storage_bucket_name()
+    service = StorageService(benchmark, storage_options=resolved_options)
+    service.load_version()
 
-    if storage_api is None:
-        logger.error("Error: No storage API found.")
-        raise ValueError("No storage API found")
-    if bucket_name is None:
-        logger.error("Error: No storage bucket found.")
-        raise ValueError("No storage bucket found")
-
-    auth_options = remote_storage_args(benchmark)
-    ss = get_storage(storage_api, auth_options, bucket_name, resolved_options)
-    if ss is None:
-        logger.error("Error: No storage found.")
-        raise ValueError("No storage found")
-
-    ss.set_version(benchmark.get_benchmark_version())
-    ss.load_objects()
-
-    return ss, benchmark, expected_files
+    return service.storage, benchmark, expected_files
 
 
 def list_files(

--- a/omnibenchmark/remote/files.py
+++ b/omnibenchmark/remote/files.py
@@ -4,12 +4,50 @@ import warnings
 from pathlib import Path
 
 import tqdm
-import yaml
 
 from omnibenchmark.benchmark import Benchmark
 from omnibenchmark.cli.utils.logging import logger
 from omnibenchmark.remote.RemoteStorage import StorageOptions
 from omnibenchmark.remote.versioning import get_expected_benchmark_output_files
+
+
+def _setup_remote_storage(
+    benchmark_path: str,
+    storage_options: StorageOptions = StorageOptions(out_dir="out"),
+):
+    """Set up remote storage for a benchmark.
+
+    Returns:
+        (storage, benchmark, expected_files) tuple.
+
+    Raises:
+        ValueError if storage cannot be configured.
+    """
+    from .storage import get_storage, remote_storage_args
+
+    benchmark = Benchmark(Path(benchmark_path))
+    expected_files = get_expected_benchmark_output_files(benchmark, storage_options)
+
+    storage_api = benchmark.get_storage_api()
+    bucket_name = benchmark.get_storage_bucket_name()
+
+    if storage_api is None:
+        logger.error("Error: No storage API found.")
+        raise ValueError("No storage API found")
+    if bucket_name is None:
+        logger.error("Error: No storage bucket found.")
+        raise ValueError("No storage bucket found")
+
+    auth_options = remote_storage_args(benchmark)
+    ss = get_storage(storage_api, auth_options, bucket_name, storage_options)
+    if ss is None:
+        logger.error("Error: No storage found.")
+        raise ValueError("No storage found")
+
+    ss.set_version(benchmark.get_benchmark_version())
+    ss._get_objects()
+
+    return ss, benchmark, expected_files
 
 
 def list_files(
@@ -22,46 +60,14 @@ def list_files(
     storage_options: StorageOptions = StorageOptions(out_dir="out"),
 ):
     """List all available files for a certain benchmark, version and stage"""
-    from .storage import get_storage, remote_storage_args
-
-    with open(benchmark_path, "r") as fh:
-        yaml.safe_load(fh)
-        benchmark = Benchmark(Path(benchmark_path))
-
-    expected_files = get_expected_benchmark_output_files(benchmark, storage_options)
-
     if remote_storage:
-        auth_options = remote_storage_args(benchmark)
-
-        storage_api = benchmark.get_storage_api()
-        bucket_name = benchmark.get_storage_bucket_name()
-
-        if storage_api is None:
-            logger.error("Error: No storage API found.")
-            raise ValueError("No storage API found")
-        if bucket_name is None:
-            logger.error("Error: No storage bucket found.")
-            raise ValueError("No storage bucket found")
-
-        ss = get_storage(
-            storage_api,
-            auth_options,
-            bucket_name,
-            storage_options,
-        )
-        if ss is None:
-            logger.error("Error: No storage found.")
-            raise ValueError("No storage found")
-
-        ss.set_version(benchmark.get_benchmark_version())
-        ss._get_objects()
+        ss, _, expected_files = _setup_remote_storage(benchmark_path, storage_options)
         files = {k: v for k, v in ss.files.items() if k in expected_files}
-
-        # get urls
         objectnames = list(files.keys())
         etags = [files[objectname]["etag"] for objectname in objectnames]
-
     else:
+        benchmark = Benchmark(Path(benchmark_path))
+        expected_files = get_expected_benchmark_output_files(benchmark, storage_options)
         file_local_is_local = [Path(f).is_file() for f in expected_files]
         if not all(file_local_is_local):
             logger.warning("Not all expected files are available locally")
@@ -86,42 +92,15 @@ def download_files(
     overwrite: bool = False,
 ):
     """Download all available files for a certain benchmark, version and stage"""
-    from .storage import get_storage, remote_storage_args
     from .hash import checksum
     from .sizeof import sizeof_fmt
 
-    objectnames, etags = list_files(benchmark_path, type, stage, module, file_id)
+    ss, _, expected_files = _setup_remote_storage(benchmark_path)
 
-    # storage path locally, TODO: maybe add as argument
+    files = {k: v for k, v in ss.files.items() if k in expected_files}
+    objectnames = list(files.keys())
+    etags = [files[objectname]["etag"] for objectname in objectnames]
     filenames = objectnames
-
-    with open(benchmark_path, "r") as fh:
-        yaml.safe_load(fh)
-        benchmark = Benchmark(Path(benchmark_path))
-
-    auth_options = remote_storage_args(benchmark)
-
-    storage_api = benchmark.get_storage_api()
-    bucket_name = benchmark.get_storage_bucket_name()
-
-    if storage_api is None:
-        logger.error("Error: No storage API found.")
-        raise ValueError("No storage API found")
-    if bucket_name is None:
-        logger.error("Error: No storage bucket found.")
-        raise ValueError("No storage bucket found")
-
-    ss = get_storage(
-        storage_api,
-        auth_options,
-        bucket_name,
-    )
-    if ss is None:
-        logger.error("Error: No storage found.")
-        raise ValueError("No storage found")
-
-    ss.set_version(benchmark.get_benchmark_version())
-    ss._get_objects()
 
     logger.debug("Checking if files are already downloaded... ")
     do_download_file = []
@@ -142,8 +121,8 @@ def download_files(
     if verbose:
         size = sum(
             [
-                int(ss.files[objectname]["size"])
-                for objectname, do_download in zip(ss.files.keys(), do_download_file)
+                int(files[objectname]["size"])
+                for objectname, do_download in zip(objectnames, do_download_file)
                 if do_download
             ]
         )

--- a/omnibenchmark/remote/service.py
+++ b/omnibenchmark/remote/service.py
@@ -1,0 +1,64 @@
+"""High-level service for remote storage operations."""
+
+from typing import Optional
+
+from omnibenchmark.remote.RemoteStorage import StorageOptions
+
+
+class StorageService:
+    """Encapsulates storage setup: configuration validation, authentication, and object loading.
+
+    Accepts any object that implements the benchmark storage interface (i.e. both
+    ``BenchmarkExecution`` and the lighter-weight ``Benchmark`` model), so callers
+    can avoid building a full DAG when only the storage configuration is needed.
+
+    Usage::
+
+        service = StorageService(benchmark_model)
+        service.load_version()          # set current version and fetch object list
+        files = service.storage.files   # access the loaded object dict
+    """
+
+    def __init__(
+        self,
+        benchmark_model,
+        require_credentials: bool = True,
+        storage_options: Optional[StorageOptions] = None,
+    ):
+        from omnibenchmark.remote.storage import remote_storage_args, StorageFactory
+
+        api = benchmark_model.get_storage_api()
+        bucket = benchmark_model.get_storage_bucket_name()
+
+        if api is None:
+            raise ValueError(
+                "No storage API configured. Set 'storage.api' in your benchmark YAML."
+            )
+        if bucket is None:
+            raise ValueError(
+                "No storage bucket configured."
+                " Set 'storage.bucket_name' in your benchmark YAML."
+            )
+
+        auth_options = remote_storage_args(
+            benchmark_model, required=require_credentials
+        )
+        storage = StorageFactory.create(api, auth_options, bucket, storage_options)
+
+        if storage is None:
+            raise ValueError(
+                "S3 storage dependencies not installed. Run: pip install omnibenchmark[s3]"
+            )
+
+        self.storage = storage
+        self._benchmark_model = benchmark_model
+
+    def load_version(self, version: Optional[str] = None) -> None:
+        """Set and load a version (defaults to the benchmark's configured version)."""
+        resolved = (
+            version
+            if version is not None
+            else self._benchmark_model.get_benchmark_version()
+        )
+        self.storage.set_version(resolved)
+        self.storage.load_objects()

--- a/omnibenchmark/remote/service.py
+++ b/omnibenchmark/remote/service.py
@@ -40,10 +40,25 @@ class StorageService:
                 " Set 'storage.bucket_name' in your benchmark YAML."
             )
 
+        # Derive out_dir from the benchmark's execution context when available,
+        # falling back to "out" for lightweight model objects that have no context.
+        if storage_options is None:
+            from pathlib import Path
+
+            out_dir = getattr(
+                getattr(benchmark_model, "context", None), "out_dir", Path("out")
+            )
+            storage_options = StorageOptions(out_dir=str(out_dir))
+
         auth_options = remote_storage_args(
             benchmark_model, required=require_credentials
         )
-        storage = StorageFactory.create(api, auth_options, bucket, storage_options)
+        try:
+            storage = StorageFactory.create(api, auth_options, bucket, storage_options)
+        except Exception as e:
+            # Re-raise S3/storage-level exceptions as ValueError so callers only
+            # need to handle one exception type at the service boundary.
+            raise ValueError(str(e)) from e
 
         if storage is None:
             raise ValueError(

--- a/omnibenchmark/remote/service.py
+++ b/omnibenchmark/remote/service.py
@@ -15,8 +15,8 @@ class StorageService:
     Usage::
 
         service = StorageService(benchmark_model)
-        service.load_version()          # set current version and fetch object list
-        files = service.storage.files   # access the loaded object dict
+        service.load_version()          # set current version
+        files = service.storage.files   # lazily fetches object list on first access
     """
 
     def __init__(
@@ -69,11 +69,52 @@ class StorageService:
         self._benchmark_model = benchmark_model
 
     def load_version(self, version: Optional[str] = None) -> None:
-        """Set and load a version (defaults to the benchmark's configured version)."""
+        """Set a version (defaults to the benchmark's configured version).
+
+        File metadata is fetched lazily on first access of ``storage.files``.
+        """
         resolved = (
             version
             if version is not None
             else self._benchmark_model.get_benchmark_version()
         )
         self.storage.set_version(resolved)
-        self.storage.load_objects()
+
+    @classmethod
+    def from_path(
+        cls,
+        benchmark_path: str,
+        *,
+        full_model: bool = False,
+        require_credentials: bool = True,
+        storage_options: Optional[StorageOptions] = None,
+    ) -> "StorageService":
+        """Create a StorageService directly from a benchmark YAML path.
+
+        Args:
+            benchmark_path: Path to the benchmark YAML file.
+            full_model: When True load a ``BenchmarkExecution`` (full DAG);
+                when False load a lightweight ``Benchmark``.
+            require_credentials: Whether write credentials are required.
+            storage_options: Optional storage configuration override.
+
+        Returns:
+            A configured ``StorageService``.  Call ``load_version()`` on the
+            result before accessing ``storage.files``.
+        """
+        from pathlib import Path
+
+        if full_model:
+            from omnibenchmark.benchmark import BenchmarkExecution
+
+            benchmark_model = BenchmarkExecution(Path(benchmark_path))
+        else:
+            from omnibenchmark.benchmark import Benchmark
+
+            benchmark_model = Benchmark(Path(benchmark_path))
+
+        return cls(
+            benchmark_model,
+            require_credentials=require_credentials,
+            storage_options=storage_options,
+        )

--- a/omnibenchmark/remote/storage.py
+++ b/omnibenchmark/remote/storage.py
@@ -7,18 +7,18 @@ from omnibenchmark.benchmark import BenchmarkExecution
 from .RemoteStorage import StorageOptions
 
 if TYPE_CHECKING:
-    from .MinIOStorage import MinIOStorage as MinIOStorageType
+    from .S3Storage import S3CompatibleStorage as S3CompatibleStorageType
 else:
-    MinIOStorageType = Any
+    S3CompatibleStorageType = Any
 
 try:
-    from .MinIOStorage import MinIOStorage
+    from .S3Storage import S3CompatibleStorage
     from .S3config import S3_access_config_from_env
 
     S3_AVAILABLE = True
 except ImportError:
     S3_AVAILABLE = False
-    MinIOStorage = None  # type: ignore
+    S3CompatibleStorage = None  # type: ignore
     S3_access_config_from_env = None
 
 
@@ -60,7 +60,7 @@ class StorageFactory:
         auth_options: dict,
         bucket: str,
         storage_options: Optional[StorageOptions] = None,
-    ) -> Optional[MinIOStorageType]:
+    ) -> Optional[S3CompatibleStorageType]:
         """Return a RemoteStorage instance for *storage_api*, or None.
 
         Args:
@@ -77,9 +77,9 @@ class StorageFactory:
         resolved_options = storage_options or StorageOptions(out_dir="out")
 
         if storage_api.upper() in ("MINIO", "S3"):
-            if not _check_s3_available() or MinIOStorage is None:
+            if not _check_s3_available() or S3CompatibleStorage is None:
                 return None
-            return MinIOStorage(auth_options, bucket, resolved_options)
+            return S3CompatibleStorage(auth_options, bucket, resolved_options)
 
         return None
 
@@ -94,7 +94,7 @@ def get_storage(
     auth_options: dict,
     benchmark: str,
     storage_options: Optional[StorageOptions] = None,
-) -> Optional[MinIOStorageType]:
+) -> Optional[S3CompatibleStorageType]:
     """Return a RemoteStorage instance for *storage_api*.
 
     Thin wrapper around :class:`StorageFactory` kept for backward
@@ -112,7 +112,7 @@ def get_storage(
 
 def get_storage_from_benchmark(
     benchmark: BenchmarkExecution,
-) -> Optional[MinIOStorageType]:
+) -> Optional[S3CompatibleStorageType]:
     """Return a RemoteStorage instance configured from *benchmark*.
 
     Args:

--- a/omnibenchmark/remote/storage.py
+++ b/omnibenchmark/remote/storage.py
@@ -56,15 +56,15 @@ class StorageFactory:
 
     @staticmethod
     def create(
-        storage_type: str,
+        storage_api: str,
         auth_options: dict,
         bucket: str,
         storage_options: StorageOptions = StorageOptions(out_dir="out"),
     ) -> Optional[MinIOStorageType]:
-        """Return a RemoteStorage instance for *storage_type*, or None.
+        """Return a RemoteStorage instance for *storage_api*, or None.
 
         Args:
-            storage_type: Storage API identifier ("S3" or the deprecated "MinIO").
+            storage_api: Storage API identifier ("S3" or the deprecated "MinIO").
             auth_options: Authentication dict (endpoint, access_key, secret_key).
             bucket: S3 bucket name used as the benchmark identifier.
             storage_options: Tracked-directory configuration.
@@ -73,9 +73,9 @@ class StorageFactory:
             A RemoteStorage instance, or None when the required extras are not
             installed.
         """
-        _warn_minio_deprecated(storage_type)
+        _warn_minio_deprecated(storage_api)
 
-        if storage_type.upper() in ("MINIO", "S3"):
+        if storage_api.upper() in ("MINIO", "S3"):
             if not _check_s3_available() or MinIOStorage is None:
                 return None
             return MinIOStorage(auth_options, bucket, storage_options)
@@ -89,24 +89,24 @@ class StorageFactory:
 
 
 def get_storage(
-    storage_type: str,
+    storage_api: str,
     auth_options: dict,
     benchmark: str,
     storage_options: StorageOptions = StorageOptions(out_dir="out"),
 ) -> Optional[MinIOStorageType]:
-    """Return a RemoteStorage instance for *storage_type*.
+    """Return a RemoteStorage instance for *storage_api*.
 
     Thin wrapper around :class:`StorageFactory` kept for backward
     compatibility. Prefer calling ``StorageFactory.create()`` directly in
     new code.
 
     Args:
-        storage_type: Storage API identifier ("S3" or the deprecated "MinIO").
+        storage_api: Storage API identifier ("S3" or the deprecated "MinIO").
         auth_options: Authentication dict (endpoint, access_key, secret_key).
         benchmark: S3 bucket / benchmark name.
         storage_options: Tracked-directory configuration.
     """
-    return StorageFactory.create(storage_type, auth_options, benchmark, storage_options)
+    return StorageFactory.create(storage_api, auth_options, benchmark, storage_options)
 
 
 def get_storage_from_benchmark(

--- a/omnibenchmark/remote/storage.py
+++ b/omnibenchmark/remote/storage.py
@@ -62,6 +62,14 @@ def get_storage(
     Returns:
     - Optional[MinIOStorage]: The remote storage object, or None if unavailable.
     """
+    if storage_type.upper() == "MINIO":
+        import warnings
+
+        warnings.warn(
+            "Storage type 'MinIO' is deprecated. Use 'S3' with a custom endpoint instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if storage_type.upper() == "MINIO" or storage_type.upper() == "S3":
         if not _check_s3_available() or MinIOStorage is None:
             return None
@@ -104,6 +112,14 @@ def remote_storage_args(benchmark, required: bool = False) -> dict:
         dict: Authentication options for remote storage
     """
     storage_api = benchmark.get_storage_api()
+    if storage_api and storage_api.upper() == "MINIO":
+        import warnings
+
+        warnings.warn(
+            "Storage type 'MinIO' is deprecated. Use 'S3' with a custom endpoint instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if storage_api and (storage_api.upper() == "MINIO" or storage_api.upper() == "S3"):
         if not _check_s3_available() or S3_access_config_from_env is None:
             return {}
@@ -131,6 +147,14 @@ def remote_storage_args(benchmark, required: bool = False) -> dict:
 
 def remote_storage_snakemake_args(benchmark) -> dict:
     storage_api = benchmark.get_storage_api()
+    if storage_api and storage_api.upper() == "MINIO":
+        import warnings
+
+        warnings.warn(
+            "Storage type 'MinIO' is deprecated. Use 'S3' with a custom endpoint instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if storage_api and (storage_api.upper() == "MINIO" or storage_api.upper() == "S3"):
         if not _check_s3_available() or S3_access_config_from_env is None:
             return {}

--- a/omnibenchmark/remote/storage.py
+++ b/omnibenchmark/remote/storage.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from typing import Optional, TYPE_CHECKING, Any
 
@@ -31,99 +32,123 @@ def _check_s3_available():
     return S3_AVAILABLE
 
 
-# XXX ARCHITECTURAL DEBT: Storage Factory Pattern Missing
-#
-# Current Issue: We're mixing the storage API abstraction with concrete MinIO implementation.
-# This creates tight coupling and makes it difficult to add new storage backends.
-#
-# Recommended Pattern:
-# class StorageFactory:
-#     @staticmethod
-#     def create_storage(storage_config: Storage) -> RemoteStorage:
-#         match storage_config.api:
-#             case StorageAPIEnum.s3: return MinIOStorage(...)
-#             case StorageAPIEnum.gcs: return GCSStorage(...)  # future
-#
-# This would allow proper dependency injection and easier testing with mock storage.
+def _warn_minio_deprecated(storage_type: str) -> None:
+    """Emit a deprecation warning if storage_type is MinIO."""
+    if storage_type.upper() == "MINIO":
+        warnings.warn(
+            "Storage type 'MinIO' is deprecated. Use 'S3' with a custom endpoint instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+
+class StorageFactory:
+    """Factory for creating RemoteStorage instances.
+
+    Centralises backend selection so that adding a new storage backend
+    (e.g. GCS, Azure Blob) only requires a change here, not across all
+    call sites.
+
+    Example::
+
+        ss = StorageFactory.create("S3", auth_options, bucket_name)
+    """
+
+    @staticmethod
+    def create(
+        storage_type: str,
+        auth_options: dict,
+        bucket: str,
+        storage_options: StorageOptions = StorageOptions(out_dir="out"),
+    ) -> Optional[MinIOStorageType]:
+        """Return a RemoteStorage instance for *storage_type*, or None.
+
+        Args:
+            storage_type: Storage API identifier ("S3" or the deprecated "MinIO").
+            auth_options: Authentication dict (endpoint, access_key, secret_key).
+            bucket: S3 bucket name used as the benchmark identifier.
+            storage_options: Tracked-directory configuration.
+
+        Returns:
+            A RemoteStorage instance, or None when the required extras are not
+            installed.
+        """
+        _warn_minio_deprecated(storage_type)
+
+        if storage_type.upper() in ("MINIO", "S3"):
+            if not _check_s3_available() or MinIOStorage is None:
+                return None
+            return MinIOStorage(auth_options, bucket, storage_options)
+
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
 def get_storage(
     storage_type: str,
     auth_options: dict,
     benchmark: str,
     storage_options: StorageOptions = StorageOptions(out_dir="out"),
 ) -> Optional[MinIOStorageType]:
-    """
-    Selects a remote storage type.
+    """Return a RemoteStorage instance for *storage_type*.
+
+    Thin wrapper around :class:`StorageFactory` kept for backward
+    compatibility. Prefer calling ``StorageFactory.create()`` directly in
+    new code.
 
     Args:
-    - storage_type (str): The type of the remote storage.
-    - auth_options (dict): The authentication options.
-    - benchmark (str): The benchmark name.
-
-    Returns:
-    - Optional[MinIOStorage]: The remote storage object, or None if unavailable.
+        storage_type: Storage API identifier ("S3" or the deprecated "MinIO").
+        auth_options: Authentication dict (endpoint, access_key, secret_key).
+        benchmark: S3 bucket / benchmark name.
+        storage_options: Tracked-directory configuration.
     """
-    if storage_type.upper() == "MINIO":
-        import warnings
-
-        warnings.warn(
-            "Storage type 'MinIO' is deprecated. Use 'S3' with a custom endpoint instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-    if storage_type.upper() == "MINIO" or storage_type.upper() == "S3":
-        if not _check_s3_available() or MinIOStorage is None:
-            return None
-        return MinIOStorage(auth_options, benchmark, storage_options)
+    return StorageFactory.create(storage_type, auth_options, benchmark, storage_options)
 
 
 def get_storage_from_benchmark(
     benchmark: BenchmarkExecution,
 ) -> Optional[MinIOStorageType]:
-    """
-    Selects a remote storage type from a benchmark object.
+    """Return a RemoteStorage instance configured from *benchmark*.
 
     Args:
-    - benchmark (BenchmarkExecution): The benchmark object.
+        benchmark: The benchmark execution object.
 
     Returns:
-    - Optional[MinIOStorage]: The remote storage object, or None if unavailable.
+        A RemoteStorage instance, or None when storage is not configured.
     """
     auth_options = remote_storage_args(benchmark)
-    # setup storage
     storage_api = benchmark.get_storage_api()
     bucket_name = benchmark.get_storage_bucket_name()
 
     if storage_api is None or bucket_name is None:
         return None
 
-    return get_storage(
+    return StorageFactory.create(
         storage_api, auth_options, bucket_name, StorageOptions(out_dir="out")
     )
 
 
 def remote_storage_args(benchmark, required: bool = False) -> dict:
-    """Get remote storage authentication arguments.
+    """Return authentication args for the benchmark's remote storage.
 
     Args:
-        benchmark: The benchmark object
-        required: If True, require credentials to be present (for write operations)
+        benchmark: The benchmark object.
+        required: If True, require credentials to be present (write operations).
 
     Returns:
-        dict: Authentication options for remote storage
+        dict with endpoint, secure, and optionally access_key / secret_key.
     """
     storage_api = benchmark.get_storage_api()
-    if storage_api and storage_api.upper() == "MINIO":
-        import warnings
+    if storage_api:
+        _warn_minio_deprecated(storage_api)
 
-        warnings.warn(
-            "Storage type 'MinIO' is deprecated. Use 'S3' with a custom endpoint instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     if storage_api and (storage_api.upper() == "MINIO" or storage_api.upper() == "S3"):
         if not _check_s3_available() or S3_access_config_from_env is None:
             return {}
-        # Let caller decide if credentials are required
         auth_options = S3_access_config_from_env(required=required)
         endpoint = benchmark.get_storage_endpoint()
         if endpoint is None:
@@ -146,15 +171,11 @@ def remote_storage_args(benchmark, required: bool = False) -> dict:
 
 
 def remote_storage_snakemake_args(benchmark) -> dict:
+    """Return Snakemake storage plugin args for *benchmark*'s remote storage."""
     storage_api = benchmark.get_storage_api()
-    if storage_api and storage_api.upper() == "MINIO":
-        import warnings
+    if storage_api:
+        _warn_minio_deprecated(storage_api)
 
-        warnings.warn(
-            "Storage type 'MinIO' is deprecated. Use 'S3' with a custom endpoint instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     if storage_api and (storage_api.upper() == "MINIO" or storage_api.upper() == "S3"):
         if not _check_s3_available() or S3_access_config_from_env is None:
             return {}

--- a/omnibenchmark/remote/storage.py
+++ b/omnibenchmark/remote/storage.py
@@ -59,7 +59,7 @@ class StorageFactory:
         storage_api: str,
         auth_options: dict,
         bucket: str,
-        storage_options: StorageOptions = StorageOptions(out_dir="out"),
+        storage_options: Optional[StorageOptions] = None,
     ) -> Optional[MinIOStorageType]:
         """Return a RemoteStorage instance for *storage_api*, or None.
 
@@ -74,11 +74,12 @@ class StorageFactory:
             installed.
         """
         _warn_minio_deprecated(storage_api)
+        resolved_options = storage_options or StorageOptions(out_dir="out")
 
         if storage_api.upper() in ("MINIO", "S3"):
             if not _check_s3_available() or MinIOStorage is None:
                 return None
-            return MinIOStorage(auth_options, bucket, storage_options)
+            return MinIOStorage(auth_options, bucket, resolved_options)
 
         return None
 
@@ -92,7 +93,7 @@ def get_storage(
     storage_api: str,
     auth_options: dict,
     benchmark: str,
-    storage_options: StorageOptions = StorageOptions(out_dir="out"),
+    storage_options: Optional[StorageOptions] = None,
 ) -> Optional[MinIOStorageType]:
     """Return a RemoteStorage instance for *storage_api*.
 

--- a/omnibenchmark/remote/storage.py
+++ b/omnibenchmark/remote/storage.py
@@ -128,8 +128,11 @@ def get_storage_from_benchmark(
     if storage_api is None or bucket_name is None:
         return None
 
+    from pathlib import Path
+
+    out_dir = getattr(getattr(benchmark, "context", None), "out_dir", Path("out"))
     return StorageFactory.create(
-        storage_api, auth_options, bucket_name, StorageOptions(out_dir="out")
+        storage_api, auth_options, bucket_name, StorageOptions(out_dir=str(out_dir))
     )
 
 

--- a/omnibenchmark/remote/versioning.py
+++ b/omnibenchmark/remote/versioning.py
@@ -58,8 +58,6 @@ def get_expected_benchmark_output_files(
             glob_expression
         ) in storage_options.extra_files_to_version_not_in_benchmark_yaml:
             found_files = glob.glob(glob_expression, recursive=True)
-            if isinstance(found_files, str):
-                found_files = [found_files]
             for found_file in found_files:
                 object_names_to_keep.add(found_file)
     return list(object_names_to_keep)

--- a/omnibenchmark/remote/versioning.py
+++ b/omnibenchmark/remote/versioning.py
@@ -77,7 +77,7 @@ def filter_objects_to_tag(
             benchmark, storage_options
         )
 
-        rootdirs = [Path(obj).parents[-2].name for obj in object_names_to_tag]
+        rootdirs = [Path(obj).parts[0] for obj in object_names_to_tag]
         overwrite_dirs_to_keep = [
             t
             for t in storage_options.tracked_directories

--- a/omnibenchmark/remote/versioning.py
+++ b/omnibenchmark/remote/versioning.py
@@ -5,7 +5,7 @@ import glob
 
 from omnibenchmark.benchmark import Benchmark
 from omnibenchmark.remote.RemoteStorage import StorageOptions
-from omnibenchmark.remote.exception import MinIOStorageVersioningCorruptionException
+from omnibenchmark.remote.exception import S3StorageVersioningCorruptionException
 
 
 def get_objects_to_tag(
@@ -116,7 +116,7 @@ def get_single_remoteversion_from_bmversion(
         )
     )
     if len(version_ls) > 1:
-        raise MinIOStorageVersioningCorruptionException(
+        raise S3StorageVersioningCorruptionException(
             f"Multiple versions found for object {object_name}"
         )
     return version_ls[0] if version_ls else None

--- a/pixi.lock
+++ b/pixi.lock
@@ -4775,8 +4775,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: omnibenchmark
-  version: 0.4.0rc3.post1+g345dfb7bd.d20260220
-  sha256: c81004fcc1f548ffa024140476488f78416a243b3a71049f0dc58e9a54e3e1fc
+  version: 0.4.0.post25+ge2b0a3e3f
+  sha256: fd418acea78c95bcef3ff287874dfb5a1743bca20cd0cee8500b82c0df96c438
   requires_dist:
   - click>=8.1.7
   - python-dateutil>=2.9.0.post0
@@ -4793,7 +4793,6 @@ packages:
   - matplotlib==3.8.0
   - pydot>=3.0.2
   - tqdm>=4.66.4
-  - minio==7.2.18 ; extra == 's3'
   - boto3>=1.34.102 ; extra == 's3'
   - snakemake-storage-plugin-s3>=0.2.12 ; extra == 's3'
   - snakemake-executor-plugin-slurm>=1.4.0,<2.0.0 ; extra == 'slurm'

--- a/pixi.toml
+++ b/pixi.toml
@@ -102,7 +102,7 @@ pip = "pip"
 # Tox for comprehensive testing (with library interactions like snakemake)
 test-tox = "tox"
 # Fast pixi alternative for CI (run with: pixi run -e py313 test-py313)
-test-py313 = "pytest -m 'short and not e2e' --ignore=tests/e2e --ignore=tests/cli/test_archive.py --ignore=tests/cli/test_io.py --ignore=tests/cli/test_run_benchmark.py --ignore=tests/cli/test_run_module.py --ignore=tests/io/test_MinIOStorage.py --ignore=tests/io/test_storage.py --ignore=tests/workflow/test_run_workflow.py"
+test-py313 = "pytest -m 'short and not e2e' --ignore=tests/e2e --ignore=tests/cli/test_archive.py --ignore=tests/cli/test_io.py --ignore=tests/cli/test_run_benchmark.py --ignore=tests/cli/test_run_module.py --ignore=tests/io/test_S3Storage.py --ignore=tests/io/test_storage.py --ignore=tests/workflow/test_run_workflow.py"
 
 [feature.docs.dependencies]
 # Documentation dependencies (optional feature)
@@ -143,4 +143,4 @@ minio = "==7.2.18"  # Pin to 7.2.18, 7.2.19 has breaking API changes
 
 [feature.py313.tasks]
 # Test task for Python 3.13 environment
-test-py313 = "pytest -m 'short and not e2e' --ignore=tests/e2e --ignore=tests/cli/test_archive.py --ignore=tests/cli/test_io.py --ignore=tests/cli/test_run_benchmark.py --ignore=tests/cli/test_run_module.py --ignore=tests/io/test_MinIOStorage.py --ignore=tests/io/test_storage.py --ignore=tests/workflow/test_run_workflow.py"
+test-py313 = "pytest -m 'short and not e2e' --ignore=tests/e2e --ignore=tests/cli/test_archive.py --ignore=tests/cli/test_io.py --ignore=tests/cli/test_run_benchmark.py --ignore=tests/cli/test_run_module.py --ignore=tests/io/test_S3Storage.py --ignore=tests/io/test_storage.py --ignore=tests/workflow/test_run_workflow.py"

--- a/pixi.toml
+++ b/pixi.toml
@@ -62,7 +62,7 @@ tqdm = ">=4.66.4"
 minio = "==7.2.18"  # Pin to 7.2.18, 7.2.19 has breaking API changes
 boto3 = ">=1.34.102"
 snakemake-storage-plugin-s3 = ">=0.2.12"
-s3fs = { version = ">=2023.12.0", extras = ["boto3"] }
+s3fs = ">=2023.12.0"
 
 # Test dependencies
 testcontainers = ">=4.5.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Homepage = "https://omnibenchmark.org"
 Repository = "https://github.com/omnibenchmark/omnibenchmark"
 
 [project.optional-dependencies]
-s3 = ["minio==7.2.18", "boto3>=1.34.102", "snakemake-storage-plugin-s3>=0.2.12"]  # Pin to 7.2.18, 7.2.19 has breaking API changes
+s3 = ["boto3>=1.34.102", "snakemake-storage-plugin-s3>=0.2.12"]
 slurm = [
     "snakemake-executor-plugin-slurm (>=1.4.0,<2.0.0)",
     "pandas",  # Required by snakemake-executor-plugin-slurm

--- a/tests/cli/fixtures.py
+++ b/tests/cli/fixtures.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from tests.remote.S3Storage_setup import MinIOSetup, TmpS3Storage as TmpMinIOStorage
+from tests.remote.S3Storage_setup import MinIOSetup, TmpMinIOStorage
 
 from .path import data
 

--- a/tests/cli/fixtures.py
+++ b/tests/cli/fixtures.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from tests.remote.MinIOStorage_setup import MinIOSetup, TmpMinIOStorage
+from tests.remote.S3Storage_setup import MinIOSetup, TmpS3Storage as TmpMinIOStorage
 
 from .path import data
 

--- a/tests/cli/test_remote.py
+++ b/tests/cli/test_remote.py
@@ -49,7 +49,7 @@ def test_create_version(minio_storage):  # noqa: F811
 
         store = minio_storage.get_storage_client()
         store.set_version("1.0")
-        store._get_objects()
+        store.load_objects()
 
         assert "versions/1.0.csv" in store.files.keys()
 
@@ -188,7 +188,7 @@ def test_download_files(minio_storage):  # noqa: F811
         # Verify downloaded files exist by comparing with remote files
         store = minio_storage.get_storage_client()
         store.set_version("1.0")
-        store._get_objects()
+        store.load_objects()
 
         # Get remote files (focusing on out directory files)
         remote_files = [f for f in store.files.keys() if Path(f).parts[0] == "out"]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -321,7 +321,7 @@ def _minio_container_e2e():
             allow_module_level=True,
         )
 
-    from tests.remote.MinIOStorage_setup import MinIOSetup
+    from tests.remote.S3Storage_setup import MinIOSetup
 
     # Initialize a MinIO test container with a lifetime of this test session
     minio = MinIOSetup()

--- a/tests/e2e/s3/docker-compose.yml
+++ b/tests/e2e/s3/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   minio:
-    image: quay.io/minio/minio:RELEASE.2024-06-13T22-53-53Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: omnibenchmark-minio-e2e
     ports:
       - "9000:9000"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,7 +4,7 @@ import pytest
 
 from pathlib import Path
 
-from tests.remote.MinIOStorage_setup import MinIOSetup, TmpMinIOStorage
+from tests.remote.S3Storage_setup import MinIOSetup, TmpS3Storage as TmpMinIOStorage
 
 
 def get_benchmark_data_path() -> Path:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,7 +4,7 @@ import pytest
 
 from pathlib import Path
 
-from tests.remote.S3Storage_setup import MinIOSetup, TmpS3Storage as TmpMinIOStorage
+from tests.remote.S3Storage_setup import MinIOSetup, TmpMinIOStorage
 
 
 def get_benchmark_data_path() -> Path:

--- a/tests/remote/MinIOStorage_setup.py
+++ b/tests/remote/MinIOStorage_setup.py
@@ -9,7 +9,7 @@ from testcontainers.minio import MinioContainer
 import yaml
 
 from omnibenchmark.model import Benchmark
-from omnibenchmark.remote.MinIOStorage import MinIOStorage
+from omnibenchmark.remote.S3Storage import S3CompatibleStorage as MinIOStorage
 from omnibenchmark.remote.RemoteStorage import StorageOptions
 
 MINIO_IMAGE = "minio/minio:RELEASE.2024-06-13T22-53-53Z"

--- a/tests/remote/S3Storage_setup.py
+++ b/tests/remote/S3Storage_setup.py
@@ -9,7 +9,7 @@ from testcontainers.minio import MinioContainer
 import yaml
 
 from omnibenchmark.model import Benchmark
-from omnibenchmark.remote.S3Storage import S3CompatibleStorage as MinIOStorage
+from omnibenchmark.remote.S3Storage import S3CompatibleStorage
 from omnibenchmark.remote.RemoteStorage import StorageOptions
 
 MINIO_IMAGE = "minio/minio:RELEASE.2024-06-13T22-53-53Z"
@@ -38,7 +38,7 @@ class MinIOSetup:
         self.minio.stop()
 
 
-class TmpMinIOStorage:
+class TmpS3Storage:
     """Manages a temporary bucket for a single test."""
 
     def __init__(self, testcontainer: MinIOSetup) -> None:
@@ -94,7 +94,7 @@ class TmpMinIOStorage:
             shutil.copyfile(env_path, env_path_after)
 
     def get_storage_client(self):
-        return MinIOStorage(
+        return S3CompatibleStorage(
             auth_options=self.auth_options,
             storage_options=self.storage_options,
             benchmark=self.bucket_name,

--- a/tests/remote/S3Storage_setup.py
+++ b/tests/remote/S3Storage_setup.py
@@ -12,7 +12,7 @@ from omnibenchmark.model import Benchmark
 from omnibenchmark.remote.S3Storage import S3CompatibleStorage
 from omnibenchmark.remote.RemoteStorage import StorageOptions
 
-MINIO_IMAGE = "minio/minio:RELEASE.2024-06-13T22-53-53Z"
+MINIO_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z"
 
 # How many buckets to pre-seed
 BUCKETS_NUMBER = 100

--- a/tests/remote/S3Storage_setup.py
+++ b/tests/remote/S3Storage_setup.py
@@ -38,7 +38,7 @@ class MinIOSetup:
         self.minio.stop()
 
 
-class TmpS3Storage:
+class TmpMinIOStorage:
     """Manages a temporary bucket for a single test."""
 
     def __init__(self, testcontainer: MinIOSetup) -> None:

--- a/tests/remote/test_MinIOStorage.py
+++ b/tests/remote/test_MinIOStorage.py
@@ -12,7 +12,7 @@ from omnibenchmark.model import SoftwareBackendEnum
 from omnibenchmark.benchmark import BenchmarkExecution
 from omnibenchmark.remote.RemoteStorage import StorageOptions
 from omnibenchmark.remote.exception import RemoteStorageInvalidInputException
-from omnibenchmark.remote.MinIOStorage import MinIOStorage
+from omnibenchmark.remote.S3Storage import S3CompatibleStorage as MinIOStorage
 
 from ..fixtures import minio_storage, _minio_container  # noqa: F401
 

--- a/tests/remote/test_MinIOStorage.py
+++ b/tests/remote/test_MinIOStorage.py
@@ -88,13 +88,13 @@ class TestMinIOStorage:
         assert Version("0.2") in client.versions
 
     # fmt: off
-    def test__get_objects(self, minio_storage):  # noqa: F811
+    def test_load_objects(self, minio_storage):  # noqa: F811
     # fmt: on
         client = minio_storage.get_storage_client()
         client.client.put_object(client.benchmark, "out/file1.txt", io.BytesIO(b""), 0)
         client.client.put_object(client.benchmark, "out/file2.txt", io.BytesIO(b""), 0)
         client.set_version()
-        client._get_objects()
+        client.load_objects()
         assert all(
             [f in client.files.keys() for f in ["out/file1.txt", "out/file2.txt"]]
         )
@@ -127,13 +127,13 @@ class TestMinIOStorage:
         )
 
     # fmt: off
-    def test__get_objects_public(self, minio_storage):  # noqa: F811
+    def test_load_objects_public(self, minio_storage):  # noqa: F811
     # fmt: on
         client = minio_storage.get_storage_client()
         client.client.put_object(client.benchmark, "out/file1.txt", io.BytesIO(b""), 0)
         client.client.put_object(client.benchmark, "out/file2.txt", io.BytesIO(b""), 0)
         client.set_version()
-        client._get_objects()
+        client.load_objects()
         assert all(
             [f in client.files.keys() for f in ["out/file1.txt", "out/file2.txt"]]
         )
@@ -176,7 +176,7 @@ class TestMinIOStorage:
         )
         client.set_version("0.2")
         client.create_new_version()
-        client._get_objects()
+        client.load_objects()
         assert all(
             [f in client.files.keys() for f in ["out/file1.txt", "out/file2.txt"]]
         )
@@ -205,7 +205,7 @@ class TestMinIOStorage:
         )
         client.set_version("0.2")
         client.create_new_version()
-        client._get_objects()
+        client.load_objects()
         client.files
 
         # Set up a temporary git repository for testing version persistence
@@ -230,7 +230,7 @@ class TestMinIOStorage:
 
             client.set_version("0.3")
             client.create_new_version(benchmark)
-            client._get_objects()
+            client.load_objects()
             assert all(
                 [f not in client.files.keys() for f in ["out/file1.txt", "out/file2.txt"]]
             )
@@ -272,7 +272,7 @@ class TestMinIOStorage:
 
             client.set_version("0.3")
             client.create_new_version(benchmark)
-            client._get_objects()
+            client.load_objects()
             client.files.keys()
             assert all(
                 [

--- a/tests/remote/test_S3Storage.py
+++ b/tests/remote/test_S3Storage.py
@@ -12,7 +12,7 @@ from omnibenchmark.model import SoftwareBackendEnum
 from omnibenchmark.benchmark import BenchmarkExecution
 from omnibenchmark.remote.RemoteStorage import StorageOptions
 from omnibenchmark.remote.exception import RemoteStorageInvalidInputException
-from omnibenchmark.remote.S3Storage import S3CompatibleStorage as MinIOStorage
+from omnibenchmark.remote.S3Storage import S3CompatibleStorage
 
 from ..fixtures import minio_storage, _minio_container  # noqa: F401
 
@@ -21,10 +21,10 @@ def get_benchmark_data_path() -> Path:
     return Path(__file__).resolve().parent.parent / "data"
 
 
-class TestMinIOStorage:
+class TestS3CompatibleStorage:
     def test_init_fail(self):
         with pytest.raises(AssertionError):
-            MinIOStorage(
+            S3CompatibleStorage(
                 auth_options={},
                 benchmark="test",
                 storage_options=StorageOptions(out_dir="out"),

--- a/tests/remote/test_S3Storage.py
+++ b/tests/remote/test_S3Storage.py
@@ -1,5 +1,4 @@
 import datetime
-import io
 import tempfile
 import shutil
 from packaging.version import Version
@@ -47,8 +46,8 @@ class TestS3CompatibleStorage:
         # XXX should not test private methods
         client._create_benchmark(f"{minio_storage.bucket_name}2")
 
-        assert client.client.bucket_exists(f"{minio_storage.bucket_name}")
-        assert client.client.bucket_exists(f"{minio_storage.bucket_name}2")
+        assert client._bucket_exists(f"{minio_storage.bucket_name}")
+        assert client._bucket_exists(f"{minio_storage.bucket_name}2")
 
     # fmt: off
     def test__get_versions_success_get_version(self, minio_storage):  # noqa: F811
@@ -91,8 +90,8 @@ class TestS3CompatibleStorage:
     def test_load_objects(self, minio_storage):  # noqa: F811
     # fmt: on
         client = minio_storage.get_storage_client()
-        client.client.put_object(client.benchmark, "out/file1.txt", io.BytesIO(b""), 0)
-        client.client.put_object(client.benchmark, "out/file2.txt", io.BytesIO(b""), 0)
+        client.client.put_object(Bucket=client.benchmark, Key="out/file1.txt", Body=b"")
+        client.client.put_object(Bucket=client.benchmark, Key="out/file2.txt", Body=b"")
         client.set_version()
         client.load_objects()
         assert all(
@@ -130,8 +129,8 @@ class TestS3CompatibleStorage:
     def test_load_objects_public(self, minio_storage):  # noqa: F811
     # fmt: on
         client = minio_storage.get_storage_client()
-        client.client.put_object(client.benchmark, "out/file1.txt", io.BytesIO(b""), 0)
-        client.client.put_object(client.benchmark, "out/file2.txt", io.BytesIO(b""), 0)
+        client.client.put_object(Bucket=client.benchmark, Key="out/file1.txt", Body=b"")
+        client.client.put_object(Bucket=client.benchmark, Key="out/file2.txt", Body=b"")
         client.set_version()
         client.load_objects()
         assert all(
@@ -169,10 +168,10 @@ class TestS3CompatibleStorage:
     # fmt: on
         client = minio_storage.get_storage_client()
         _ = client.client.put_object(
-            client.benchmark, "out/file1.txt", io.BytesIO(b""), 0
+            Bucket=client.benchmark, Key="out/file1.txt", Body=b""
         )
         _ = client.client.put_object(
-            client.benchmark, "out/file2.txt", io.BytesIO(b""), 0
+            Bucket=client.benchmark, Key="out/file2.txt", Body=b""
         )
         client.set_version("0.2")
         client.create_new_version()
@@ -198,10 +197,10 @@ class TestS3CompatibleStorage:
     # fmt: on
         client = minio_storage.get_storage_client()
         _ = client.client.put_object(
-            client.benchmark, "out/file1.txt", io.BytesIO(b""), 0
+            Bucket=client.benchmark, Key="out/file1.txt", Body=b""
         )
         _ = client.client.put_object(
-            client.benchmark, "out/file2.txt", io.BytesIO(b""), 0
+            Bucket=client.benchmark, Key="out/file2.txt", Body=b""
         )
         client.set_version("0.2")
         client.create_new_version()

--- a/tests/remote/test_S3versioning.py
+++ b/tests/remote/test_S3versioning.py
@@ -7,7 +7,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from omnibenchmark.remote.S3versioning import get_s3_object_versions_and_tags
-from omnibenchmark.remote.exception import MinIOStorageBucketManipulationException
+from omnibenchmark.remote.exception import S3StorageBucketManipulationException
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +59,7 @@ class TestGetS3ObjectVersionsAndTags:
         mock_client = Mock()
         mock_client.head_bucket.side_effect = _client_error("404")
 
-        with pytest.raises(MinIOStorageBucketManipulationException) as exc_info:
+        with pytest.raises(S3StorageBucketManipulationException) as exc_info:
             get_s3_object_versions_and_tags(mock_client, "nonexistent_benchmark")
 
         assert "nonexistent_benchmark does not exist" in str(exc_info.value)

--- a/tests/remote/test_S3versioning.py
+++ b/tests/remote/test_S3versioning.py
@@ -2,10 +2,53 @@
 
 import datetime
 from unittest.mock import Mock
+
 import pytest
+from botocore.exceptions import ClientError
 
 from omnibenchmark.remote.S3versioning import get_s3_object_versions_and_tags
 from omnibenchmark.remote.exception import MinIOStorageBucketManipulationException
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_paginator(*pages):
+    """Return a mock boto3 paginator that yields the given pages."""
+    paginator = Mock()
+    paginator.paginate.return_value = list(pages)
+    return paginator
+
+
+def _version(key, vid, size=100, etag="etag1", last_modified=None):
+    """Build a boto3-style Version dict (ETag is quoted as in real responses)."""
+    return {
+        "Key": key,
+        "VersionId": vid,
+        "Size": size,
+        "ETag": f'"{etag}"',
+        "LastModified": last_modified or datetime.datetime(2025, 1, 1),
+    }
+
+
+def _delete_marker(key, vid, last_modified=None):
+    """Build a boto3-style DeleteMarker dict."""
+    return {
+        "Key": key,
+        "VersionId": vid,
+        "LastModified": last_modified or datetime.datetime(2025, 1, 1),
+    }
+
+
+def _client_error(code="404"):
+    return ClientError({"Error": {"Code": code, "Message": "Error"}}, "Op")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.short
@@ -13,48 +56,41 @@ class TestGetS3ObjectVersionsAndTags:
     """Test the get_s3_object_versions_and_tags function."""
 
     def test_raises_exception_when_bucket_does_not_exist(self):
-        """Test that function raises exception when bucket doesn't exist."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = False
+        mock_client.head_bucket.side_effect = _client_error("404")
 
         with pytest.raises(MinIOStorageBucketManipulationException) as exc_info:
             get_s3_object_versions_and_tags(mock_client, "nonexistent_benchmark")
 
         assert "nonexistent_benchmark does not exist" in str(exc_info.value)
-        mock_client.bucket_exists.assert_called_once_with("nonexistent_benchmark")
 
     def test_returns_empty_dict_when_no_objects(self):
-        """Test that function returns empty dict when bucket is empty."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-        mock_client.list_objects.return_value = iter([])
+        mock_client.get_paginator.return_value = _make_paginator({})
 
         result = get_s3_object_versions_and_tags(mock_client, "test_benchmark")
 
         assert result == {}
-        mock_client.bucket_exists.assert_called_once_with("test_benchmark")
-        mock_client.list_objects.assert_called_once_with(
-            "test_benchmark",
-            include_version=True,
-            include_user_meta=True,
-            recursive=True,
+        mock_client.get_paginator.assert_called_once_with("list_object_versions")
+        mock_client.get_paginator.return_value.paginate.assert_called_once_with(
+            Bucket="test_benchmark"
         )
 
     def test_returns_object_metadata_without_tags_in_readonly_mode(self):
-        """Test that function returns object metadata without fetching tags in readonly mode."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-
-        # Create mock object with required attributes
-        mock_object = Mock()
-        mock_object.object_name = "test_file.txt"
-        mock_object.version_id = "v1"
-        mock_object.size = 1024
-        mock_object.last_modified = datetime.datetime(2025, 1, 1, 12, 0, 0)
-        mock_object.is_delete_marker = False
-        mock_object.etag = "abc123"
-
-        mock_client.list_objects.return_value = iter([mock_object])
+        mock_client.get_paginator.return_value = _make_paginator(
+            {
+                "Versions": [
+                    _version(
+                        "test_file.txt",
+                        "v1",
+                        size=1024,
+                        etag="abc123",
+                        last_modified=datetime.datetime(2025, 1, 1, 12, 0, 0),
+                    )
+                ]
+            }
+        )
 
         result = get_s3_object_versions_and_tags(
             mock_client, "test_benchmark", readonly=True
@@ -69,27 +105,29 @@ class TestGetS3ObjectVersionsAndTags:
         )
         assert result["test_file.txt"]["v1"]["is_delete_marker"] is False
         assert result["test_file.txt"]["v1"]["etag"] == "abc123"
-
-        # Should not call get_object_tags in readonly mode
-        mock_client.get_object_tags.assert_not_called()
+        # No tagging calls in readonly mode
+        mock_client.get_object_tagging.assert_not_called()
 
     def test_returns_object_metadata_with_tags_in_readwrite_mode(self):
-        """Test that function returns object metadata with tags in read-write mode."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-
-        mock_object = Mock()
-        mock_object.object_name = "test_file.txt"
-        mock_object.version_id = "v1"
-        mock_object.size = 2048
-        mock_object.last_modified = datetime.datetime(2025, 1, 2, 14, 30, 0)
-        mock_object.is_delete_marker = False
-        mock_object.etag = "def456"
-
-        mock_client.list_objects.return_value = iter([mock_object])
-        mock_client.get_object_tags.return_value = {
-            "0.1": "valid_version",
-            "invalid_tag": "should_be_filtered",
+        mock_client.get_paginator.return_value = _make_paginator(
+            {
+                "Versions": [
+                    _version(
+                        "test_file.txt",
+                        "v1",
+                        size=2048,
+                        etag="def456",
+                        last_modified=datetime.datetime(2025, 1, 2, 14, 30, 0),
+                    )
+                ]
+            }
+        )
+        mock_client.get_object_tagging.return_value = {
+            "TagSet": [
+                {"Key": "0.1", "Value": "valid_version"},
+                {"Key": "invalid_tag", "Value": "should_be_filtered"},
+            ]
         }
 
         result = get_s3_object_versions_and_tags(
@@ -97,40 +135,27 @@ class TestGetS3ObjectVersionsAndTags:
         )
 
         assert "test_file.txt" in result
-        assert "v1" in result["test_file.txt"]
-        # Should only include valid version tags
+        # Only valid version tags are kept
         assert result["test_file.txt"]["v1"]["tags"] == {"0.1": "valid_version"}
         assert result["test_file.txt"]["v1"]["size"] == 2048
         assert result["test_file.txt"]["v1"]["etag"] == "def456"
-
-        mock_client.get_object_tags.assert_called_once_with(
-            "test_benchmark", "test_file.txt", version_id="v1"
+        mock_client.get_object_tagging.assert_called_once_with(
+            Bucket="test_benchmark", Key="test_file.txt", VersionId="v1"
         )
 
     def test_handles_multiple_versions_of_same_object(self):
-        """Test that function handles multiple versions of the same object."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-
-        # Create two versions of the same file
-        mock_object_v1 = Mock()
-        mock_object_v1.object_name = "file.txt"
-        mock_object_v1.version_id = "v1"
-        mock_object_v1.size = 100
-        mock_object_v1.last_modified = datetime.datetime(2025, 1, 1, 10, 0, 0)
-        mock_object_v1.is_delete_marker = False
-        mock_object_v1.etag = "etag1"
-
-        mock_object_v2 = Mock()
-        mock_object_v2.object_name = "file.txt"
-        mock_object_v2.version_id = "v2"
-        mock_object_v2.size = 200
-        mock_object_v2.last_modified = datetime.datetime(2025, 1, 2, 10, 0, 0)
-        mock_object_v2.is_delete_marker = False
-        mock_object_v2.etag = "etag2"
-
-        mock_client.list_objects.return_value = iter([mock_object_v1, mock_object_v2])
-        mock_client.get_object_tags.return_value = {"0.1": "tag"}
+        mock_client.get_paginator.return_value = _make_paginator(
+            {
+                "Versions": [
+                    _version("file.txt", "v1", size=100, etag="etag1"),
+                    _version("file.txt", "v2", size=200, etag="etag2"),
+                ]
+            }
+        )
+        mock_client.get_object_tagging.return_value = {
+            "TagSet": [{"Key": "0.1", "Value": "tag"}]
+        }
 
         result = get_s3_object_versions_and_tags(
             mock_client, "test_benchmark", readonly=False
@@ -145,28 +170,18 @@ class TestGetS3ObjectVersionsAndTags:
         assert result["file.txt"]["v2"]["etag"] == "etag2"
 
     def test_handles_multiple_different_objects(self):
-        """Test that function handles multiple different objects."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-
-        mock_object1 = Mock()
-        mock_object1.object_name = "file1.txt"
-        mock_object1.version_id = "v1"
-        mock_object1.size = 100
-        mock_object1.last_modified = datetime.datetime(2025, 1, 1)
-        mock_object1.is_delete_marker = False
-        mock_object1.etag = "etag1"
-
-        mock_object2 = Mock()
-        mock_object2.object_name = "file2.txt"
-        mock_object2.version_id = "v1"
-        mock_object2.size = 200
-        mock_object2.last_modified = datetime.datetime(2025, 1, 2)
-        mock_object2.is_delete_marker = False
-        mock_object2.etag = "etag2"
-
-        mock_client.list_objects.return_value = iter([mock_object1, mock_object2])
-        mock_client.get_object_tags.return_value = {"0.1": "tag"}
+        mock_client.get_paginator.return_value = _make_paginator(
+            {
+                "Versions": [
+                    _version("file1.txt", "v1", size=100, etag="etag1"),
+                    _version("file2.txt", "v1", size=200, etag="etag2"),
+                ]
+            }
+        )
+        mock_client.get_object_tagging.return_value = {
+            "TagSet": [{"Key": "0.1", "Value": "tag"}]
+        }
 
         result = get_s3_object_versions_and_tags(
             mock_client, "test_benchmark", readonly=False
@@ -178,19 +193,10 @@ class TestGetS3ObjectVersionsAndTags:
         assert result["file2.txt"]["v1"]["size"] == 200
 
     def test_skips_tag_retrieval_for_delete_markers(self):
-        """Test that function does not retrieve tags for delete markers."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-
-        mock_delete_marker = Mock()
-        mock_delete_marker.object_name = "deleted_file.txt"
-        mock_delete_marker.version_id = "v1"
-        mock_delete_marker.size = 0
-        mock_delete_marker.last_modified = datetime.datetime(2025, 1, 1)
-        mock_delete_marker.is_delete_marker = True
-        mock_delete_marker.etag = ""
-
-        mock_client.list_objects.return_value = iter([mock_delete_marker])
+        mock_client.get_paginator.return_value = _make_paginator(
+            {"DeleteMarkers": [_delete_marker("deleted_file.txt", "v1")]}
+        )
 
         result = get_s3_object_versions_and_tags(
             mock_client, "test_benchmark", readonly=False
@@ -199,53 +205,37 @@ class TestGetS3ObjectVersionsAndTags:
         assert "deleted_file.txt" in result
         assert result["deleted_file.txt"]["v1"]["tags"] == {}
         assert result["deleted_file.txt"]["v1"]["is_delete_marker"] is True
-        # Should not call get_object_tags for delete markers
-        mock_client.get_object_tags.assert_not_called()
+        # Delete markers never trigger a tagging call
+        mock_client.get_object_tagging.assert_not_called()
 
     def test_filters_out_invalid_version_tags(self):
-        """Test that function filters out tags with invalid version keys."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-
-        mock_object = Mock()
-        mock_object.object_name = "file.txt"
-        mock_object.version_id = "v1"
-        mock_object.size = 100
-        mock_object.last_modified = datetime.datetime(2025, 1, 1)
-        mock_object.is_delete_marker = False
-        mock_object.etag = "etag1"
-
-        mock_client.list_objects.return_value = iter([mock_object])
-        mock_client.get_object_tags.return_value = {
-            "0.1": "valid",
-            "1.2.3": "valid",
-            "invalid": "invalid",
-            "abc": "invalid",
-            "": "invalid",
+        mock_client.get_paginator.return_value = _make_paginator(
+            {"Versions": [_version("file.txt", "v1")]}
+        )
+        mock_client.get_object_tagging.return_value = {
+            "TagSet": [
+                {"Key": "0.1", "Value": "valid"},
+                {"Key": "1.2.3", "Value": "valid"},
+                {"Key": "invalid", "Value": "invalid"},
+                {"Key": "abc", "Value": "invalid"},
+                {"Key": "", "Value": "invalid"},
+            ]
         }
 
         result = get_s3_object_versions_and_tags(
             mock_client, "test_benchmark", readonly=False
         )
 
-        # Should only include valid version tags
         assert result["file.txt"]["v1"]["tags"] == {"0.1": "valid", "1.2.3": "valid"}
 
-    def test_handles_none_tags(self):
-        """Test that function handles None tags gracefully."""
+    def test_silently_skips_tags_on_client_error(self):
+        """ClientError from get_object_tagging is silently ignored (e.g. AccessDenied)."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-
-        mock_object = Mock()
-        mock_object.object_name = "file.txt"
-        mock_object.version_id = "v1"
-        mock_object.size = 100
-        mock_object.last_modified = datetime.datetime(2025, 1, 1)
-        mock_object.is_delete_marker = False
-        mock_object.etag = "etag1"
-
-        mock_client.list_objects.return_value = iter([mock_object])
-        mock_client.get_object_tags.return_value = None
+        mock_client.get_paginator.return_value = _make_paginator(
+            {"Versions": [_version("file.txt", "v1")]}
+        )
+        mock_client.get_object_tagging.side_effect = _client_error("AccessDenied")
 
         result = get_s3_object_versions_and_tags(
             mock_client, "test_benchmark", readonly=False
@@ -253,104 +243,65 @@ class TestGetS3ObjectVersionsAndTags:
 
         assert result["file.txt"]["v1"]["tags"] == {}
 
-    def test_handles_none_object_name(self):
-        """Test that function handles None object name gracefully."""
-        mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
-
-        mock_object = Mock()
-        mock_object.object_name = None
-        mock_object.version_id = "v1"
-        mock_object.size = 100
-        mock_object.last_modified = datetime.datetime(2025, 1, 1)
-        mock_object.is_delete_marker = False
-        mock_object.etag = "etag1"
-
-        mock_client.list_objects.return_value = iter([mock_object])
-
-        result = get_s3_object_versions_and_tags(
-            mock_client, "test_benchmark", readonly=False
-        )
-
-        # Should not call get_object_tags when object_name is None
-        mock_client.get_object_tags.assert_not_called()
-        assert None in result
-
     def test_handles_complex_scenario_with_mixed_objects(self):
-        """Test complex scenario with multiple objects, versions, and delete markers."""
+        """Multiple objects, multiple versions, and delete markers across one page."""
         mock_client = Mock()
-        mock_client.bucket_exists.return_value = True
+        mock_client.get_paginator.return_value = _make_paginator(
+            {
+                "Versions": [
+                    _version(
+                        "file1.txt",
+                        "v1",
+                        size=100,
+                        etag="etag1",
+                        last_modified=datetime.datetime(2025, 1, 1),
+                    ),
+                    _version(
+                        "file1.txt",
+                        "v2",
+                        size=150,
+                        etag="etag2",
+                        last_modified=datetime.datetime(2025, 1, 2),
+                    ),
+                    _version(
+                        "file2.txt",
+                        "v1",
+                        size=200,
+                        etag="etag3",
+                        last_modified=datetime.datetime(2025, 1, 1),
+                    ),
+                ],
+                "DeleteMarkers": [
+                    _delete_marker(
+                        "file2.txt", "v2", last_modified=datetime.datetime(2025, 1, 3)
+                    )
+                ],
+            }
+        )
 
-        # Create multiple objects with different states
-        objects = []
+        def _tags(Bucket, Key, VersionId):
+            if Key == "file1.txt":
+                return {
+                    "TagSet": [
+                        {"Key": "0.1", "Value": "tag1"},
+                        {"Key": "invalid", "Value": "x"},
+                    ]
+                }
+            if Key == "file2.txt" and VersionId == "v1":
+                return {"TagSet": [{"Key": "0.2", "Value": "tag3"}]}
+            return {"TagSet": []}
 
-        # File 1 - two versions
-        obj1_v1 = Mock()
-        obj1_v1.object_name = "file1.txt"
-        obj1_v1.version_id = "v1"
-        obj1_v1.size = 100
-        obj1_v1.last_modified = datetime.datetime(2025, 1, 1)
-        obj1_v1.is_delete_marker = False
-        obj1_v1.etag = "etag1"
-        objects.append(obj1_v1)
-
-        obj1_v2 = Mock()
-        obj1_v2.object_name = "file1.txt"
-        obj1_v2.version_id = "v2"
-        obj1_v2.size = 150
-        obj1_v2.last_modified = datetime.datetime(2025, 1, 2)
-        obj1_v2.is_delete_marker = False
-        obj1_v2.etag = "etag2"
-        objects.append(obj1_v2)
-
-        # File 2 - one version with delete marker
-        obj2_v1 = Mock()
-        obj2_v1.object_name = "file2.txt"
-        obj2_v1.version_id = "v1"
-        obj2_v1.size = 200
-        obj2_v1.last_modified = datetime.datetime(2025, 1, 1)
-        obj2_v1.is_delete_marker = False
-        obj2_v1.etag = "etag3"
-        objects.append(obj2_v1)
-
-        obj2_v2 = Mock()
-        obj2_v2.object_name = "file2.txt"
-        obj2_v2.version_id = "v2"
-        obj2_v2.size = 0
-        obj2_v2.last_modified = datetime.datetime(2025, 1, 3)
-        obj2_v2.is_delete_marker = True
-        obj2_v2.etag = ""
-        objects.append(obj2_v2)
-
-        mock_client.list_objects.return_value = iter(objects)
-
-        # Mock get_object_tags to return different tags for different calls
-        def get_tags_side_effect(bucket, obj_name, version_id):
-            if obj_name == "file1.txt":
-                return {"0.1": "tag1", "invalid": "tag2"}
-            elif obj_name == "file2.txt" and version_id == "v1":
-                return {"0.2": "tag3"}
-            return {}
-
-        mock_client.get_object_tags.side_effect = get_tags_side_effect
+        mock_client.get_object_tagging.side_effect = _tags
 
         result = get_s3_object_versions_and_tags(
             mock_client, "test_benchmark", readonly=False
         )
 
-        # Verify file1.txt has both versions with tags
-        assert "file1.txt" in result
-        assert "v1" in result["file1.txt"]
-        assert "v2" in result["file1.txt"]
         assert result["file1.txt"]["v1"]["tags"] == {"0.1": "tag1"}
         assert result["file1.txt"]["v2"]["tags"] == {"0.1": "tag1"}
         assert result["file1.txt"]["v1"]["size"] == 100
         assert result["file1.txt"]["v2"]["size"] == 150
 
-        # Verify file2.txt has both versions, including delete marker
-        assert "file2.txt" in result
-        assert "v1" in result["file2.txt"]
-        assert "v2" in result["file2.txt"]
         assert result["file2.txt"]["v1"]["tags"] == {"0.2": "tag3"}
-        assert result["file2.txt"]["v2"]["tags"] == {}  # Delete marker has no tags
+        assert result["file2.txt"]["v2"]["tags"] == {}
         assert result["file2.txt"]["v2"]["is_delete_marker"] is True

--- a/tests/remote/test_remote.py
+++ b/tests/remote/test_remote.py
@@ -1,5 +1,5 @@
-import minio
 import pytest
+from botocore.exceptions import ClientError
 
 from omnibenchmark.remote.storage import get_storage
 from omnibenchmark.remote.sizeof import sizeof_fmt
@@ -13,16 +13,17 @@ def test_get_storage_raise_exception_when_passed_invalid_benchmark_path(minio_st
 # fmt: on
     # happy path
     storage = get_storage(
-        storage_type="minio",
+        storage_api="minio",
         auth_options=minio_storage.auth_options,
         benchmark="test",
     )
     assert isinstance(storage, RemoteStorage)
 
-    # sad path
-    with pytest.raises(minio.error.S3Error):
+    # sad path: "not_existing_benchmark" contains underscores which are invalid
+    # bucket names in S3/MinIO; boto3 raises ClientError on bucket creation
+    with pytest.raises(ClientError):
         get_storage(
-            storage_type="minio",
+            storage_api="minio",
             auth_options=minio_storage.auth_options,
             benchmark="not_existing_benchmark",
         )

--- a/tests/remote/test_versioning.py
+++ b/tests/remote/test_versioning.py
@@ -10,7 +10,7 @@ from omnibenchmark.remote.versioning import (
     get_remoteversion_from_bmversion,
     prepare_csv_remoteversion_from_bmversion,
 )
-from omnibenchmark.remote.exception import MinIOStorageVersioningCorruptionException
+from omnibenchmark.remote.exception import S3StorageVersioningCorruptionException
 
 
 class FakeStorageOptions:
@@ -293,7 +293,7 @@ class TestGetSingleRemoteversionFromBmversion:
             }
         }
 
-        with pytest.raises(MinIOStorageVersioningCorruptionException) as exc_info:
+        with pytest.raises(S3StorageVersioningCorruptionException) as exc_info:
             get_single_remoteversion_from_bmversion(objdic, "file.txt", "0.1")
 
         assert "Multiple versions found" in str(exc_info.value)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     pytest-timeout==2.3.1
 commands =
     pip install -e .
-    pytest -m short --ignore=tests/cli/test_archive.py --ignore=tests/cli/test_io.py --ignore=tests/cli/test_run_benchmark.py --ignore=tests/cli/test_run_module.py --ignore=tests/io/test_MinIOStorage.py --ignore=tests/io/test_storage.py --ignore=tests/workflow/test_run_workflow.py {posargs}
+    pytest -m short --ignore=tests/cli/test_archive.py --ignore=tests/cli/test_io.py --ignore=tests/cli/test_run_benchmark.py --ignore=tests/cli/test_run_module.py --ignore=tests/io/test_S3Storage.py --ignore=tests/io/test_storage.py --ignore=tests/workflow/test_run_workflow.py {posargs}
 
 
 [testenv:py312]


### PR DESCRIPTION
## Ticket

No ticket available for this PR.

## Description

 ### Core Migration: minio → boto3                                                                                                                                                    
                                              
  The central theme of this branch is replacing the minio Python client library with boto3 for all S3 operations. Both libraries speak the same S3 wire protocol, but boto3 is more widely supported and aligns with AWS S3 natively.        
                                                                                                                                                                                   
  - refactor: migrate from minio library to boto3-only for S3 operations — The main migration commit. All minio client calls were rewritten using boto3.                           
  - fix: update storage_usage.py example for boto3 and API changes — Updated example code to reflect the new API.                                                                  
                                                                                                                                                                                   
###  Class and API Renaming                      
                                                                                                                                                                                   
  A consistent rename throughout the codebase to better reflect S3 generality (not MinIO-specific):                                                                                
                                                                                                                                                                                   
  - refactor: rename MinIOStorage → S3CompatibleStorage — Main class rename.                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                      
 ### Several structural improvements to the storage layer:                                                                                                                            
                                                                                                                                                                                   
  - refactor: introduce StorageFactory in remote/storage.py — Centralized factory for creating storage instances; easier to add new backends later.                                
  - refactor: introduce StorageService to unify storage setup — Unified how storage is configured across call sites.                                                                                                                                                                          
  - refactor: propagate out_dir, remove CLI deps from storage, drop StorageAuth — Decoupled storage layer from CLI concerns; removed StorageAuth abstraction.
  - refactor: use StorageAuth in diff and list_versions commands / refactor: eliminate double storage init in remote/files.py — Cleaned up redundant storage initialization.       
                                                                                                                                                                                   
 ### Bug Fixes                                                                                                                                                                        
                                                                                                                                                                                   
  - fix: align abstract create_new_version signature with its implementation / fix: align RemoteStorage abstract signatures with S3CompatibleStorage — Kept abstract base class
  signatures in sync with the concrete implementation.                                                                                                                             
  - fix: move .env filesystem walk out of S3config module scope — Fixed a side effect that ran at import time.                                                                     
  - fix: guard unimplemented --stage and --module CLI options — Defensive guard for CLI options that aren't yet implemented.
  - Bump minio image version — Updated the MinIO Docker image used in tests.                                                                                                       
                                                                                                                                                                                   
 ### Deprecations & Cleanup                                                                                                                                                           
                                                                                                                                                                                   
  - Introduce deprecation warnings for MinIO and ob remote policy commands — Added warnings when users pass storage_type="minio" (now "s3") or use deprecated CLI commands.        
  - chore: remove dead code and fix stale documentation — Housekeeping.                                                                                                            
 
## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

## Remarks for the reviewer:

```mermaid
flowchart TD

subgraph CLI["CLI — ob remote"]
    remote["ob remote"]
    files["ob remote files"]
    version["ob remote version"]
    policy["ob remote policy<br/>⚠️ deprecated"]

    remote --> files
    remote --> version
    remote --> policy

    files --> fl["list"]
    files --> fd["download"]
    files --> fc["checksum"]

    version --> vc["create"]
    version --> vl["list"]
    version --> vd["diff"]
end


subgraph helpers["CLI Helpers"]
    make_storage["_make_storage()<br/>remote.py"]
    files_mod["files.py<br/>list_files()<br/>download_files()<br/>checksum_files()"]
end

fl & fd & fc --> files_mod
vc & vl & vd --> make_storage


subgraph service["Service Layer"]
    StorageService["StorageService<br/>──────────────<br/>+ storage: RemoteStorage<br/>──────────────<br/>+ load_version()"]

    StorageFactory["StorageFactory<br/>──────────────<br/>+ create(api, auth, bucket)<br/>→ S3CompatibleStorage"]

    get_storage["get_storage()<br/>get_storage_from_benchmark()<br/>remote_storage_args()"]
end

make_storage --> StorageService
files_mod --> StorageService
StorageService --> StorageFactory
get_storage --> StorageFactory


subgraph storage["Storage Layer"]

    RemoteStorage["<<abstract>><br/>RemoteStorage<br/>──────────────<br/>+ benchmark: str<br/>+ version: Version<br/>+ versions: list<br/>+ files: dict<br/>+ storage_options: StorageOptions<br/>──────────────<br/>+ set_version()<br/>+ connect() ⬚<br/>+ _create_benchmark() ⬚<br/>+ _get_versions() ⬚<br/>+ create_new_version() ⬚<br/>+ load_objects() ⬚<br/>+ download_object() ⬚"]

    S3["S3CompatibleStorage<br/>──────────────<br/>+ client: boto3.S3Client<br/>+ roclient: boto3.S3Client<br/>──────────────<br/>+ connect()<br/>+ _bucket_exists()<br/>+ _create_benchmark()<br/>+ _get_versions()<br/>+ create_new_version()<br/>→ _build_version_manager()<br/>→ _persist_version()<br/>→ _upload_benchmark_config()<br/>→ _tag_and_protect_objects()<br/>→ _write_version_manifest()<br/>+ load_objects()<br/>+ download_object()"]

    RemoteStorage -.->|implements| S3
end


StorageFactory --> S3


subgraph versioning["Version Managers"]
    BVM["BenchmarkVersionManager"]
    GitBVM["GitAwareBenchmarkVersionManager"]

    BVM -.->|extends| GitBVM
end

S3 --> versioning


subgraph exceptions["Exceptions"]
    RSE["RemoteStorageException"]
    RSII["RemoteStorageInvalidInputException"]
    S3SE["S3StorageException"]
    S3CE["S3StorageConnectionException"]
    S3BE["S3StorageBucketManipulationException"]
    S3VE["S3StorageVersioningCorruptionException"]

    RSE --> RSII
    RSE --> S3SE
    S3SE --> S3CE
    S3SE --> S3BE
    S3SE --> S3VE
end

S3 -.->|raises| exceptions
```