### PR TITLE
fix: clearer error on missing entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 This document records all notable changes to `omnibenchmark`.
 This project adheres to [Semantic Versioning](https://semver.org/) and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- 
+
 ## [0.5.1](UNRELEASED) ()
 
 - fix: raise warning for disjoint keys (Closes: #313)
+- fix: clearer error on missing entrypoint (Closes: #321)
 
 ## [0.5.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.0) (Apr 23th 2026)
 

--- a/omnibenchmark/backend/resolver.py
+++ b/omnibenchmark/backend/resolver.py
@@ -276,12 +276,12 @@ class ModuleResolver:
 
         # Dereference entrypoint
         entrypoint_key = module.repository.entrypoint or "default"
-        entrypoint = self._read_entrypoint(actual_work_dir, module_id, entrypoint_key)
-        if entrypoint is None:
-            raise RuntimeError(
-                f"Failed to dereference entrypoint for module '{module_id}'. "
-                f"Expected omnibenchmark.yaml or config.cfg in {actual_work_dir}"
+        try:
+            entrypoint = self._read_entrypoint(
+                actual_work_dir, module_id, entrypoint_key
             )
+        except ValueError as e:
+            raise RuntimeError(str(e)) from e
 
         # Entrypoint is relative to module_dir
         entrypoint_path = Path(entrypoint)
@@ -659,7 +659,7 @@ class ModuleResolver:
 
     def _read_entrypoint(
         self, module_dir: Path, module_id: str, entrypoint_key: str = "default"
-    ) -> Optional[str]:
+    ) -> str:
         """
         Read entrypoint from omnibenchmark.yaml or fall back to config.cfg.
 
@@ -672,7 +672,10 @@ class ModuleResolver:
             entrypoint_key: Key to look up in the entrypoints dict (default: "default")
 
         Returns:
-            Entrypoint path relative to module_dir, or None if not found
+            Entrypoint path relative to module_dir
+
+        Raises:
+            ValueError: With a descriptive message when the entrypoint cannot be resolved
         """
         # Try new-style omnibenchmark.yaml first
         yaml_path = module_dir / "omnibenchmark.yaml"
@@ -691,33 +694,29 @@ class ModuleResolver:
                         return entrypoint
                     elif isinstance(entrypoints, dict):
                         available = ", ".join(sorted(entrypoints.keys()))
-                        logger.error(
+                        raise ValueError(
                             f"Entrypoint '{entrypoint_key}' not found in module '{module_id}'. "
                             f"Available entrypoints: {available}"
                         )
-                        return None
                     else:
-                        logger.error(
+                        raise ValueError(
                             f"Invalid omnibenchmark.yaml format in '{module_id}'. "
                             "Expected 'entrypoints' to be a dict."
                         )
-                        return None
             except yaml.YAMLError as e:
-                logger.error(
+                raise ValueError(
                     f"Failed to parse omnibenchmark.yaml in '{module_id}': {e}"
                 )
-                return None
 
         # Fall back to old-style config.cfg
         config_path = module_dir / "config.cfg"
         if config_path.exists():
             if entrypoint_key != "default":
-                logger.error(
-                    f"Module '{module_id}' uses deprecated config.cfg which only supports "
-                    f"the 'default' entrypoint. Requested entrypoint: '{entrypoint_key}'. "
+                raise ValueError(
+                    f"Entrypoint '{entrypoint_key}' not found in module '{module_id}'. "
+                    "This module uses deprecated config.cfg which only supports the 'default' entrypoint. "
                     "Please migrate to omnibenchmark.yaml to use named entrypoints."
                 )
-                return None
 
             warnings.warn(
                 f"Module '{module_id}' is using deprecated config.cfg. "
@@ -735,11 +734,12 @@ class ModuleResolver:
                 logger.debug(f"Found entrypoint in config.cfg: {entrypoint}")
                 return entrypoint
             else:
-                logger.error(f"Invalid config.cfg format in '{module_id}'.")
-                return None
+                raise ValueError(
+                    f"Invalid config.cfg format in '{module_id}'. "
+                    "Expected a [DEFAULT] section with a SCRIPT key."
+                )
 
-        logger.error(
-            f"No configuration file found in '{module_id}'. "
+        raise ValueError(
+            f"No configuration file found for module '{module_id}' in {module_dir}. "
             "Expected omnibenchmark.yaml or config.cfg."
         )
-        return None

--- a/tests/backend/test_resolver.py
+++ b/tests/backend/test_resolver.py
@@ -394,34 +394,24 @@ class TestReadEntrypoint:
         )
         assert result == "scripts/validate.R"
 
-    def test_missing_entrypoint_key_returns_none(
-        self, resolver, module_dir_with_entrypoints
-    ):
-        """A missing entrypoint key returns None."""
-        result = resolver._read_entrypoint(
-            module_dir_with_entrypoints, "mod1", entrypoint_key="nonexistent"
-        )
-        assert result is None
-
-    def test_missing_entrypoint_key_logs_available(
-        self, resolver, module_dir_with_entrypoints, caplog
-    ):
-        """A missing entrypoint key logs the available keys."""
-        import logging
-
-        # Ensure the omnibenchmark logger propagates (may be suppressed by parallel resolution)
-        omni_logger = logging.getLogger("omnibenchmark")
-        omni_logger.propagate = True
-        omni_logger.setLevel(logging.DEBUG)
-
-        with caplog.at_level(logging.ERROR):
+    def test_missing_entrypoint_key_raises(self, resolver, module_dir_with_entrypoints):
+        """A missing entrypoint key raises ValueError with the key name."""
+        with pytest.raises(ValueError, match="nonexistent"):
             resolver._read_entrypoint(
                 module_dir_with_entrypoints, "mod1", entrypoint_key="nonexistent"
             )
-        assert "nonexistent" in caplog.text
-        assert "Available entrypoints:" in caplog.text
-        assert "default" in caplog.text
-        assert "preprocess" in caplog.text
+
+    def test_missing_entrypoint_key_error_lists_available(
+        self, resolver, module_dir_with_entrypoints
+    ):
+        """The ValueError for a missing entrypoint key names the available entrypoints."""
+        with pytest.raises(ValueError, match="Available entrypoints:") as exc_info:
+            resolver._read_entrypoint(
+                module_dir_with_entrypoints, "mod1", entrypoint_key="nonexistent"
+            )
+        error_msg = str(exc_info.value)
+        assert "default" in error_msg
+        assert "preprocess" in error_msg
 
     def test_config_cfg_default_key_works(self, resolver, module_dir_with_config_cfg):
         """config.cfg fallback works for default entrypoint."""
@@ -431,23 +421,20 @@ class TestReadEntrypoint:
             )
         assert result == "legacy_run.py"
 
-    def test_config_cfg_named_key_rejected(
-        self, resolver, module_dir_with_config_cfg, caplog
-    ):
-        """config.cfg fallback rejects non-default entrypoint keys."""
-        import logging
-
-        omni_logger = logging.getLogger("omnibenchmark")
-        omni_logger.propagate = True
-        omni_logger.setLevel(logging.DEBUG)
-
-        with caplog.at_level(logging.ERROR):
-            result = resolver._read_entrypoint(
+    def test_config_cfg_named_key_raises(self, resolver, module_dir_with_config_cfg):
+        """config.cfg fallback raises ValueError for non-default entrypoint keys."""
+        with pytest.raises(ValueError, match="preprocess") as exc_info:
+            resolver._read_entrypoint(
                 module_dir_with_config_cfg, "mod1", entrypoint_key="preprocess"
             )
-        assert result is None
-        assert "only supports" in caplog.text
-        assert "preprocess" in caplog.text
+        assert "only supports" in str(exc_info.value)
+
+    def test_no_config_file_raises(self, resolver, tmp_path):
+        """Missing config file raises ValueError mentioning expected files."""
+        empty_dir = tmp_path / "empty_module"
+        empty_dir.mkdir()
+        with pytest.raises(ValueError, match="omnibenchmark.yaml"):
+            resolver._read_entrypoint(empty_dir, "empty_mod")
 
 
 class TestRepositoryEntrypointField:


### PR DESCRIPTION
## Ticket

#321

## Description

When a benchmark requests repository.entrypoint: and that key isn't in the module's omnibenchmark.yaml, the resolver raises a misleading error.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

## Testing

This can be tested manually with an omnibenchmark.yaml for a module where you request a missing entrypoint.
