### PR TITLE
feat: implement provenance metadata tracking

### DIFF
--- a/docs/design/003-storage.md
+++ b/docs/design/003-storage.md
@@ -105,8 +105,8 @@ Furthermore, so far handling the remote objects during execution has been done b
 
 ## 5. Implementation Plan
 
-1. Phase 1: Hash of benchmark yaml
-2. Phase 2: Child benchmark yaml, i.e., add additional fields
+1. ~~Phase 1: Hash of benchmark yaml~~ — implemented as `Benchmark.summary_hash()` (see design/004-yaml-specification.md Section 9). Covers execution-relevant fields only; follows the same canonicalize+sort+SHA256 convention as parameter set hashing. Short form (first 8 hex chars) is the `HASH` component of the `VERSION-HASH` artifact tag.
+2. Phase 2: Child benchmark yaml — `provenance` block now accepted in YAML (see design/004-yaml-specification.md Section 9). The `subset_of` field stores the parent's `summary_hash()`.
 3. Phase 3: Local cache
 4. Phase 4: automatic versioning
 5. Phase 5: execution module update

--- a/docs/design/004-yaml-specification.md
+++ b/docs/design/004-yaml-specification.md
@@ -17,6 +17,7 @@
 |---------|------|-------------|--------|
 | 1       | 2026-01-20 | Initial specification for v0.4 | ben |
 | 2       | 2026-03-31 | Add resource allocation (Section 8) | ben |
+| 3       | 2026-05-06 | Add provenance metadata (Section 9): canonical_url, derived_from, subset_of | ben |
 
 ## 1. Problem Statement
 
@@ -57,6 +58,10 @@ api_version: <string>                  # Optional: spec version (default: "0.4")
 software_backend: <string>             # Optional: default backend (e.g., "conda")
 software_environments: <object>        # Optional: named environments
 stages: <array>                        # Required: pipeline stages (≥1)
+provenance:                            # Optional: lineage metadata
+  canonical_url: <string>             #   URL of the authoritative publication
+  derived_from: <string>              #   identifier/URL of the upstream benchmark
+  subset_of: <string>                 #   summary hash of the parent benchmark
 ```
 
 #### Required Fields
@@ -72,6 +77,7 @@ stages: <array>                        # Required: pipeline stages (≥1)
 - `api_version`: Specification version (default: `"0.3"`)
 - `software_backend`: Default execution backend
 - `software_environments`: Named environment definitions
+- `provenance`: Lineage metadata (see Section 9)
 
 ### 3.2 Software Environments
 
@@ -593,6 +599,39 @@ metric_collectors:
       - id: plot
         path: "plot.html"
 ```
+
+## 9. Provenance Metadata
+
+The optional `provenance` block records lineage relationships between benchmarks. All fields are informational — the runtime does not act on them today, but they are preserved in the parsed model for tooling and future use.
+
+```yaml
+provenance:
+  canonical_url: "https://omnibenchmark.org/b/clustering-benchmark"
+  derived_from: "clustering-benchmark"
+  subset_of: "a1b2c3d4"
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `canonical_url` | string (URL) | Where the authoritative, published version of this benchmark lives. Useful when a benchmark is mirrored or forked across organisations. |
+| `derived_from` | string | Identifier or URL of the upstream benchmark this one was forked or adapted from. Intended to be populated automatically by a future `ob fork` command. |
+| `subset_of` | string | Summary hash of the parent benchmark of which this is a strict subset (e.g. fewer stages, modules, or parameter grid). The hash should match the value returned by `Benchmark.summary_hash()` once that method is public. |
+
+### Rationale
+
+These fields answer three common questions:
+
+- **Where is the canonical version?** (`canonical_url`) — multiple groups may publish mirrors or slight variants of the same benchmark. This field points back to the source of truth.
+- **Where did this come from?** (`derived_from`) — tracks intellectual lineage. When/if a `fork` command is added, it will write this field automatically.
+- **Is this a strict subset?** (`subset_of`) — a reduced benchmark (e.g. a quick-run variant with fewer methods) can declare which full benchmark it was derived from, enabling tools to aggregate or compare results across the two. It also allows for automated filtering and grouping of benchmarks by their subset relationship. For instance, a web editor can offer a wizard to select subsets of a benchmark for "slicing and dicing" the plan themselves, and export the subset in a standard compact notation.
+
+### Notes on `subset_of` hashing
+
+`subset_of` should be the value returned by `Benchmark.summary_hash()` on the parent benchmark. This is the same hash used to tag storage artifacts (see design/003-storage.md, Section 3 — "HASH of benchmark yaml"). It covers the execution-relevant fields only: `id`, `software_backend`, `software_environments`, `stages`, and `metric_collectors`. Descriptive fields (`benchmarker`, `authors`, `description`), the `version` string (already encoded separately in the artifact version tag as `VERSION-HASH`), storage configuration, `api_version`, and `provenance` itself are all excluded so that purely administrative edits do not invalidate artifact lineage.
+
+The hash follows the same canonicalize-then-SHA256 convention as parameter set hashing: the execution fields are serialised to canonical JSON (`json.dumps(..., sort_keys=True)`) and the full 64-character hex digest is the output. The short 8-character form (first 8 hex chars) matches the `HASH` component of the `VERSION-HASH` artifact tag described in 003-storage.md.
 
 ## 8. References
 

--- a/omnibenchmark/model/__init__.py
+++ b/omnibenchmark/model/__init__.py
@@ -12,6 +12,7 @@ from omnibenchmark.model.benchmark import (
     # Core models
     Repository,
     Storage,
+    Provenance,
     Parameter,
     IOFile,
     InputCollection,
@@ -57,6 +58,7 @@ __all__ = [
     # Core models
     "Repository",
     "Storage",
+    "Provenance",
     "Parameter",
     "IOFile",
     "InputCollection",

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -222,6 +222,23 @@ class Repository(BaseModel):
         return v
 
 
+class Provenance(BaseModel):
+    """Optional lineage metadata. No runtime effect; preserved for tooling."""
+
+    canonical_url: Optional[str] = Field(
+        None,
+        description="Canonical URL where the authoritative version of this benchmark is published",
+    )
+    derived_from: Optional[str] = Field(
+        None,
+        description="Identifier or URL of the benchmark this one was forked/derived from",
+    )
+    subset_of: Optional[str] = Field(
+        None,
+        description="summary_hash() of the parent benchmark of which this is a subset",
+    )
+
+
 class Storage(BaseModel):
     """
     Storage configuration for remote storage of benchmark artifacts.
@@ -666,6 +683,7 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
         description="Benchmark YAML specification version (deprecated, use api_version)",
     )
     api_version: APIVersion = Field(APIVersion.V0_4_0, description="API version")
+    provenance: Optional[Provenance] = Field(None, description="Lineage metadata")
 
     @field_validator("api_version", mode="before")
     @classmethod
@@ -1032,6 +1050,51 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
     def get_author(self) -> str:
         """Get author of the benchmark."""
         return self.benchmarker
+
+    def summary_hash(self) -> str:
+        """Stable SHA-256 hash of execution-relevant fields.
+
+        Follows the same canonicalize-then-hash convention as Params: the
+        fields that determine execution (id, software_backend,
+        software_environments, stages, metric_collectors) are serialised to
+        canonical JSON (sorted keys, sorted list elements where order is
+        insignificant) and hashed with SHA-256.
+
+        Excluded: benchmarker, authors, description, version (already part
+        of the storage version string per design/003-storage.md), storage
+        config, api_version, and provenance.
+
+        Returns the full 64-character hex digest.  Use [:8] for the short
+        form that matches the convention in Params.hash_short().
+        """
+        import json as _json
+        import hashlib as _hashlib
+
+        _EXEC_FIELDS = (
+            "id",
+            "software_backend",
+            "software_environments",
+            "stages",
+            "metric_collectors",
+        )
+        _OMIT_ALWAYS = {
+            "name",
+            "description",
+            "benchmarker",
+            "authors",
+            "version",
+            "storage",
+            "storage_api",
+            "storage_bucket_name",
+            "api_version",
+            "benchmark_yaml_spec",
+            "provenance",
+        }
+
+        raw = self.model_dump(mode="json")
+        execution = {k: v for k, v in raw.items() if k in _EXEC_FIELDS}
+        canonical = _json.dumps(execution, sort_keys=True)
+        return _hashlib.sha256(canonical.encode()).hexdigest()
 
     def get_software_backend(self) -> SoftwareBackendEnum:
         """Get software backend of the benchmark."""


### PR DESCRIPTION
## Ticket

#327

## Description

Add housekeeping metadata fields. `obeditor` will use these fields to track lineage of subsets of the metadata and to convey slicing logic. The ultimate goal is to allow for clean tracking of which plans are derivations or subsets.

It also helps with portability, since we can refer to a benchmark by its canonical URL.

Part of the work done here will also be used by the storage module (stable hashing).