### PR TITLE
fix: cache refresh no longer returns stale branch commits

### DIFF
--- a/omnibenchmark/git/cache.py
+++ b/omnibenchmark/git/cache.py
@@ -367,13 +367,54 @@ def get_or_update_cached_repo(repo_url: str, cache_dir: Optional[Path] = None) -
         if repo_cache_dir.exists():
             # Update existing repository
             try:
-                repo = cast(Repo, porcelain.open_repo(str(repo_cache_dir)))
                 logging.info(f"Updating cached repository at {repo_cache_dir}")
-                # Fetch all updates from remote
-                # Note: porcelain.fetch by default fetches all refs
-                porcelain.fetch(
-                    repo, repo_url, errstream=_DEVNULL, outstream=_DEVNULL_TEXT
-                )
+                # Use the repo as a context manager so it is closed (and any
+                # in-memory ref caches are released) before callers open their
+                # own handle.  Fetch by remote name ("origin") so dulwich
+                # applies the configured refspec and advances
+                # refs/remotes/origin/*; fetching by URL alone retrieves
+                # objects but does not update tracking refs.
+                with cast(Repo, porcelain.open_repo(str(repo_cache_dir))) as repo:
+                    porcelain.fetch(
+                        repo, "origin", errstream=_DEVNULL, outstream=_DEVNULL_TEXT
+                    )
+
+                    # Update the working tree to match the remote tracking branch
+                    # so the cache directory reflects the latest fetched state
+                    try:
+                        from dulwich.index import build_index_from_tree
+                        from dulwich.objectspec import parse_commit
+
+                        # Get the current branch from HEAD
+                        head_ref = repo.refs.read_ref(Ref(b"HEAD"))
+                        if head_ref and head_ref.startswith(b"ref: refs/heads/"):
+                            local_branch = head_ref[len(b"ref: refs/heads/") :]
+                            remote_ref = Ref(b"refs/remotes/origin/" + local_branch)
+
+                            if remote_ref in repo.refs:
+                                # Update local branch to match remote tracking branch
+                                remote_sha = repo.refs[remote_ref]
+                                repo.refs[Ref(b"refs/heads/" + local_branch)] = (
+                                    remote_sha
+                                )
+
+                                # Update working tree to the new HEAD
+                                commit_obj = parse_commit(repo, remote_sha)
+                                # Use temp index file since we don't want to keep it
+                                with tempfile.TemporaryDirectory() as _tmp:
+                                    build_index_from_tree(
+                                        str(repo_cache_dir),
+                                        str(Path(_tmp) / "index"),
+                                        repo.object_store,
+                                        commit_obj.tree,
+                                    )
+                                logging.debug(
+                                    f"Updated cache working tree to {remote_sha.hex()[:7]}"
+                                )
+                    except Exception as e:
+                        logging.debug(f"Could not update working tree after fetch: {e}")
+                        # Non-fatal: remote refs are updated, which is sufficient
+
                 return repo_cache_dir
             except (NotGitRepository, Exception) as e:
                 logging.warning(f"Cached repo appears corrupt: {e}. Re-cloning.")
@@ -436,42 +477,48 @@ def checkout_to_work_dir(
         """dulwich ShaFile.id is 40-byte ASCII hex; repo.head() may be 20-byte binary."""
         return sha.hex() if len(sha) == 20 else sha.decode("ascii")
 
-    try:
-        commit_obj = parse_commit(cached_repo, ref.encode("ascii"))
-        logging.debug(f"Resolved {ref} to {_id_to_str(commit_obj.id)}")
-    except KeyError:
-        commit_obj = None
+    commit_obj = None
 
-        # Try remote tracking branch: refs/remotes/origin/{ref}
-        remote_ref = Ref(f"refs/remotes/origin/{ref}".encode("ascii"))
-        if remote_ref in cached_repo.refs:
-            sha = cached_repo.refs[remote_ref]
-            commit_obj = parse_commit(cached_repo, sha)
-            logging.debug(
-                f"Resolved {ref} via refs/remotes/origin/{ref} to {_id_to_str(commit_obj.id)}"
+    # Check remote tracking branch first.
+    # dulwich's parse_commit(repo, b"main") resolves via refs/heads/main (the
+    # local branch), which is NOT updated by fetch — only refs/remotes/origin/*
+    # is advanced.  Checking the remote tracking ref first ensures we always
+    # return the commit that the remote HEAD points to after a fresh fetch.
+    remote_ref = Ref(f"refs/remotes/origin/{ref}".encode("ascii"))
+    if remote_ref in cached_repo.refs:
+        sha = cached_repo.refs[remote_ref]
+        commit_obj = parse_commit(cached_repo, sha)
+        logging.debug(
+            f"Resolved {ref} via refs/remotes/origin/{ref} to {_id_to_str(commit_obj.id)}"
+        )
+
+    # Direct parse: full commit hash, tag, or any other ref dulwich understands.
+    if commit_obj is None:
+        try:
+            commit_obj = parse_commit(cached_repo, ref.encode("ascii"))
+            logging.debug(f"Resolved {ref} to {_id_to_str(commit_obj.id)}")
+        except KeyError:
+            pass
+
+    # Short hash expansion — object_store yields 20-byte binary SHAs
+    if commit_obj is None and re.match(r"^[0-9a-f]{4,39}$", ref, re.IGNORECASE):
+        ref_prefix = ref.lower()
+        matching = [
+            obj_id.hex()
+            for obj_id in cached_repo.object_store
+            if obj_id.hex().startswith(ref_prefix)
+        ]
+        if len(matching) == 1:
+            commit_obj = parse_commit(cached_repo, matching[0].encode("ascii"))
+            logging.debug(f"Expanded short hash {ref} to {_id_to_str(commit_obj.id)}")
+        elif len(matching) > 1:
+            raise RuntimeError(
+                f"Reference '{ref}' is ambiguous (matches {len(matching)} commits)"
+                f" in repository {repo_url}"
             )
 
-        # Short hash expansion — object_store yields 20-byte binary SHAs
-        if commit_obj is None and re.match(r"^[0-9a-f]{4,39}$", ref, re.IGNORECASE):
-            ref_prefix = ref.lower()
-            matching = [
-                obj_id.hex()
-                for obj_id in cached_repo.object_store
-                if obj_id.hex().startswith(ref_prefix)
-            ]
-            if len(matching) == 1:
-                commit_obj = parse_commit(cached_repo, matching[0].encode("ascii"))
-                logging.debug(
-                    f"Expanded short hash {ref} to {_id_to_str(commit_obj.id)}"
-                )
-            elif len(matching) > 1:
-                raise RuntimeError(
-                    f"Reference '{ref}' is ambiguous (matches {len(matching)} commits)"
-                    f" in repository {repo_url}"
-                )
-
-        if commit_obj is None:
-            raise RuntimeError(f"Reference '{ref}' not found in repository {repo_url}")
+    if commit_obj is None:
+        raise RuntimeError(f"Reference '{ref}' not found in repository {repo_url}")
 
     # Write the commit's tree directly from the object store to work_dir.
     # build_index_from_tree needs an index path — we use a temp file and

--- a/tests/git/test_cache_refresh.py
+++ b/tests/git/test_cache_refresh.py
@@ -1,0 +1,260 @@
+"""Integration tests for git cache refresh and branch-tracking behaviour.
+
+These tests exercise the scenario that caused reported flakiness: a module
+repository receives new commits after the local cache was first populated, and
+the next resolution must return the *new* commit — not the stale cached one.
+
+Strategy
+--------
+A local directory acts as the "remote" (dulwich can clone/fetch from plain
+filesystem paths without a git server).  We patch only ``parse_repo_url`` so
+that ``get_or_update_cached_repo`` maps our local path to a predictable cache
+key; every other code path — the fetch, the object-store lookup, the
+``build_index_from_tree`` write — runs unmodified.
+
+Tests
+-----
+* ``test_checkout_reflects_new_commit_after_push``
+      Main regression: second checkout returns the new SHA and new content.
+
+* ``test_old_work_dir_unchanged_after_cache_update``
+      The first work directory must not be mutated when the cache is refreshed.
+
+* ``test_pinned_commit_still_resolves_after_cache_update``
+      After new commits arrive, checking out the old pinned SHA still works and
+      returns the original content.
+
+* ``test_get_or_update_cached_repo_fetches_new_commits``
+      Focused test of the fetch step: verifies that ``get_or_update_cached_repo``
+      brings new objects into the cache so they can later be resolved.
+
+* ``test_local_copy_tracks_head_after_new_commit``
+      ``copy_local_to_work_dir`` (the non-cache, local-path code path) must also
+      reflect HEAD after a new commit.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from dulwich import porcelain
+from dulwich.repo import Repo
+
+from omnibenchmark.git.cache import (
+    checkout_to_work_dir,
+    copy_local_to_work_dir,
+    get_or_update_cached_repo,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_AUTHOR = b"Test User <test@example.com>"
+_CACHE_KEY = "local/test/origin"  # stable key returned by the patched parse_repo_url
+
+
+def _commit(repo_dir, filename, content, message):
+    """Write *filename* with *content*, stage it, and create a commit.
+
+    Returns the 40-character hex SHA string of the new commit.
+    """
+    (repo_dir / filename).write_text(content)
+    porcelain.add(str(repo_dir), paths=[filename])
+    sha_bytes = porcelain.commit(
+        str(repo_dir),
+        message=message if isinstance(message, bytes) else message.encode(),
+        author=_AUTHOR,
+        committer=_AUTHOR,
+    )
+    return sha_bytes.decode("ascii")
+
+
+def _head_sha(repo_dir):
+    """Return the 40-char HEAD SHA of *repo_dir*."""
+    with Repo(str(repo_dir)) as r:
+        return r.head().decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def local_remote_with_cache(tmp_path):
+    """Return *(origin, cache_dir, fake_url, initial_sha)*.
+
+    * ``origin``     — git repo used as the "remote"; commits here simulate
+                       upstream pushes.
+    * ``cache_dir``  — pre-populated cache (a clone of *origin* at
+                       ``cache_dir / _CACHE_KEY``).
+    * ``fake_url``   — the string passed as *repo_url* to the cache functions;
+                       it is the local path of *origin* so dulwich can
+                       clone/fetch from it, but ``parse_repo_url`` is patched
+                       to map it to ``_CACHE_KEY``.
+    * ``initial_sha``— 40-char hex SHA of the first commit in *origin*.
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    porcelain.init(str(origin))
+    # Ensure the default branch is named "main" regardless of system git config.
+    with Repo(str(origin)) as _r:
+        _r.refs.set_symbolic_ref(b"HEAD", b"refs/heads/main")
+    initial_sha = _commit(origin, "sentinel.txt", "v1", b"initial: v1")
+
+    # Populate cache exactly as get_or_update_cached_repo does on first call.
+    cache_repo = tmp_path / "cache" / _CACHE_KEY
+    cache_repo.parent.mkdir(parents=True)
+    porcelain.clone(str(origin), str(cache_repo), checkout=True)
+
+    return origin, tmp_path / "cache", str(origin), initial_sha
+
+
+# ---------------------------------------------------------------------------
+# Patch helper
+# ---------------------------------------------------------------------------
+
+
+def _patched_checkout(fake_url, ref, work_dir, cache_dir):
+    """Call checkout_to_work_dir with parse_repo_url patched to _CACHE_KEY."""
+    with patch(
+        "omnibenchmark.git.cache.parse_repo_url",
+        return_value=_CACHE_KEY,
+    ):
+        return checkout_to_work_dir(fake_url, ref, work_dir, cache_dir)
+
+
+# ---------------------------------------------------------------------------
+# Tests: cache refresh via two-tier system
+# ---------------------------------------------------------------------------
+
+
+class TestCacheRefreshTracksBranch:
+    """checkout_to_work_dir must fetch new commits and reflect them in the work dir."""
+
+    def test_checkout_reflects_new_commit_after_push(
+        self, local_remote_with_cache, tmp_path
+    ):
+        """Second checkout on the same branch returns the new SHA and file content."""
+        origin, cache_dir, fake_url, _initial_sha = local_remote_with_cache
+
+        # First checkout — sees v1
+        work_v1 = tmp_path / "work_v1"
+        _, sha1 = _patched_checkout(fake_url, "main", work_v1, cache_dir)
+
+        assert (work_v1 / "sentinel.txt").read_text() == "v1"
+
+        # Push a new commit to origin (simulates upstream activity)
+        sha2_expected = _commit(
+            origin,
+            "sentinel.txt",
+            "SENTINEL=cache_refresh_test_v2",
+            b"feat: sentinel v2",
+        )
+
+        # Second checkout — cache must fetch and resolve to the new commit
+        work_v2 = tmp_path / "work_v2"
+        _, sha2 = _patched_checkout(fake_url, "main", work_v2, cache_dir)
+
+        assert sha2 != sha1
+        assert sha2 == sha2_expected
+        assert (
+            work_v2 / "sentinel.txt"
+        ).read_text() == "SENTINEL=cache_refresh_test_v2"
+
+    def test_old_work_dir_unchanged_after_cache_update(
+        self, local_remote_with_cache, tmp_path
+    ):
+        """The first work directory must not be mutated when the cache is refreshed."""
+        origin, cache_dir, fake_url, _ = local_remote_with_cache
+
+        work_v1 = tmp_path / "work_v1"
+        _patched_checkout(fake_url, "main", work_v1, cache_dir)
+
+        _commit(origin, "sentinel.txt", "v2 content", b"feat: v2")
+
+        work_v2 = tmp_path / "work_v2"
+        _patched_checkout(fake_url, "main", work_v2, cache_dir)
+
+        # v1 work dir must still contain the original content
+        assert (work_v1 / "sentinel.txt").read_text() == "v1"
+
+    def test_pinned_commit_still_resolves_after_cache_update(
+        self, local_remote_with_cache, tmp_path
+    ):
+        """After new commits arrive, the old pinned SHA still resolves correctly."""
+        origin, cache_dir, fake_url, _ = local_remote_with_cache
+
+        # Record sha1 via an initial checkout
+        work_pin_ref = tmp_path / "work_pin_ref"
+        _, sha1 = _patched_checkout(fake_url, "main", work_pin_ref, cache_dir)
+
+        # Push more commits so the cache is refreshed on the next call
+        _commit(origin, "sentinel.txt", "SENTINEL=newer_content", b"feat: newer")
+        _commit(origin, "extra.txt", "extra", b"chore: add extra file")
+
+        # Checkout the old pinned SHA — the old object must still be in the store
+        work_pinned = tmp_path / "work_pinned"
+        _, resolved = _patched_checkout(fake_url, sha1, work_pinned, cache_dir)
+
+        assert resolved == sha1
+        assert (work_pinned / "sentinel.txt").read_text() == "v1"
+        assert not (work_pinned / "extra.txt").exists()
+
+
+class TestGetOrUpdateCachedRepoFetches:
+    """get_or_update_cached_repo must bring new objects into the cache."""
+
+    def test_fetch_updates_remote_tracking_ref(self, local_remote_with_cache, tmp_path):
+        """After a new commit on origin, the remote-tracking ref in the cache advances."""
+        origin, cache_dir, fake_url, _ = local_remote_with_cache
+
+        sha_new = _commit(origin, "sentinel.txt", "v2", b"feat: v2")
+
+        with patch(
+            "omnibenchmark.git.cache.parse_repo_url",
+            return_value=_CACHE_KEY,
+        ):
+            cache_path = get_or_update_cached_repo(fake_url, cache_dir)
+
+        # The remote-tracking branch in the cache should now point to sha_new
+        with Repo(str(cache_path)) as cached_repo:
+            remote_ref = b"refs/remotes/origin/main"
+            assert remote_ref in cached_repo.refs
+            cached_sha = cached_repo.refs[remote_ref].decode("ascii")
+
+        assert cached_sha == sha_new
+
+
+# ---------------------------------------------------------------------------
+# Tests: local copy path (no cache involved)
+# ---------------------------------------------------------------------------
+
+
+class TestLocalCopyTracksHead:
+    """copy_local_to_work_dir must always reflect the current HEAD of the local repo."""
+
+    def test_reflects_new_commit_after_local_commit(self, tmp_path):
+        """New commit in the local repo is picked up by a subsequent copy."""
+        repo_dir = tmp_path / "local_repo"
+        repo_dir.mkdir()
+        porcelain.init(str(repo_dir))
+        sha1 = _commit(repo_dir, "sentinel.txt", "v1", b"initial")
+
+        work_v1 = tmp_path / "work_v1"
+        _, resolved1 = copy_local_to_work_dir(repo_dir, work_v1)
+        assert resolved1 == sha1
+        assert (work_v1 / "sentinel.txt").read_text() == "v1"
+
+        sha2 = _commit(
+            repo_dir, "sentinel.txt", "SENTINEL=local_head_test_v2", b"feat: v2"
+        )
+
+        work_v2 = tmp_path / "work_v2"
+        _, resolved2 = copy_local_to_work_dir(repo_dir, work_v2)
+
+        assert resolved2 == sha2
+        assert resolved2 != resolved1
+        assert (work_v2 / "sentinel.txt").read_text() == "SENTINEL=local_head_test_v2"
+        # v1 work dir is independent
+        assert (work_v1 / "sentinel.txt").read_text() == "v1"

--- a/tests/git/test_cache_unit.py
+++ b/tests/git/test_cache_unit.py
@@ -1,0 +1,228 @@
+"""Short unit tests for git/cache.py — no real git operations, all dulwich mocked."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from dulwich.refs import Ref
+
+from omnibenchmark.git.cache import checkout_to_work_dir, get_or_update_cached_repo
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _commit_obj(hex_sha: str):
+    """Minimal mock dulwich commit object whose .id is 20-byte binary."""
+    obj = MagicMock()
+    obj.id = bytes.fromhex(hex_sha)
+    obj.tree = b"\x00" * 20
+    return obj
+
+
+_SHA1 = "a" * 40
+
+
+def _checkout(ref, refs_dict, object_store_ids, parse_side_effect, tmp_path):
+    """
+    Run checkout_to_work_dir with all dulwich calls replaced by mocks.
+
+    parse_side_effect is passed directly as the side_effect of the
+    dulwich.objectspec.parse_commit mock, so it can be a list of
+    return-values / exceptions or a single exception class.
+    """
+    mock_repo = MagicMock()
+    mock_repo.refs = refs_dict
+    mock_repo.object_store = object_store_ids
+
+    work_dir = tmp_path / "work"
+    cache_dir = tmp_path / "cache"
+
+    with (
+        patch(
+            "omnibenchmark.git.cache.get_or_update_cached_repo",
+            return_value=cache_dir,
+        ),
+        patch(
+            "omnibenchmark.git.cache.porcelain.open_repo",
+            return_value=mock_repo,
+        ),
+        patch(
+            "dulwich.objectspec.parse_commit",
+            side_effect=parse_side_effect,
+        ),
+        patch("dulwich.index.build_index_from_tree"),
+    ):
+        return checkout_to_work_dir("fake://url", ref, work_dir, cache_dir)
+
+
+# ── ref resolution ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.short
+class TestCheckoutRefResolution:
+    """Unit tests for the three-stage ref resolution in checkout_to_work_dir."""
+
+    def test_remote_tracking_ref_resolves(self, tmp_path):
+        """refs/remotes/origin/<branch> is used when present."""
+        sha_bytes = bytes.fromhex(_SHA1)
+        commit = _commit_obj(_SHA1)
+        refs = {Ref(b"refs/remotes/origin/main"): sha_bytes}
+
+        _, sha = _checkout("main", refs, [], [commit], tmp_path)
+
+        assert sha == _SHA1
+
+    def test_direct_parse_used_when_no_remote_ref(self, tmp_path):
+        """Full SHA with no matching remote tracking ref resolves via direct parse."""
+        commit = _commit_obj(_SHA1)
+
+        _, sha = _checkout(_SHA1, {}, [], [commit], tmp_path)
+
+        assert sha == _SHA1
+
+    def test_direct_parse_keyerror_falls_through(self, tmp_path):
+        """KeyError from direct parse is silently swallowed; short hash path runs next."""
+        sha_bytes = bytes.fromhex(_SHA1)
+        commit = _commit_obj(_SHA1)
+        # First call (direct parse) raises KeyError; second call (short-hash) succeeds.
+        _, sha = _checkout(
+            _SHA1[:8],
+            {},
+            [sha_bytes],
+            [KeyError, commit],
+            tmp_path,
+        )
+
+        assert sha == _SHA1
+
+    def test_short_hash_expansion(self, tmp_path):
+        """A 7-char hex prefix resolves via object_store scan."""
+        sha_bytes = bytes.fromhex(_SHA1)
+        commit = _commit_obj(_SHA1)
+
+        _, sha = _checkout(
+            _SHA1[:7],
+            {},
+            [sha_bytes],
+            [KeyError, commit],
+            tmp_path,
+        )
+
+        assert sha == _SHA1
+
+    def test_ambiguous_short_hash_raises(self, tmp_path):
+        """Two objects sharing the same prefix → RuntimeError 'ambiguous'."""
+        # Both SHAs start with "abcd" (≥4 chars required by the regex guard)
+        sha_a = "abcd" + "00" * 18
+        sha_b = "abcd" + "ff" * 18
+
+        with pytest.raises(RuntimeError, match="ambiguous"):
+            _checkout(
+                "abcd",
+                {},
+                [bytes.fromhex(sha_a), bytes.fromhex(sha_b)],
+                KeyError,
+                tmp_path,
+            )
+
+    def test_unknown_ref_raises(self, tmp_path):
+        """A ref that matches nothing raises RuntimeError 'not found'."""
+        with pytest.raises(RuntimeError, match="not found"):
+            _checkout(
+                "nonexistent-branch",
+                {},
+                [],
+                KeyError,
+                tmp_path,
+            )
+
+    def test_existing_work_dir_is_replaced(self, tmp_path):
+        """If work_dir already exists its contents are replaced by the checkout."""
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        stale = work_dir / "stale.txt"
+        stale.write_text("old")
+
+        sha_bytes = bytes.fromhex(_SHA1)
+        commit = _commit_obj(_SHA1)
+        refs = {Ref(b"refs/remotes/origin/main"): sha_bytes}
+
+        mock_repo = MagicMock()
+        mock_repo.refs = refs
+        mock_repo.object_store = []
+        cache_dir = tmp_path / "cache"
+
+        with (
+            patch(
+                "omnibenchmark.git.cache.get_or_update_cached_repo",
+                return_value=cache_dir,
+            ),
+            patch(
+                "omnibenchmark.git.cache.porcelain.open_repo",
+                return_value=mock_repo,
+            ),
+            patch("dulwich.objectspec.parse_commit", return_value=commit),
+            patch("dulwich.index.build_index_from_tree"),
+        ):
+            checkout_to_work_dir("fake://url", "main", work_dir, cache_dir)
+
+        assert not stale.exists()
+
+
+# ── corrupt cache fallback ─────────────────────────────────────────────────────
+
+
+@pytest.mark.short
+class TestGetOrUpdateCachedRepo:
+    """Unit tests for get_or_update_cached_repo error paths."""
+
+    def test_corrupt_cache_triggers_reclone(self, tmp_path):
+        """If fetch raises, the corrupt dir is removed and the repo is re-cloned."""
+        cache_dir = tmp_path / "cache"
+        repo_cache_dir = cache_dir / "local" / "test" / "origin"
+        repo_cache_dir.mkdir(parents=True)
+        sentinel = repo_cache_dir / "sentinel"
+        sentinel.write_text("corrupt")
+
+        with (
+            patch(
+                "omnibenchmark.git.cache.parse_repo_url",
+                return_value="local/test/origin",
+            ),
+            patch(
+                "omnibenchmark.git.cache.porcelain.open_repo",
+                side_effect=Exception("corrupt repo"),
+            ),
+            patch("omnibenchmark.git.cache.porcelain.clone") as mock_clone,
+        ):
+            get_or_update_cached_repo("fake://url", cache_dir)
+
+        # The corrupt directory must have been wiped before re-cloning.
+        assert not sentinel.exists()
+        mock_clone.assert_called_once()
+
+    def test_clone_failure_cleans_partial_dir_and_raises(self, tmp_path):
+        """If the clone partially creates the target dir then fails, it is cleaned up."""
+        cache_dir = tmp_path / "cache"
+        target = cache_dir / "local" / "test" / "origin"
+
+        def _partial_clone(source, target, **kwargs):
+            Path(target).mkdir(parents=True, exist_ok=True)
+            (Path(target) / "partial").write_text("debris")
+            raise Exception("network error")
+
+        with (
+            patch(
+                "omnibenchmark.git.cache.parse_repo_url",
+                return_value="local/test/origin",
+            ),
+            patch(
+                "omnibenchmark.git.cache.porcelain.clone",
+                side_effect=_partial_clone,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to clone"):
+                get_or_update_cached_repo("fake://url", cache_dir)
+
+        assert not target.exists()


### PR DESCRIPTION
Two bugs prevented the two-tier cache from tracking upstream branch changes after the initial clone:

1. `get_or_update_cached_repo` called `porcelain.fetch(repo, url)` which fetches objects but does not update `refs/remotes/origin/*`.  Changed to `porcelain.fetch(repo, "origin")` so dulwich applies the configured refspec and advances the remote tracking refs.  Also close the Repo via a context manager before returning, so no in-memory state leaks.

2. `checkout_to_work_dir` tried `parse_commit(cached_repo, b"<branch>")` first.  dulwich resolves a bare branch name against `refs/heads/<branch>` (the local branch, which is NOT updated by fetch), so the function returned the pre-fetch commit and never reached the remote tracking ref. Fixed by checking `refs/remotes/origin/<ref>` first, then falling back to direct parse for commit hashes and tags.

New test file `tests/git/test_cache_refresh.py` covers the full cache-refresh pipeline without network access by using a local directory as the "remote" and patching only `parse_repo_url` for cache key routing.


## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.

