### PR TITLE
feat: resolve module name correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 
 ## [0.6.0](UNRELEASED)
 
-- ...
+- feat: output path templates now support `{name}`, `{module.name}`, `{module.stage}`, and `{params.KEY}`; `{name}` always resolves to the current module's own ID (never inherited)
 
 ## [0.5.3](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.4) (Jun 15th 2026)
 

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -468,6 +468,96 @@ ob dashboard benchmark.yaml -o out
 
 This reads `out/performances.tsv` and writes `out/bettr_dashboard.json`. If the table is missing, run `ob collect performance` first.
 
+## Use template variables in output paths
+
+Output `path` fields in the benchmark YAML accept template variables that are resolved at runtime for each node in the execution graph. All variables use `{curly_brace}` syntax.
+
+### Available variables
+
+| Variable | Resolves to | Notes |
+|----------|-------------|-------|
+| `{dataset}` | Root dataset ID (e.g. `D1`) | Inherited from the first stage; see deprecation note below |
+| `{name}` | Current module's own ID (e.g. `M1`) | Always the *current* module — never inherited |
+| `{module.id}` | Current module's own ID | Same as `{name}` |
+| `{module.name}` | Module's human-readable `name` attribute | Falls back to the module ID if `name` is not set |
+| `{module.stage}` | Current stage ID (e.g. `methods`) | |
+| `{params.KEY}` | Value of parameter `KEY` for this node | Fully resolved before Snakemake sees the path; one output path per parameter combination |
+
+### When to use `{dataset}` vs `{name}`
+
+Use **`{name}`** when you want the filename to reflect *which module produced the file* — this is the recommended choice for method and metric stages, where each module's output should be independently identifiable.
+
+Use **`{dataset}`** when the first-stage module IDs are themselves meaningful dataset identifiers (e.g. `D1`, `pbmc3k`) and you want that identity to propagate through the whole pipeline. **`{dataset}` is only useful if the first-stage module `id` values are semantically meaningful.** If the first stage uses a single dispatcher module with a fixed ID (e.g. `id: loader`) and instead varies datasets via parameters, `{dataset}` will always resolve to `"loader"` — which is not useful. In that case use `{params.dataset}` or `{name}` instead.
+
+> **Deprecation notice:** `{dataset}` is a legacy variable that couples output filenames to first-stage module IDs. It will be deprecated in a future release. Prefer `{name}` for new benchmarks.
+
+```yaml
+stages:
+  - id: data
+    modules:
+      - id: D1
+        name: "Dataset 1"
+        ...
+    outputs:
+      - id: data.counts
+        path: "{dataset}.txt.gz"     # → D1.txt.gz  (dataset ID)
+
+  - id: methods
+    inputs: [data.counts]
+    modules:
+      - id: M1
+        name: "Method 1"
+        ...
+      - id: M2
+        name: "Method 2"
+        ...
+    outputs:
+      - id: methods.result
+        path: "{name}_result.txt"    # → M1_result.txt / M2_result.txt  (own module ID)
+        # or equivalently:
+        # path: "{module.id}_result.txt"
+```
+
+The `--name` CLI argument passed to each module script always receives the current module's own ID, matching the `{name}` template variable.
+
+### Using the human-readable module name
+
+`{module.name}` gives the `name:` field from the YAML entry rather than the `id:`. This is useful for labelling outputs with a descriptive string:
+
+```yaml
+stages:
+  - id: methods
+    modules:
+      - id: kmeans
+        name: "k-Means Clustering"
+        ...
+    outputs:
+      - id: methods.result
+        path: "{module.name}_output.txt"  # → k-Means Clustering_output.txt
+```
+
+When `name:` is omitted from the module entry, `{module.name}` falls back to the module ID.
+
+### Encoding parameter values in output paths
+
+`{params.KEY}` is resolved to the concrete parameter value for each node before the Snakefile is written, so Snakemake always sees fully-qualified, concrete output paths — one per parameter combination.
+
+```yaml
+stages:
+  - id: data
+    modules:
+      - id: D1
+        parameters:
+          - k: "3"
+          - k: "5"
+    outputs:
+      - id: data.result
+        path: "{name}_k{params.k}_result.txt"
+        # → D1_k3_result.txt  (k=3 node)
+        # → D1_k5_result.txt  (k=5 node)
+```
+
+This is useful when a single module is run with multiple parameter sweeps and each run's output must be stored at a distinct path.
 
 ## Use local module repositories
 

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -533,12 +533,17 @@ def _substitute_params_in_path(template: str, params) -> str:
 def _build_template_context(
     stage,
     module_id: str,
+    module_name: Optional[str] = None,
     input_node=None,
     params=None,
 ) -> TemplateContext:
     """Build a TemplateContext for a node during expansion."""
     provides: dict[str, str] = {}
-    module_attrs: dict[str, str] = {"id": module_id, "stage": stage.id}
+    module_attrs: dict[str, str] = {
+        "id": module_id,
+        "stage": stage.id,
+        "name": module_name or module_id,
+    }
 
     stage_provides = getattr(stage, "provides", None)
 
@@ -567,6 +572,9 @@ def _build_template_context(
             provides.setdefault("dataset", str(params["dataset"]))
         else:
             provides.setdefault("dataset", module_id)
+
+    # {name} always resolves to the current module's own ID, never inherited
+    provides["name"] = module_id
 
     return TemplateContext(provides=provides, module_attrs=module_attrs)
 
@@ -988,6 +996,7 @@ def _generate_explicit_snakefile(
                     ctx = _build_template_context(
                         stage=stage,
                         module_id=module_id,
+                        module_name=getattr(module, "name", None),
                         input_node=input_node,
                         params=params,
                     )

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -1167,15 +1167,13 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
         all_stages_outputs: List[Dict[str, str]] = []
         for stage in self.stages:
             stage_outputs = self.get_stage_outputs(stage)
-            # Substitute the actual stage_id into the template like the old LinkML code
+            # Resolve {stage} eagerly here; leave every other placeholder
+            # ({input}, {module}, {params.*}, {dataset}, {name}, {module.*})
+            # for the per-node template engine. We use str.replace rather than
+            # str.format so dotted placeholders like {params.n_components}
+            # pass through untouched instead of triggering attribute lookup.
             stage_outputs = {
-                key: value.format(
-                    input="{input}",
-                    stage=stage.id,  # Substitute actual stage_id here
-                    module="{module}",
-                    params="{params}",
-                    dataset="{dataset}",
-                )
+                key: value.replace("{stage}", stage.id)
                 for key, value in stage_outputs.items()
             }
             all_stages_outputs.append(stage_outputs)

--- a/tests/cli/test_run_benchmark.py
+++ b/tests/cli/test_run_benchmark.py
@@ -1,4 +1,6 @@
 import os
+import re
+import textwrap
 
 import pytest
 
@@ -173,3 +175,154 @@ def test_benchmark_ok_if_one_module_fails_with_continue(tmp_path, bundled_repos)
         assert failed_msg not in result.stdout
         assert failed_msg not in result.stderr
         assert result.returncode == 0
+
+
+def test_params_key_in_output_path_resolved_in_snakefile(tmp_path, bundled_repos):  # noqa: F811
+    """
+    Integration test: {params.key} in output path templates must be fully
+    substituted to concrete values before being written into the Snakefile.
+    Snakemake must never see a {params.*} wildcard in an output: block.
+
+    This test verifies the full pipeline:
+      YAML parsing → param expansion → TemplateContext.substitute() → Snakefile generation
+    """
+    out_dir = tmp_path / "out"
+    benchmark_yaml = tmp_path / "bench_params_output.yaml"
+    benchmark_yaml.write_text(
+        textwrap.dedent("""
+            id: test_params_in_output
+            version: "1.0"
+            benchmarker: "test"
+            api_version: "0.5.0"
+            software_backend: host
+            software_environments:
+              host:
+                description: "host env"
+            stages:
+              - id: data
+                modules:
+                  - id: D1
+                    software_environment: host
+                    repository:
+                      url: bundles/dummymodule_4ff8427.bundle
+                      commit: 4ff8427
+                    parameters:
+                      - k: "3"
+                      - k: "5"
+                outputs:
+                  - id: data.result
+                    path: "{name}_k{params.k}_result.txt"
+        """).strip()
+    )
+
+    with OmniCLISetup() as omni:
+        result = omni.call(
+            ["run", str(benchmark_yaml), "--dry", "--out-dir", str(out_dir)],
+            cwd=str(tmp_path),
+        )
+
+    assert (
+        result.returncode == 0
+    ), f"CLI failed (rc={result.returncode}):\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+
+    snakefile = out_dir / "Snakefile"
+    assert snakefile.exists(), "Snakefile was not generated"
+    content = snakefile.read_text()
+
+    # Extract all output: blocks and verify no {params.*} placeholders remain —
+    # Snakemake would misinterpret them as wildcards.
+    output_blocks = re.findall(
+        r"\boutput:\s*\n(.*?)(?=\n[ \t]+\w|\nrule |\Z)", content, re.DOTALL
+    )
+    assert output_blocks, "No output: blocks found in Snakefile"
+    for block in output_blocks:
+        assert (
+            "{params." not in block
+        ), f"Unresolved {{params.*}} placeholder in Snakefile output: block:\n{block}"
+
+    # Both parameter variants must produce distinct, concrete output filenames.
+    assert (
+        "_k3_result.txt" in content
+    ), "Expected k=3 output path not found in Snakefile"
+    assert (
+        "_k5_result.txt" in content
+    ), "Expected k=5 output path not found in Snakefile"
+
+
+def test_params_key_in_upstream_output_consumed_downstream(tmp_path, bundled_repos):  # noqa: F811
+    """
+    Regression test: a {params.*} placeholder in an upstream stage's output
+    template must survive the cross-stage input-stitching pass without
+    triggering attribute-access errors.
+
+    The previous code path-stitched outputs via str.format(), which would
+    interpret {params.foo} as attribute access on a string and crash with
+    AttributeError. We now keep dotted placeholders untouched so the per-node
+    template engine resolves them later.
+    """
+    out_dir = tmp_path / "out"
+    benchmark_yaml = tmp_path / "bench_params_cross_stage.yaml"
+    benchmark_yaml.write_text(
+        textwrap.dedent("""
+            id: test_params_cross_stage
+            version: "1.0"
+            benchmarker: "test"
+            api_version: "0.5.0"
+            software_backend: host
+            software_environments:
+              host:
+                description: "host env"
+            stages:
+              - id: data
+                modules:
+                  - id: D1
+                    software_environment: host
+                    repository:
+                      url: bundles/dummymodule_4ff8427.bundle
+                      commit: 4ff8427
+                    parameters:
+                      - k: "3"
+                outputs:
+                  - id: data.result
+                    path: "{name}_k{params.k}_result.txt"
+              - id: consume
+                inputs:
+                  - data.result
+                modules:
+                  - id: C1
+                    software_environment: host
+                    repository:
+                      url: bundles/dummymodule_4ff8427.bundle
+                      commit: 4ff8427
+                outputs:
+                  - id: consume.out
+                    path: "{name}_consumed.txt"
+        """).strip()
+    )
+
+    with OmniCLISetup() as omni:
+        result = omni.call(
+            ["run", str(benchmark_yaml), "--dry", "--out-dir", str(out_dir)],
+            cwd=str(tmp_path),
+        )
+
+    assert (
+        result.returncode == 0
+    ), f"CLI failed (rc={result.returncode}):\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    assert "AttributeError" not in result.stderr
+    assert "has no attribute" not in result.stderr
+
+    content = (out_dir / "Snakefile").read_text()
+    assert "_k3_result.txt" in content
+
+    # No {params.*} should leak into output: blocks (Snakemake would treat
+    # them as wildcards). {params.*} in shell: blocks is fine — that's
+    # Snakemake's own params: directive being referenced.
+    output_blocks = re.findall(
+        r"\boutput:\s*\n(.*?)(?=\n[ \t]+\w|\nrule |\Z)", content, re.DOTALL
+    )
+    assert output_blocks, "No output: blocks found in Snakefile"
+    for block in output_blocks:
+        assert (
+            "{params." not in block
+        ), f"Unresolved {{params.*}} in output: block:\n{block}"

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -244,6 +244,46 @@ class TestBuildTemplateContext:
         ctx = _build_template_context(stage, "M1", input_node=input_node, params=p)
         assert ctx.provides["method"] == "kmeans"
 
+    # --- {name} template variable: always the current module's own ID ---
+
+    def test_root_node_provides_name_is_module_id(self):
+        stage = _make_stage("data", provides=None)
+        ctx = _build_template_context(stage, "D1")
+        assert ctx.provides["name"] == "D1"
+
+    def test_child_node_provides_name_is_own_module_id_not_inherited(self):
+        # {name} must always be the *current* module's ID, never inherited from parent
+        parent_ctx = TemplateContext(
+            provides={"dataset": "D1", "name": "D1"},
+            module_attrs={"id": "D1", "stage": "data"},
+        )
+        input_node = _make_input_node("D1", "data", template_context=parent_ctx)
+        stage = _make_stage("methods", provides=None)
+        ctx = _build_template_context(stage, "M1", input_node=input_node)
+        assert ctx.provides["name"] == "M1"
+
+    def test_name_template_variable_substitution(self):
+        stage = _make_stage("methods", provides=None)
+        ctx = _build_template_context(stage, "M1")
+        assert ctx.substitute("{name}_result.txt") == "M1_result.txt"
+
+    # --- {module.name} template variable: module's human-readable name ---
+
+    def test_module_name_attr_uses_provided_name(self):
+        stage = _make_stage("data", provides=None)
+        ctx = _build_template_context(stage, "D1", module_name="Dataset 1")
+        assert ctx.module_attrs["name"] == "Dataset 1"
+
+    def test_module_name_attr_falls_back_to_module_id(self):
+        stage = _make_stage("data", provides=None)
+        ctx = _build_template_context(stage, "D1", module_name=None)
+        assert ctx.module_attrs["name"] == "D1"
+
+    def test_module_name_template_variable_substitution(self):
+        stage = _make_stage("data", provides=None)
+        ctx = _build_template_context(stage, "D1", module_name="Dataset 1")
+        assert ctx.substitute("{module.name}_output.txt") == "Dataset 1_output.txt"
+
 
 # ---------------------------------------------------------------------------
 # _satisfies_requires


### PR DESCRIPTION
## Ticket

...

## Description

Fix the wrong behavior by which dataset name was propagated as name. name should be the module's id. ensure other variables are working, and document them properly in the user-facing site.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

