### PR TITLE
fix: raise warning for disjoint keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This document records all notable changes to `omnibenchmark`.
 This project adheres to [Semantic Versioning](https://semver.org/) and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
  
+## [0.5.1](UNRELEASED) ()
+
+- fix: raise warning for disjoint keys (Closes: #313)
+
 ## [0.5.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.0) (Apr 23th 2026)
 
 - feat: add `--compact-params` and `--no-show-params` options to `ob describe topology` (#299)

--- a/omnibenchmark/cli/create.py
+++ b/omnibenchmark/cli/create.py
@@ -522,9 +522,7 @@ def _generate_module_yaml_snippet(
         )
         snippet_lines.append("    repository:")
         snippet_lines.append(f"      url: {module_entry['repository']['url']}")
-        snippet_lines.append(
-            f"      commit: \"{module_entry['repository']['commit']}\""
-        )
+        snippet_lines.append(f'      commit: "{module_entry["repository"]["commit"]}"')
 
         snippet = "\n".join(snippet_lines)
         return snippet

--- a/omnibenchmark/cli/create.py
+++ b/omnibenchmark/cli/create.py
@@ -715,7 +715,7 @@ def create_benchmark(
             sys.exit(1)
 
         # Run copier
-        copier_data = {"omnibenchmark_version": __version__}
+        copier_data: Dict[str, Any] = {"omnibenchmark_version": __version__}
 
         # If non-interactive, include provided parameters and enable defaults
         if non_interactive:
@@ -991,7 +991,10 @@ def create_module(
             # Use provided parameters for non-interactive mode
             module_data = {
                 "module_name": name,
-                "module_title": name.replace("-", " ").replace("_", " ").title(),
+                "module_title": (name or "")
+                .replace("-", " ")
+                .replace("_", " ")
+                .title(),
                 "author_name": author_name,
                 "author_email": author_email,
                 "license": license or "GPL-3.0-or-later",

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -422,14 +422,19 @@ def _warn_if_disjoint_parameter_keys(
     parameters: Optional[List["Parameter"]],
     line_map: Optional[Dict[str, int]] = None,
 ) -> None:
-    """Warn when a parameter list has items with completely disjoint key sets.
+    """Warn when parameter list items don't all share the same key set.
 
-    This catches the common mistake of using separate list items instead of a
-    single item with multiple keys:
+    The only safe pattern is items with identical key sets (a grid of values):
+        - method: genie     <- same keys in every item
+          threshold: 0.1
+        - method: other
+          threshold: 0.5
 
-      Wrong (disjoint):           Correct (combined):
-        - selection_type: [...]     - selection_type: [...]
-        - number_selected: 2000       number_selected: 2000
+    Both fully-disjoint and partially-overlapping key sets are suspicious:
+        Wrong (disjoint):           Wrong (partial overlap):
+          - selection_type: [...]     - filter_type: [...]
+          - number_selected: 2000     - filter_type: [...]
+                                        this: ["a", "b"]
     """
     if parameters is None or len(parameters) < 2:
         return
@@ -438,17 +443,13 @@ def _warn_if_disjoint_parameter_keys(
     if len(param_items) < 2:
         return
 
-    key_sets = [set(p.params.keys()) for p in param_items if p.params is not None]
-    key_counts: Dict[str, int] = {}
-    for ks in key_sets:
-        for k in ks:
-            key_counts[k] = key_counts.get(k, 0) + 1
+    key_sets = [frozenset(p.params.keys()) for p in param_items]
 
-    if not all(count == 1 for count in key_counts.values()):
+    if len(set(key_sets)) == 1:
         return
 
-    all_keys = sorted(key_counts.keys())
     per_item = [sorted(ks) for ks in key_sets]
+    all_keys = sorted(set().union(*key_sets))
 
     line_hint = ""
     if line_map:
@@ -463,9 +464,8 @@ def _warn_if_disjoint_parameter_keys(
     indent = "      "
     sys.stderr.write(
         f"{BOLD}{YELLOW}WARN{RESET}{YELLOW}: parameter list has {len(param_items)} items "
-        f"with disjoint keys {per_item}{line_hint}.\n"
-        f"{indent}This creates {len(param_items)} separate runs each with different "
-        f"parameter names.\n"
+        f"with inconsistent keys {per_item}{line_hint}.\n"
+        f"{indent}Each item should have the same set of keys (a grid of values).\n"
         f"{indent}Did you mean to combine them under one item?\n"
         f"{indent}  Use:  - {' / '.join(all_keys)}: ...\n"
         f"{indent}  Instead of separate '- ' entries.{RESET}\n"

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -417,6 +417,42 @@ class SoftwareEnvironmentReference(BaseModel):
     )
 
 
+def _warn_if_disjoint_parameter_keys(parameters: Optional[List["Parameter"]]) -> None:
+    """Warn when a parameter list has items with completely disjoint key sets.
+
+    This catches the common mistake of using separate list items instead of a
+    single item with multiple keys:
+
+      Wrong (disjoint):           Correct (combined):
+        - selection_type: [...]     - selection_type: [...]
+        - number_selected: 2000       number_selected: 2000
+    """
+    if parameters is None or len(parameters) < 2:
+        return
+
+    param_items = [p for p in parameters if p.params is not None]
+    if len(param_items) < 2:
+        return
+
+    key_sets = [set(p.params.keys()) for p in param_items]
+    key_counts: Dict[str, int] = {}
+    for ks in key_sets:
+        for k in ks:
+            key_counts[k] = key_counts.get(k, 0) + 1
+
+    if all(count == 1 for count in key_counts.values()):
+        all_keys = sorted(key_counts.keys())
+        per_item = [sorted(ks) for ks in key_sets]
+        warnings.warn(
+            f"Parameter list has {len(param_items)} items with completely disjoint keys "
+            f"{per_item}. This expands to {len(param_items)} separate runs each with "
+            f"different parameter names. If you meant a single run with all parameters "
+            f"combined, merge them under one list item with keys {all_keys}.",
+            UserWarning,
+            stacklevel=4,
+        )
+
+
 class Module(DescribableEntity, SoftwareEnvironmentReference):
     """Module definition."""
 
@@ -440,6 +476,14 @@ class Module(DescribableEntity, SoftwareEnvironmentReference):
         description="Resource requirements (overrides stage-level resources)",
     )
 
+    @field_validator("parameters")
+    @classmethod
+    def warn_disjoint_parameter_keys(
+        cls, v: Optional[List[Parameter]]
+    ) -> Optional[List[Parameter]]:
+        _warn_if_disjoint_parameter_keys(v)
+        return v
+
     def has_environment_reference(self, env_id: Optional[str] = None) -> bool:
         """Check if module has a software environment reference."""
         if env_id is None:
@@ -462,6 +506,14 @@ class MetricCollector(DescribableEntity, SoftwareEnvironmentReference):
     resources: Optional[Resources] = Field(
         None, description="Resource requirements for this collector"
     )
+
+    @field_validator("parameters")
+    @classmethod
+    def warn_disjoint_parameter_keys(
+        cls, v: Optional[List[Parameter]]
+    ) -> Optional[List[Parameter]]:
+        _warn_if_disjoint_parameter_keys(v)
+        return v
 
     def has_environment_reference(self, env_id: Optional[str] = None) -> bool:
         """Check if metric collector has a software environment reference."""

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -443,7 +443,7 @@ def _warn_if_disjoint_parameter_keys(
     if len(param_items) < 2:
         return
 
-    key_sets = [frozenset(p.params.keys()) for p in param_items]
+    key_sets = [frozenset(p.params.keys()) for p in param_items if p.params is not None]
 
     if len(set(key_sets)) == 1:
         return

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 import warnings
 from enum import Enum
 from pathlib import Path
@@ -417,7 +418,10 @@ class SoftwareEnvironmentReference(BaseModel):
     )
 
 
-def _warn_if_disjoint_parameter_keys(parameters: Optional[List["Parameter"]]) -> None:
+def _warn_if_disjoint_parameter_keys(
+    parameters: Optional[List["Parameter"]],
+    line_map: Optional[Dict[str, int]] = None,
+) -> None:
     """Warn when a parameter list has items with completely disjoint key sets.
 
     This catches the common mistake of using separate list items instead of a
@@ -440,17 +444,32 @@ def _warn_if_disjoint_parameter_keys(parameters: Optional[List["Parameter"]]) ->
         for k in ks:
             key_counts[k] = key_counts.get(k, 0) + 1
 
-    if all(count == 1 for count in key_counts.values()):
-        all_keys = sorted(key_counts.keys())
-        per_item = [sorted(ks) for ks in key_sets]
-        warnings.warn(
-            f"Parameter list has {len(param_items)} items with completely disjoint keys "
-            f"{per_item}. This expands to {len(param_items)} separate runs each with "
-            f"different parameter names. If you meant a single run with all parameters "
-            f"combined, merge them under one list item with keys {all_keys}.",
-            UserWarning,
-            stacklevel=4,
-        )
+    if not all(count == 1 for count in key_counts.values()):
+        return
+
+    all_keys = sorted(key_counts.keys())
+    per_item = [sorted(ks) for ks in key_sets]
+
+    line_hint = ""
+    if line_map:
+        for key in line_map:
+            if "parameters[0]" in key:
+                line_hint = f" (line {line_map[key]})"
+                break
+
+    YELLOW = "\033[33m"
+    BOLD = "\033[1m"
+    RESET = "\033[0m"
+    indent = "      "
+    sys.stderr.write(
+        f"{BOLD}{YELLOW}WARN{RESET}{YELLOW}: parameter list has {len(param_items)} items "
+        f"with disjoint keys {per_item}{line_hint}.\n"
+        f"{indent}This creates {len(param_items)} separate runs each with different "
+        f"parameter names.\n"
+        f"{indent}Did you mean to combine them under one item?\n"
+        f"{indent}  Use:  - {' / '.join(all_keys)}: ...\n"
+        f"{indent}  Instead of separate '- ' entries.{RESET}\n"
+    )
 
 
 class Module(DescribableEntity, SoftwareEnvironmentReference):
@@ -479,9 +498,10 @@ class Module(DescribableEntity, SoftwareEnvironmentReference):
     @field_validator("parameters")
     @classmethod
     def warn_disjoint_parameter_keys(
-        cls, v: Optional[List[Parameter]]
+        cls, v: Optional[List[Parameter]], info
     ) -> Optional[List[Parameter]]:
-        _warn_if_disjoint_parameter_keys(v)
+        line_map = info.context.get("line_map") if info.context else None
+        _warn_if_disjoint_parameter_keys(v, line_map)
         return v
 
     def has_environment_reference(self, env_id: Optional[str] = None) -> bool:
@@ -510,9 +530,10 @@ class MetricCollector(DescribableEntity, SoftwareEnvironmentReference):
     @field_validator("parameters")
     @classmethod
     def warn_disjoint_parameter_keys(
-        cls, v: Optional[List[Parameter]]
+        cls, v: Optional[List[Parameter]], info
     ) -> Optional[List[Parameter]]:
-        _warn_if_disjoint_parameter_keys(v)
+        line_map = info.context.get("line_map") if info.context else None
+        _warn_if_disjoint_parameter_keys(v, line_map)
         return v
 
     def has_environment_reference(self, env_id: Optional[str] = None) -> bool:

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -438,7 +438,7 @@ def _warn_if_disjoint_parameter_keys(
     if len(param_items) < 2:
         return
 
-    key_sets = [set(p.params.keys()) for p in param_items]
+    key_sets = [set(p.params.keys()) for p in param_items if p.params is not None]
     key_counts: Dict[str, int] = {}
     for ks in key_sets:
         for k in ks:

--- a/omnibenchmark/versioning/git.py
+++ b/omnibenchmark/versioning/git.py
@@ -135,14 +135,14 @@ class GitAwareBenchmarkVersionManager(BenchmarkVersionManager):
                 part_bytes = part.encode()
                 # tree items: (mode, name, sha)
                 found = False
-                for item in obj.items():
+                for item in obj.items():  # type: ignore[union-attr]
                     if item.path == part_bytes:
                         obj = self.repo[item.sha]
                         found = True
                         break
                 if not found:
                     return None
-            return obj.data.decode("utf-8")
+            return obj.data.decode("utf-8")  # type: ignore[union-attr]
         except Exception:
             return None
 
@@ -203,7 +203,10 @@ class GitAwareBenchmarkVersionManager(BenchmarkVersionManager):
                 if head_ref and head_ref.startswith(b"refs/heads/"):
                     info["branch"] = head_ref[len(b"refs/heads/") :].decode()
             except Exception:
-                logger.debug("Failed to determine current git branch from HEAD ref.", exc_info=True)
+                logger.debug(
+                    "Failed to determine current git branch from HEAD ref.",
+                    exc_info=True,
+                )
 
             # Dirty check via subprocess (dulwich has no simple is_dirty())
             try:
@@ -214,7 +217,9 @@ class GitAwareBenchmarkVersionManager(BenchmarkVersionManager):
                 )
                 info["clean"] = result.stdout.strip() == ""
             except Exception:
-                logger.debug("Failed to determine git working tree cleanliness.", exc_info=True)
+                logger.debug(
+                    "Failed to determine git working tree cleanliness.", exc_info=True
+                )
 
             # Remote URL
             try:
@@ -223,7 +228,10 @@ class GitAwareBenchmarkVersionManager(BenchmarkVersionManager):
                 if url:
                     info["remote"] = url.decode()
             except Exception:
-                logger.debug("Failed to retrieve git remote URL from repository config.", exc_info=True)
+                logger.debug(
+                    "Failed to retrieve git remote URL from repository config.",
+                    exc_info=True,
+                )
 
         except Exception:
             logger.debug("Failed to collect git repository information.", exc_info=True)

--- a/pixi.lock
+++ b/pixi.lock
@@ -115,7 +115,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.408-py312h5253ce2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.409-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -319,7 +319,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.408-py312hf7082af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.409-py312hba6025d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -520,7 +520,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.408-py312hb3ab3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.409-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -774,7 +774,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pypandoc-1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.408-py312h5253ce2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.409-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -1008,7 +1008,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pypandoc-1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.408-py312hf7082af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.409-py312hba6025d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -1239,7 +1239,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pypandoc-1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.408-py312hb3ab3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.409-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -5304,7 +5304,7 @@ packages:
   timestamp: 1774517834028
 - pypi: ./
   name: omnibenchmark
-  version: 0.4.0.post14+g4e90fdc96.d20260331
+  version: 0.4.0.post57+ge27c7290d.d20260330
   sha256: 58e018d90124fe9bd1e788ba6d52509640cf599e6b95ff062f7e5eb10e59cc37
   requires_dist:
   - click>=8.1.7
@@ -5341,7 +5341,7 @@ packages:
   requires_python: '>=3.12.0,<3.14'
 - pypi: ./
   name: omnibenchmark
-  version: 0.4.0.post57+ge27c7290d.d20260330
+  version: 0.5.0.post2+g0bdbf3b55.d20260428
   sha256: 58e018d90124fe9bd1e788ba6d52509640cf599e6b95ff062f7e5eb10e59cc37
   requires_dist:
   - click>=8.1.7
@@ -6017,56 +6017,56 @@ packages:
   version: 1.2.0
   sha256: 9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
   requires_python: '>=3.7'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.408-py312h5253ce2_0.conda
-  sha256: 322c3b30fa00fa6d759fae449a281e74bec5acbf863ed82b15d6f2eff245de67
-  md5: 80a544b026a01c0b9e6b1fc2196de949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.409-py312h5253ce2_0.conda
+  sha256: 6b3720b7118f5dbe90645565823a6d238e15d4832cd81a0c78640a20f78cdc36
+  md5: 008f0a166ebe2837d724c29cb96458d4
   depends:
   - nodeenv >=1.6.0
   - nodejs
   - python
   - typing_extensions >=4.1
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/pyright?source=hash-mapping
-  size: 4101313
-  timestamp: 1767872890841
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.408-py312hf7082af_0.conda
-  sha256: d538bac9736105d6c66e3fe356cc9ded04309fa517405a2cb329b3c25de868ba
-  md5: 51667b055791a1643c143eba6d93f735
-  depends:
-  - nodeenv >=1.6.0
-  - nodejs
-  - python
-  - typing_extensions >=4.1
-  - __osx >=10.13
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyright?source=hash-mapping
-  size: 4102127
-  timestamp: 1767873115418
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.408-py312hb3ab3e3_0.conda
-  sha256: 971b7800f996ab203bbdc97480772e38d506fc4615566fb1440c3433a8a95a64
-  md5: 42de17c3d5f6439292b77f558366698f
+  size: 4129119
+  timestamp: 1776947291301
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.409-py312hba6025d_0.conda
+  sha256: 9b609d7464186ae297cb5de8bfc24423a1c2bca752e646c263da8160de84fd99
+  md5: 3375e4ff2abd2336b28b6eac20ecd048
   depends:
   - nodeenv >=1.6.0
   - nodejs
   - python
   - typing_extensions >=4.1
   - __osx >=11.0
-  - python 3.12.* *_cpython
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/pyright?source=hash-mapping
-  size: 4105355
-  timestamp: 1767872955083
+  size: 4129642
+  timestamp: 1776947625732
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.409-py312hb3ab3e3_0.conda
+  sha256: 376608791d5d3f0b2cd58fbbe628e646ef96582496b5dae3984038299b377630
+  md5: 8514d375b178e08ab24e58a96fa071d7
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyright?source=hash-mapping
+  size: 4133160
+  timestamp: 1776947494834
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,7 +22,7 @@ pytest-cov = ">=4.1.0"
 pytest-timeout = "==2.3.1"
 
 # Type checking and linting
-pyright = ">=1.1.408,<2"
+pyright = ">=1.1.409,<2"
 ruff = "*"
 
 # Core dependencies for the package

--- a/tests/model/test_parameter_expansion.py
+++ b/tests/model/test_parameter_expansion.py
@@ -1,5 +1,7 @@
 """Tests for parameter expansion with combinatorial validation."""
 
+import warnings
+
 import pytest
 
 from omnibenchmark.model.benchmark import Benchmark
@@ -435,3 +437,92 @@ stages:
     serialized = params[0].serialize()
     assert "gini_threshold" in serialized
     assert "0.1" in serialized
+
+
+@pytest.mark.short
+def test_disjoint_parameter_keys_raises_warning():
+    """Disjoint parameter keys across list items should emit a UserWarning.
+
+    The common mistake:
+        parameters:
+          - selection_type: ["a", "b"]   # list item 1
+          - number_selected: 2000        # list item 2 (separate item, different key)
+
+    The intended form (single item with both keys):
+        parameters:
+          - selection_type: ["a", "b"]
+            number_selected: 2000
+    """
+    yaml_content = """
+id: test_benchmark
+description: Test benchmark
+version: "1.0"
+benchmarker: Test
+software_backend: host
+software_environments:
+  - id: python
+    description: Python environment
+stages:
+  - id: test_stage
+    modules:
+      - id: test_module
+        name: Test Module
+        software_environment: python
+        repository:
+          url: https://github.com/test/test.git
+          commit: abc123
+        parameters:
+          - selection_type: ["seurat_vst", "scrapper_modelGeneVariances"]
+          - number_selected: 2000
+    outputs:
+      - id: test.output
+        path: test.csv
+"""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Benchmark.from_yaml(yaml_content)
+
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    msg = str(user_warnings[0].message)
+    assert "disjoint" in msg.lower()
+    assert "selection_type" in msg
+    assert "number_selected" in msg
+
+
+@pytest.mark.short
+def test_non_disjoint_parameter_keys_no_warning():
+    """Parameters sharing at least one common key should not trigger a warning."""
+    yaml_content = """
+id: test_benchmark
+description: Test benchmark
+version: "1.0"
+benchmarker: Test
+software_backend: host
+software_environments:
+  - id: python
+    description: Python environment
+stages:
+  - id: test_stage
+    modules:
+      - id: test_module
+        name: Test Module
+        software_environment: python
+        repository:
+          url: https://github.com/test/test.git
+          commit: abc123
+        parameters:
+          - method: genie
+            threshold: 0.1
+          - method: other
+            threshold: 0.5
+    outputs:
+      - id: test.output
+        path: test.csv
+"""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Benchmark.from_yaml(yaml_content)
+
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 0

--- a/tests/model/test_parameter_expansion.py
+++ b/tests/model/test_parameter_expansion.py
@@ -610,6 +610,6 @@ def test_disjoint_warning_metric_collector(capsys):
         }
     )
     err = capsys.readouterr().err
-    assert "disjoint" in err.lower()
+    assert "inconsistent" in err.lower()
     assert "metric_type" in err
     assert "cutoff" in err

--- a/tests/model/test_parameter_expansion.py
+++ b/tests/model/test_parameter_expansion.py
@@ -1,7 +1,5 @@
 """Tests for parameter expansion with combinatorial validation."""
 
-import warnings
-
 import pytest
 
 from omnibenchmark.model.benchmark import Benchmark
@@ -440,8 +438,8 @@ stages:
 
 
 @pytest.mark.short
-def test_disjoint_parameter_keys_raises_warning():
-    """Disjoint parameter keys across list items should emit a UserWarning.
+def test_disjoint_parameter_keys_raises_warning(capsys):
+    """Disjoint parameter keys across list items should print a prominent warning to stderr.
 
     The common mistake:
         parameters:
@@ -478,20 +476,16 @@ stages:
       - id: test.output
         path: test.csv
 """
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        Benchmark.from_yaml(yaml_content)
+    Benchmark.from_yaml(yaml_content)
 
-    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
-    assert len(user_warnings) == 1
-    msg = str(user_warnings[0].message)
-    assert "disjoint" in msg.lower()
-    assert "selection_type" in msg
-    assert "number_selected" in msg
+    err = capsys.readouterr().err
+    assert "disjoint" in err.lower()
+    assert "selection_type" in err
+    assert "number_selected" in err
 
 
 @pytest.mark.short
-def test_non_disjoint_parameter_keys_no_warning():
+def test_non_disjoint_parameter_keys_no_warning(capsys):
     """Parameters sharing at least one common key should not trigger a warning."""
     yaml_content = """
 id: test_benchmark
@@ -520,9 +514,7 @@ stages:
       - id: test.output
         path: test.csv
 """
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        Benchmark.from_yaml(yaml_content)
+    Benchmark.from_yaml(yaml_content)
 
-    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
-    assert len(user_warnings) == 0
+    err = capsys.readouterr().err
+    assert "disjoint" not in err.lower()

--- a/tests/model/test_parameter_expansion.py
+++ b/tests/model/test_parameter_expansion.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from omnibenchmark.model.benchmark import Benchmark
+from omnibenchmark.model.benchmark import Benchmark, _warn_if_disjoint_parameter_keys
 
 
 @pytest.mark.short
@@ -518,3 +518,98 @@ stages:
 
     err = capsys.readouterr().err
     assert "disjoint" not in err.lower()
+
+
+@pytest.mark.short
+def test_disjoint_warning_none_parameters(capsys):
+    """No warning when parameters is None."""
+    _warn_if_disjoint_parameter_keys(None)
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.short
+def test_disjoint_warning_legacy_values_no_params(capsys):
+    """No warning when parameter items have no dict params (legacy values format)."""
+    from omnibenchmark.model.benchmark import Parameter
+
+    params = [
+        Parameter(id="p1", values=["--method", "cosine"]),
+        Parameter(id="p2", values=["--k", "10"]),
+    ]
+    _warn_if_disjoint_parameter_keys(params)
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.short
+def test_disjoint_warning_single_parameter(capsys):
+    """No warning when there is only one parameter item."""
+    yaml_content = """
+id: test_benchmark
+description: Test benchmark
+version: "1.0"
+benchmarker: Test
+software_backend: host
+software_environments:
+  - id: python
+    description: Python environment
+stages:
+  - id: test_stage
+    modules:
+      - id: test_module
+        name: Test Module
+        software_environment: python
+        repository:
+          url: https://github.com/test/test.git
+          commit: abc123
+        parameters:
+          - selection_type: ["seurat_vst"]
+    outputs:
+      - id: test.output
+        path: test.csv
+"""
+    Benchmark.from_yaml(yaml_content)
+    assert "disjoint" not in capsys.readouterr().err.lower()
+
+
+@pytest.mark.short
+def test_disjoint_warning_with_line_map(capsys):
+    """Line hint is included in warning when line_map contains a parameters[0] key."""
+    from omnibenchmark.model.benchmark import Parameter
+
+    params = [
+        Parameter(id="p1", params={"alpha": 0.1}),
+        Parameter(id="p2", params={"beta": 0.5}),
+    ]
+    line_map = {"stages[0].modules[0].parameters[0]": 42}
+    _warn_if_disjoint_parameter_keys(params, line_map)
+    err = capsys.readouterr().err
+    assert "disjoint" in err.lower()
+    assert "line 42" in err
+
+
+@pytest.mark.short
+def test_disjoint_warning_metric_collector(capsys):
+    """Disjoint parameter keys on a MetricCollector also trigger a warning."""
+    from omnibenchmark.model.benchmark import MetricCollector
+
+    MetricCollector.model_validate(
+        {
+            "id": "test_collector",
+            "name": "Test Collector",
+            "software_environment": "python",
+            "repository": {
+                "url": "https://github.com/test/test.git",
+                "commit": "abc123",
+            },
+            "inputs": ["test.output"],
+            "outputs": [{"id": "metrics.json", "path": "metrics.json"}],
+            "parameters": [
+                {"id": "p1", "params": {"metric_type": ["rmse", "mae"]}},
+                {"id": "p2", "params": {"cutoff": 100}},
+            ],
+        }
+    )
+    err = capsys.readouterr().err
+    assert "disjoint" in err.lower()
+    assert "metric_type" in err
+    assert "cutoff" in err

--- a/tests/model/test_parameter_expansion.py
+++ b/tests/model/test_parameter_expansion.py
@@ -479,14 +479,14 @@ stages:
     Benchmark.from_yaml(yaml_content)
 
     err = capsys.readouterr().err
-    assert "disjoint" in err.lower()
+    assert "inconsistent" in err.lower()
     assert "selection_type" in err
     assert "number_selected" in err
 
 
 @pytest.mark.short
 def test_non_disjoint_parameter_keys_no_warning(capsys):
-    """Parameters sharing at least one common key should not trigger a warning."""
+    """Parameters with identical key sets (a value grid) should not trigger a warning."""
     yaml_content = """
 id: test_benchmark
 description: Test benchmark
@@ -517,7 +517,7 @@ stages:
     Benchmark.from_yaml(yaml_content)
 
     err = capsys.readouterr().err
-    assert "disjoint" not in err.lower()
+    assert "inconsistent" not in err.lower()
 
 
 @pytest.mark.short
@@ -568,7 +568,7 @@ stages:
         path: test.csv
 """
     Benchmark.from_yaml(yaml_content)
-    assert "disjoint" not in capsys.readouterr().err.lower()
+    assert "inconsistent" not in capsys.readouterr().err.lower()
 
 
 @pytest.mark.short
@@ -583,7 +583,7 @@ def test_disjoint_warning_with_line_map(capsys):
     line_map = {"stages[0].modules[0].parameters[0]": 42}
     _warn_if_disjoint_parameter_keys(params, line_map)
     err = capsys.readouterr().err
-    assert "disjoint" in err.lower()
+    assert "inconsistent" in err.lower()
     assert "line 42" in err
 
 


### PR DESCRIPTION
## Ticket

#313

## Description

It's unlikely that the user really intends to pass disjoint parameters to a method. Raising a hint for a common gotcha.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

