### PR TITLE
feat: introduce filtering and capability gating (api 0.6) 

### DIFF
--- a/docs/design/000-template.md
+++ b/docs/design/000-template.md
@@ -1,21 +1,23 @@
 # 000: A new awesome feature
 
 [![Status: Draft](https://img.shields.io/badge/Status-Draft-yellow.svg)](https://github.com/omnibenchmark/docs/design)
-[![Version: 0.1](https://img.shields.io/badge/Version-0.1-blue.svg)](https://github.com/omnibenchmark/docs/design)
+[![Version: 1](https://img.shields.io/badge/Version-1-blue.svg)](https://github.com/omnibenchmark/docs/design)
 
-**Authors**: [your name], ...
-**Date**: [YYYY-MM-DD]
-**Status**: Draft
-**Version**: 0.1
-**Supersedes**: N/A
-**Reviewed-by**: TBD
-**Related Issues**: [Links to related GitHub issues]
+| Field           | Value                                |
+|-----------------|--------------------------------------|
+| Authors         | [your name], …                       |
+| Date            | [YYYY-MM-DD]                         |
+| Status          | Draft                                |
+| Version         | 1                                    |
+| Supersedes      | N/A                                  |
+| Reviewed-by     | TBD                                  |
+| Related Issues  | [Links to related GitHub issues]     |
 
 ## Changes
 
-| Version | Date | Description | Author |
-|---------|------|-------------|--------|
-| 0.1 | [YYYY-MM-DD] | Initial draft | [your name] |
+| Version | Date         | Description    | Author       |
+|---------|--------------|----------------|--------------|
+| 1       | [YYYY-MM-DD] | Initial draft  | [your name]  |
 
 ## 1. Problem Statement
 

--- a/docs/design/004-yaml-specification.md
+++ b/docs/design/004-yaml-specification.md
@@ -149,6 +149,7 @@ modules:
     name: <string>                     # Optional: human-readable name
     parameters: <array>                # Optional: module parameters
     exclude: <array>                   # Optional: exclusion list
+    requires_capabilities: <array>     # Optional: required host capabilities
 ```
 
 #### Required Fields
@@ -156,6 +157,31 @@ modules:
 - `id`: Unique identifier within stage (used as wildcard value)
 - `software_environment`: Reference to defined environment
 - `repository`: Source code specification
+
+#### Capability Gating
+
+`requires_capabilities` declares host capabilities the module needs in order
+to execute (e.g. `gpu`, `large_mem`). At run time, modules whose required set
+is not a subset of the capabilities provided via `ob run --capability <name>`
+(repeatable) are silently pruned from the resolved DAG. Their outputs are
+never registered, so downstream stages naturally lose those branches without
+any explicit exclusion logic.
+
+```yaml
+modules:
+  - id: pca_gpu
+    software_environment: cuda
+    repository:
+      url: https://github.com/example/pca-gpu
+      commit: abc1234
+    requires_capabilities: [gpu]
+```
+
+Capabilities are deliberately scoped to *host* requirements. Free-form tags
+("experimental", "phase2", …) are out of scope; if a value begs for
+free-form text it should be a parameter, a stage split, or a separate
+benchmark. See [008-filtering.md](./008-filtering.md) for the broader
+filtering design.
 
 #### Repository Specification
 

--- a/docs/design/004-yaml-specification.md
+++ b/docs/design/004-yaml-specification.md
@@ -129,7 +129,12 @@ stages:
     modules: <array>                   # Required: module list (≥1)
     inputs: <array>                    # Optional: input dependencies
     outputs: <array>                   # Optional: output declarations
+    provides: <array>                  # Optional: lineage labels (api 0.6+)
 ```
+
+`provides:` is a list of label names this stage advertises to downstream
+modules; downstream modules can gate on these labels via `requires:`. See
+[008-filtering.md §3.5](./008-filtering.md) for details.
 
 #### Stage Ordering
 

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -114,6 +114,63 @@ Rationale for silent (not strict) pruning: typos in capability names surface
 loudly via "no nodes resolved for stage X." A `--strict` mode would be
 redundant.
 
+> **TODO (follow-up):** support `requires_capabilities` at the *stage* level
+> as well, with **union** semantics — a module's effective set =
+> `stage.requires_capabilities ∪ module.requires_capabilities`. Override-down
+> (a module silently dropping a stage-level requirement) must not be allowed,
+> because it would let a module fake-pass a host gate the stage author
+> declared. Defer until a real benchmark asks: the DRY case is narrower than
+> it looks (if every module in a stage needs the same capability, that often
+> reads cleaner as a separate stage or benchmark). Tracked separately.
+
+> **TODO (follow-up):** emit a diagnostic when a stage ends up with zero
+> nodes after capability pruning (or after any other filter). Today the
+> resolved DAG silently cascades-empty downstream, which makes a typo in
+> a capability name look like "nothing happened." A single
+> `logger.warning("stage X pruned to empty by --capability …")` line at
+> graph-build time would surface this. Out of scope for the v1 cut.
+
+> **TODO (follow-up):** make capabilities settable once per host so that
+> operators don't have to retype `--capability` every run. Two layered
+> sources, both strictly additive (host facts only ever accumulate, never
+> revoke):
+>
+> - **`~/.omnibenchmarkrc`** (or equivalent user config) — the right home
+>   for *persistent* host facts: capabilities don't change between shell
+>   sessions, they're a property of the box. A workstation operator
+>   declares `capabilities: [gpu, large_mem]` once.
+> - **`OMNIBENCHMARK_CAPABILITIES=gpu,large_mem`** env var — useful for
+>   *ephemeral / scoped* contexts: CI jobs that want per-job control
+>   without writing files, `direnv`-managed project shells, container
+>   entrypoints.
+>
+> Precedence is union, not override: effective set = rc-file ∪ env ∪ CLI.
+> Each layer can only add; nothing can subtract. (If you reach for
+> subtraction, see §3.6 / the rejected-`!gpu` note.) Cheap to add when
+> someone asks.
+
+#### Considered and rejected: negative capabilities (`--capability !gpu`)
+
+A negation syntax was considered and deliberately not adopted in v1.
+`--capability` is scoped to *host facts*: "what does this machine have?"
+A `!gpu` form would conflate that with *node selection*: "which modules do
+I want to exclude?" Two reasons this is the wrong place:
+
+- **Two semantics on one flag is a UX tax.** Host-fact declaration and
+  module-set filtering are orthogonal axes; mixing them invites the user to
+  reason about which interpretation applies in each case.
+- **Most "I want to skip gpu modules" cases collapse to "don't pass
+  `--capability gpu`."** The remaining real case — "skip gpu modules on a
+  host that does have gpu" — belongs in the v2 filter spec (§3.6) as
+  `exclude: [{capability: gpu}]`, where it sits alongside other exclusions
+  in one shared selector grammar.
+- **Slippery slope.** Once `!gpu` is accepted, the next requests are
+  `gpu|tpu`, `gpu&large_mem`, regex, glob. We do not want to negotiate a
+  mini-language on this flag.
+
+If you find yourself reaching for negation, that is the signal to use the
+filter spec instead.
+
 #### What capabilities are good for
 
 Capabilities are *host facts*: things that are true (or not) about the

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -242,6 +242,20 @@ Two axes, composed by AND:
 
 A module is included only when both gates pass for the candidate node.
 
+#### Implementation status (api ≥ 0.6.0)
+
+`Stage.provides` and `Module.requires` are wired end-to-end as of api 0.6.0.
+For each label in `provides`, every node of the providing stage carries a
+value taken from a same-named parameter (if present) or defaulting to the
+module id. Downstream modules with `requires: {label: value}` run only on
+nodes whose provides dict contains the matching value; non-matching
+upstream branches are pruned at DAG-construction time.
+
+This is the *list-of-labels* form of `provides:`. A separate *map* form
+(`provides: {label: output_id}`) was proposed for gather contracts (see
+PR #291) but is intentionally out of scope here. If gather lands later,
+its binding will use a different keyword to keep the namespaces clean.
+
 #### Suggested canonical labels
 
 | Label scope | Example labels | Where declared |

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -3,7 +3,7 @@
 [![Status: Draft](https://img.shields.io/badge/Status-Draft-yellow.svg)](https://github.com/omnibenchmark/docs/design)
 [![Version: 0.1](https://img.shields.io/badge/Version-0.1-blue.svg)](https://github.com/omnibenchmark/docs/design)
 
-**Authors**: btraven00
+**Authors**: btraven00, atchox
 **Date**: 2026-05-07
 **Status**: Draft
 **Version**: 0.1
@@ -81,7 +81,7 @@ v1 is restricted to four predicates, all typed:
 
 A *selector set* is a list of selectors interpreted as a union. There is no
 boolean algebra in v1; if combinations are needed they are expressed as
-multiple selector sets (see §3.5).
+multiple selector sets (see §3.6).
 
 ### 3.2 `--until <stage>`
 
@@ -114,14 +114,91 @@ Rationale for silent (not strict) pruning: typos in capability names surface
 loudly via "no nodes resolved for stage X." A `--strict` mode would be
 redundant.
 
-### 3.4 Capabilities are *not* tags
+#### What capabilities are good for
 
-`requires_capabilities` is deliberately scoped to host capabilities. Any field
-that begs for free-form values ("experimental", "old", "phase2") is a code
-smell — it should be modeled either as a parameter, a stage split, or a
-separate benchmark.
+Capabilities are *host facts*: things that are true (or not) about the
+machine running the benchmark. They are static for the duration of a run.
+Useful categories:
 
-### 3.5 Filter spec (deferred to v2)
+| Category | Example labels | Meaning |
+|---|---|---|
+| Hardware accelerator | `gpu`, `tpu`, `cuda_12` | a specific class of accelerator is present |
+| Memory tier | `large_mem` | the host has enough RAM for the heavy method |
+| Compute tier (laptop → cluster) | `compute_xs`, `compute_sm`, `compute_md`, `compute_lg`, `compute_xl` | coarse profile of available compute (cores × RAM × time budget) |
+| Network / data access | `internet`, `s3_egress` | the host can reach remote resources at run time |
+
+The compute-tier vocabulary is a *suggested convention*, not enforced by the
+schema. A module declaring `requires_capabilities: [compute_md]` is asking
+the operator to assert "this is a medium-tier machine"; it does not measure
+RAM. The benchmark author chooses the granularity. Standardizing the names
+in the suggested set lets the wizard surface them as fixed checkboxes
+instead of free-form strings.
+
+### 3.4 Capabilities are *not* tags, and *not* lineage labels
+
+`requires_capabilities` is deliberately scoped to **host facts**, not to:
+
+- **Free-form tags** (`experimental`, `old`, `phase2`). Any value that begs
+  for free-form text is a code smell — it should be modeled as a parameter,
+  a stage split, or a separate benchmark.
+- **Lineage labels** (`dataset_size: lg`, `treatment: ctrl`). Those describe
+  the *data* flowing through an execution path, not the *host*. They are
+  expressed via the existing `provides:` (on stages) / `requires:` (on
+  modules) mechanism — see §3.5 below.
+
+This distinction matters: a host with `--capability lg` should not be
+allowed to fake-run a "large dataset only" method on small data. Host gates
+and lineage gates compose independently and a module may need both.
+
+### 3.5 Lineage-derived gates (`provides` / `requires`)
+
+Independent of capabilities, a module can be gated on properties of its
+upstream lineage. Stages emit labels via `provides:`; modules opt in via
+`requires:`. The values flow with the data, not with the host.
+
+```yaml
+stages:
+  - id: data
+    provides: [dataset_size]
+    modules:
+      - id: small_set
+        parameters: [{dataset_size: sm}]
+      - id: huge_set
+        parameters: [{dataset_size: lg}]
+        requires_capabilities: [large_mem]   # host gate at the source
+
+  - id: methods
+    modules:
+      - id: cheap_method
+        requires: {dataset_size: sm}         # lineage gate
+      - id: scalable_method
+        requires_capabilities: [gpu]         # host gate
+        # no `requires` → runs on every dataset_size
+```
+
+Two axes, composed by AND:
+
+- **Host axis** (`requires_capabilities` ↔ `--capability`): is this box
+  capable?
+- **Lineage axis** (`requires` ↔ `provides`): is this execution path
+  carrying the right kind of data?
+
+A module is included only when both gates pass for the candidate node.
+
+#### Suggested canonical labels
+
+| Label scope | Example labels | Where declared |
+|---|---|---|
+| Lineage / dataset size | `xs`, `sm`, `md`, `lg`, `xl` (as values of a `dataset_size` provides-label) | parameter on the dataset module + `provides` on the stage |
+| Lineage / domain | `treatment: ctrl|drug`, `species: human|mouse` | stage `provides:` |
+| Host / compute tier | `compute_xs`, `compute_sm`, `compute_md`, `compute_lg`, `compute_xl` | module `requires_capabilities:` + run-time `--capability` |
+| Host / hardware | `gpu`, `tpu`, `large_mem`, `internet` | module `requires_capabilities:` |
+
+These are conventions, not enforced names. Encouraging consistency lets the
+filter wizard offer fixed checkboxes and a benchmarker can pick a tier
+without reinventing one per benchmark.
+
+### 3.6 Filter spec (deferred to v2)
 
 Sketch only; do not implement in v1.
 
@@ -141,7 +218,7 @@ included. `exclude` is removed after `include`. The wizard may emit this spec
 verbatim or transport it as base64-JSON (`.obfilter`); both forms must
 round-trip.
 
-### 3.6 Provenance hooks
+### 3.7 Provenance hooks
 
 Every applied filter (including `--until` and `--capability`) is recorded
 under a `provenance.filters` block in the run metadata (#330). A child run
@@ -206,7 +283,7 @@ provenance:
 - Round-trip test: serialize → load → re-run produces the same node set.
 
 ### Phase 4 — Filter spec (deferred)
-- Implement §3.5 once the v1 features have shipped and we understand the
+- Implement §3.6 once the v1 features have shipped and we understand the
   ergonomics.
 
 ### Testing Strategy

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -1,21 +1,23 @@
 # 008: Filtering and gating mechanisms
 
 [![Status: Draft](https://img.shields.io/badge/Status-Draft-yellow.svg)](https://github.com/omnibenchmark/docs/design)
-[![Version: 0.1](https://img.shields.io/badge/Version-0.1-blue.svg)](https://github.com/omnibenchmark/docs/design)
+[![Version: 1](https://img.shields.io/badge/Version-1-blue.svg)](https://github.com/omnibenchmark/docs/design)
 
-**Authors**: btraven00, atchox
-**Date**: 2026-05-07
-**Status**: Draft
-**Version**: 0.1
-**Supersedes**: N/A
-**Reviewed-by**: TBD
-**Related Issues**: [#331](https://github.com/omnibenchmark/omnibenchmark/issues/331), [#330](https://github.com/omnibenchmark/omnibenchmark/pull/330) (provenance metadata)
+| Field           | Value                                                                                                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------|
+| Authors         | btraven00, atchox                                                                                                   |
+| Date            | 2026-05-07                                                                                                          |
+| Status          | Draft                                                                                                               |
+| Version         | 1                                                                                                                   |
+| Supersedes      | N/A                                                                                                                 |
+| Reviewed-by     | TBD                                                                                                                 |
+| Related Issues  | [#331](https://github.com/omnibenchmark/omnibenchmark/issues/331), [#330](https://github.com/omnibenchmark/omnibenchmark/pull/330) (provenance metadata) |
 
 ## Changes
 
-| Version | Date | Description | Author |
-|---------|------|-------------|--------|
-| 0.1 | 2026-05-07 | Initial draft | btraven00 |
+| Version | Date       | Description   | Author    |
+|---------|------------|---------------|-----------|
+| 1       | 2026-05-07 | Initial draft | btraven00 |
 
 ## 1. Problem Statement
 

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -242,19 +242,110 @@ Two axes, composed by AND:
 
 A module is included only when both gates pass for the candidate node.
 
-#### Implementation status (api ≥ 0.6.0)
+#### Resolution chain (api ≥ 0.6.0)
 
-`Stage.provides` and `Module.requires` are wired end-to-end as of api 0.6.0.
-For each label in `provides`, every node of the providing stage carries a
-value taken from a same-named parameter (if present) or defaulting to the
-module id. Downstream modules with `requires: {label: value}` run only on
-nodes whose provides dict contains the matching value; non-matching
-upstream branches are pruned at DAG-construction time.
+For each label declared in `Stage.provides`, the per-node value is
+resolved in order, most specific first:
 
-This is the *list-of-labels* form of `provides:`. A separate *map* form
-(`provides: {label: output_id}`) was proposed for gather contracts (see
-PR #291) but is intentionally out of scope here. If gather lands later,
-its binding will use a different keyword to keep the namespaces clean.
+1. **`Module.provides[label]`** — explicit benchmark-local binding. This is
+   the recommended form: it keeps label routing out of the module's CLI
+   parameter contract, so the same module can be reused across benchmarks
+   that use different label vocabularies.
+2. **`params[label]`** — same-named parameter on the module. Legacy /
+   convenience path: convenient when a parameter naturally doubles as a
+   label, but couples the label name to the module's CLI flags.
+3. **`module_id`** — silent default. The zero-config pattern for "label =
+   module identity" (e.g. `provides: [dataset]` on a data stage where
+   each module *is* a dataset and you gate downstream by dataset name).
+
+Downstream modules with `requires: {label: value}` run only on upstream
+nodes whose resolved label matches by exact string equality.
+
+#### Working example
+
+```yaml
+api_version: "0.6.0"
+stages:
+  - id: data
+    provides: [dataset_size]            # stage advertises this label
+    modules:
+      - id: small
+        provides: {dataset_size: sm}    # explicit, recommended form
+        parameters: [{evaluate: "1+1"}]
+      - id: huge
+        provides: {dataset_size: lg}
+        parameters: [{evaluate: "9+9"}]
+    outputs:
+      - {id: data.raw, path: "{dataset}_data.json"}
+
+  - id: methods
+    inputs: [data.raw]
+    modules:
+      - id: M_lg_only
+        requires: {dataset_size: lg}    # lineage gate
+        parameters: [{evaluate: "input+10"}]
+    outputs:
+      - {id: methods.result, path: "{dataset}_method.json"}
+```
+
+Result: `M_lg_only` runs only on the `huge` execution path; the `small`
+branch is pruned at DAG-construction time. No exclusion list, no
+cartesian-product subtraction.
+
+The "label = module identity" case is even shorter — no `Module.provides`
+needed:
+
+```yaml
+stages:
+  - id: data
+    provides: [dataset]
+    modules:
+      - id: iris
+      - id: penguins
+      - id: atlas_v2
+
+  - id: methods
+    modules:
+      - id: cheap
+        requires: {dataset: iris}       # match by module id
+```
+
+#### Scope and naming
+
+This is the *list-of-labels* form of `Stage.provides:` plus the
+*label → value* form of `Module.provides:`. A separate *map* form
+(`Stage.provides: {label: output_id}`) was proposed for gather contracts
+(see PR #291) but is intentionally out of scope here. If gather lands
+later, its binding will use a different keyword (e.g. `gather_outputs:`,
+`exports:`) to keep the namespaces clean.
+
+> **TODO (deferred — add only if needed):** *stage-level partition syntax*
+> for the case where many modules share a label value. Today, declaring
+> `Module.provides: {dataset_size: lg}` on each of N modules is verbose.
+> A partition form would let the stage author group modules by label
+> value once:
+>
+> ```yaml
+> # Proposed; NOT implemented.
+> provides:
+>   dataset_size:
+>     sm: [iris, penguins, mnist_subset]
+>     lg: [atlas_v2, big_brain]
+> ```
+>
+> Resolution would slot in between (1) and (2) above: stage-level
+> partition consulted if `Module.provides[label]` is unset. Defer until
+> a real benchmark hits this volume — for the small-N case, per-module
+> `provides:` is fine and reads more locally.
+
+> **TODO (follow-up):** a `provides` consistency check at parse time. When
+> a stage declares `provides: [X]`, warn if a module in the stage has no
+> source for X (no `Module.provides`, no matching parameter) — i.e. it
+> would silently fall through to module_id. This catches the foot-gun
+> where the author forgot to declare the value and a downstream `requires`
+> silently prunes the module. Cannot warn unconditionally at the producer
+> side (the "label = module_id" pattern is legitimate); needs to look at
+> sibling modules in the stage and the consumer side to be precise.
 
 #### Suggested canonical labels
 

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -1,0 +1,223 @@
+# 008: Filtering and gating mechanisms
+
+[![Status: Draft](https://img.shields.io/badge/Status-Draft-yellow.svg)](https://github.com/omnibenchmark/docs/design)
+[![Version: 0.1](https://img.shields.io/badge/Version-0.1-blue.svg)](https://github.com/omnibenchmark/docs/design)
+
+**Authors**: btraven00
+**Date**: 2026-05-07
+**Status**: Draft
+**Version**: 0.1
+**Supersedes**: N/A
+**Reviewed-by**: TBD
+**Related Issues**: [#331](https://github.com/omnibenchmark/omnibenchmark/issues/331), [#330](https://github.com/omnibenchmark/omnibenchmark/pull/330) (provenance metadata)
+
+## Changes
+
+| Version | Date | Description | Author |
+|---------|------|-------------|--------|
+| 0.1 | 2026-05-07 | Initial draft | btraven00 |
+
+## 1. Problem Statement
+
+A benchmark plan describes the full universe of stages, modules, and parameter
+combinations. In practice users want to run a *subset* of that universe for
+several distinct reasons:
+
+- **Capability gating** — a module needs a GPU, large memory, or a network
+  resource that is not present on the current host (#331).
+- **Partial pipelines** — during development a user wants to run only up to a
+  given stage and inspect intermediates before paying for the rest.
+- **Slicing a large benchmark** — a "child" run that is a stable, addressable
+  subset of a "parent" plan (e.g. one dataset out of ten, two methods out of
+  twenty), produced by tooling such as the `obeditor` web wizard.
+- **Ad-hoc skipping** — a known-broken module that should not block the rest
+  of a run.
+
+Today, the only mechanism that approaches this is `excludes:` (and `requires:`)
+on modules. `excludes:` is *defined by absence*: to exclude a combination, you
+must enumerate it. This is brittle for any non-trivial benchmark and does not
+help with the four cases above.
+
+## 2. Design Goals
+
+- **One selector vocabulary** shared by every gating feature, so that users
+  learn one mental model.
+- **Transparent specs**: filter definitions must be human-readable and
+  diffable. Opaque blobs are acceptable as a *transport* for tooling output but
+  not as the source of truth.
+- **Provenance integration**: every applied filter is recorded in the run's
+  provenance metadata (#330) so that a child run can be reproduced from
+  *parent + filter*.
+- **Additive, not subtractive**: prefer mechanisms that say "include if X"
+  over "exclude when Y".
+- **Cheap to start**: this design is rolled out feature-by-feature; no
+  big-bang migration.
+
+### Non-Goals
+
+- A general filter language. We are not building XPath/JMESPath; the selector
+  vocabulary stays small and typed.
+- Free-form `tags:` on modules. Tags ossify into a parallel DSL that the model
+  layer cannot type-check. We prefer typed fields (`requires_capabilities`,
+  parameter predicates) for every use case we can foresee.
+- The `.obfilter` opaque blob as a v1 surface. It remains a possible *output*
+  of `obeditor`, but the underlying spec must be transparent.
+- Replacing the cartesian-expansion engine. `provides`/`requires` already
+  exists and is the seed of an additive model; we grow it, we do not rewrite.
+
+## 3. Proposed Solution
+
+### 3.1 Selector vocabulary
+
+A *selector* identifies a set of nodes in the resolved DAG. The vocabulary in
+v1 is restricted to four predicates, all typed:
+
+| Selector | Matches |
+|---|---|
+| `stage_id: <id>` | every node whose `stage_id` equals `<id>` |
+| `module_id: <id>` | every node whose `module_id` equals `<id>` |
+| `capability: <name>` | every node whose module declares `<name>` in `requires_capabilities` |
+| `param: {key: <k>, value: <v>}` | every node whose `parameters[k] == v` |
+
+A *selector set* is a list of selectors interpreted as a union. There is no
+boolean algebra in v1; if combinations are needed they are expressed as
+multiple selector sets (see §3.5).
+
+### 3.2 `--until <stage>`
+
+Stops the resolved DAG at and including `<stage>`. Exactly one stage may be
+named.
+
+- Validate that `<stage>` exists; error otherwise.
+- Compute `cutoff = stage_order.index(<stage>)` and prune `resolved_nodes` to
+  those whose `stage_id` is in `stage_order[:cutoff+1]`.
+- Skip metric-collector resolution if any of its declared inputs reference
+  pruned outputs.
+
+### 3.3 `--capability <name>` (repeatable)
+
+Declares a capability available on the current host. Modules may declare
+required capabilities:
+
+```yaml
+modules:
+  - id: gpu_pca
+    requires_capabilities: [gpu]
+```
+
+Resolution rule: a module whose `requires_capabilities` is not a subset of the
+provided set is *silently pruned* — its outputs are never registered in
+`output_to_nodes`, so downstream stages naturally lose those branches without
+explicit exclusion logic. One info-level log line per pruned module.
+
+Rationale for silent (not strict) pruning: typos in capability names surface
+loudly via "no nodes resolved for stage X." A `--strict` mode would be
+redundant.
+
+### 3.4 Capabilities are *not* tags
+
+`requires_capabilities` is deliberately scoped to host capabilities. Any field
+that begs for free-form values ("experimental", "old", "phase2") is a code
+smell — it should be modeled either as a parameter, a stage split, or a
+separate benchmark.
+
+### 3.5 Filter spec (deferred to v2)
+
+Sketch only; do not implement in v1.
+
+```yaml
+filter:
+  include:
+    - stage_id: data
+      module_id: D1
+    - stage_id: methods
+      module_id: M1
+  exclude:
+    - capability: gpu
+```
+
+Rules: `include` is a positive selector set; if absent, all nodes are
+included. `exclude` is removed after `include`. The wizard may emit this spec
+verbatim or transport it as base64-JSON (`.obfilter`); both forms must
+round-trip.
+
+### 3.6 Provenance hooks
+
+Every applied filter (including `--until` and `--capability`) is recorded
+under a `provenance.filters` block in the run metadata (#330). A child run
+declares its parent benchmark by canonical URL plus the applied filter spec.
+This is what makes a sliced run reproducible.
+
+Concretely:
+
+```yaml
+provenance:
+  parent: https://example.org/benchmarks/foo@v1.2.3
+  filters:
+    until: methods
+    capabilities: [gpu]
+```
+
+## 4. Alternatives Considered
+
+### Alternative 1: free-form `tags:` on modules
+- **Description**: arbitrary string tags + `--skip <tag>`.
+- **Pros**: maximally flexible.
+- **Cons**: opaque to the model, no type checking, attracts every gating
+  question into one over-loaded field.
+- **Reason for rejection**: see §2 non-goals. Capabilities cover the concrete
+  use case in #331 with stronger semantics.
+
+### Alternative 2: replace cartesian + excludes with provides/wants slots
+- **Description**: full slot-and-signal mechanism, declarative wiring.
+- **Pros**: cleanest model, additive by construction.
+- **Cons**: large engine change; pushback on perceived complexity.
+- **Reason for rejection (for now)**: `requires:`/`provides:` already exist
+  on stages and modules and resolve through `_satisfies_requires`. We extend
+  rather than replace.
+
+### Alternative 3: `.obfilter` opaque blob as primary surface
+- **Description**: wizard emits a signed/encoded blob; tooling consumes it.
+- **Pros**: tamper-evident, easy to embed in URLs.
+- **Cons**: unreviewable in PRs; drifts silently when the parent plan
+  evolves; teaches users a thing they can't read.
+- **Reason for rejection**: kept as a *transport* for the underlying
+  transparent spec, not as the source of truth.
+
+## 5. Implementation Plan
+
+### Phase 1 — `--until <stage>`
+- CLI flag, single stage, validation against `stage_order`.
+- Prune resolved nodes; skip metric collectors that reference pruned outputs.
+- Tests: until=initial / middle / terminal / unknown / stage with multiple
+  providers.
+
+### Phase 2 — `--capability` + `requires_capabilities`
+- Model: `requires_capabilities: list[str]` on `Module` (and optionally
+  `Stage`).
+- CLI: repeatable `--capability` flag.
+- Resolution: prune modules whose required set ⊄ available set; do not
+  register their outputs.
+- Tests: missing capability prunes module; pruning cascades; provided
+  capabilities log line; interaction with `--until`.
+
+### Phase 3 — Provenance plumbing
+- After #330 lands, emit applied filters into the provenance block.
+- Round-trip test: serialize → load → re-run produces the same node set.
+
+### Phase 4 — Filter spec (deferred)
+- Implement §3.5 once the v1 features have shipped and we understand the
+  ergonomics.
+
+### Testing Strategy
+- Unit: selector predicates, `--until` boundary cases, capability pruning
+  cascades.
+- Integration: an e2e fixture that exercises capability-gated modules across
+  a multi-stage DAG.
+- Provenance round-trip in a separate test once #330 lands.
+
+## 6. References
+
+1. [Issue #331 — conditional execution of modules](https://github.com/omnibenchmark/omnibenchmark/issues/331)
+2. [PR #330 — provenance metadata tracking](https://github.com/omnibenchmark/omnibenchmark/pull/330)
+3. [Snakemake `--until` semantics](https://snakemake.readthedocs.io/en/stable/executing/cli.html)

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -125,6 +125,17 @@ def format_pydantic_errors(e: PydanticValidationError) -> str:
         "reference pruned stages are skipped."
     ),
 )
+@click.option(
+    "--capability",
+    "capabilities",
+    multiple=True,
+    type=str,
+    help=(
+        "Declare a host capability available to this run (repeatable). "
+        "Modules whose `requires_capabilities` is not a subset of the "
+        "declared set are silently pruned from the resolved DAG."
+    ),
+)
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def run(
@@ -140,6 +151,7 @@ def run(
     use_remote_storage,
     module_filter,
     until_stage,
+    capabilities,
     snakemake_args,
 ):
     """Run a benchmark.
@@ -203,6 +215,7 @@ def run(
         use_remote_storage=use_remote_storage,
         module_filter=module_filter,
         until_stage=until_stage,
+        capabilities=set(capabilities or ()),
         snakemake_args=list(snakemake_args),
     )
 
@@ -219,6 +232,7 @@ def _run_benchmark(
     use_remote_storage=False,
     module_filter=None,
     until_stage=None,
+    capabilities=None,
     snakemake_args=None,
 ):
     """Run a full benchmark, or a single-module sub-graph when module_filter is set."""
@@ -262,6 +276,7 @@ def _run_benchmark(
             unpinned=unpinned,
             module_filter=module_filter,
             until_stage=until_stage,
+            capabilities=capabilities or set(),
         )
     except ValueError as e:
         log_error_and_quit(logger, str(e))
@@ -647,6 +662,18 @@ def _apply_until_filter(stages, until_stage):
     )
 
 
+def _module_satisfies_capabilities(module, available_capabilities):
+    """Return True if a module's `requires_capabilities` is satisfied.
+
+    A module without `requires_capabilities` is always satisfied. Otherwise,
+    every required capability must appear in `available_capabilities`.
+    """
+    required = getattr(module, "requires_capabilities", None) or []
+    if not required:
+        return True
+    return set(required).issubset(set(available_capabilities or ()))
+
+
 def _filter_collectors_by_stages(collectors, included_stage_ids, benchmark):
     """Drop metric collectors whose declared inputs reference pruned stages.
 
@@ -695,6 +722,7 @@ def _generate_explicit_snakefile(
     unpinned: bool = False,
     module_filter: Optional[str] = None,
     until_stage: Optional[str] = None,
+    capabilities: Optional[set] = None,
 ):
     """Generate explicit Snakefile from resolved modules."""
     from omnibenchmark.cli.progress import ProgressDisplay
@@ -901,6 +929,22 @@ def _generate_explicit_snakefile(
                 modules_to_expand = stage.modules[:1]
         else:
             modules_to_expand = stage.modules
+
+        # Capability gating: drop modules whose required capabilities are not
+        # provided. Outputs from a pruned module are never registered, so
+        # downstream stages naturally lose those branches.
+        if capabilities is not None:
+            kept = []
+            for mod in modules_to_expand:
+                if _module_satisfies_capabilities(mod, capabilities):
+                    kept.append(mod)
+                else:
+                    required = ", ".join(mod.requires_capabilities or [])
+                    logger.info(
+                        f"--capability: skipping {stage.id}/{mod.id} "
+                        f"(requires: [{required}])."
+                    )
+            modules_to_expand = kept
 
         for module in modules_to_expand:
             module_id = module.id

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -565,13 +565,39 @@ def _substitute_params_in_path(template: str, params) -> str:
     return re.sub(r"\{params\.([^}]+)\}", _replace, template)
 
 
+def _resolve_label_value(
+    label: str,
+    module_provides,
+    params,
+    module_id: str,
+) -> str:
+    """Resolve a single provides label's value for one node.
+
+    Precedence (most specific wins):
+      1. ``module.provides[label]`` — explicit benchmark-local binding.
+      2. ``params[label]`` — same-named parameter (legacy convention).
+      3. ``module_id`` — silent default for the "label = module identity"
+         case, which is the zero-config pattern for data stages.
+    """
+    if module_provides and label in module_provides:
+        return str(module_provides[label])
+    if params is not None and label in params:
+        return str(params[label])
+    return module_id
+
+
 def _build_template_context(
     stage,
     module_id: str,
     input_node=None,
     params=None,
+    module_provides=None,
 ) -> TemplateContext:
-    """Build a TemplateContext for a node during expansion."""
+    """Build a TemplateContext for a node during expansion.
+
+    `module_provides` is the optional `Module.provides` dict (label → value).
+    When supplied it takes precedence over same-named parameters.
+    """
     provides: dict[str, str] = {}
     module_attrs: dict[str, str] = {"id": module_id, "stage": stage.id}
 
@@ -583,20 +609,18 @@ def _build_template_context(
 
         if stage_provides:
             for label in stage_provides:
-                if params is not None and label in params:
-                    provides[label] = str(params[label])
-                else:
-                    provides[label] = module_id
+                provides[label] = _resolve_label_value(
+                    label, module_provides, params, module_id
+                )
 
         module_attrs["parent.id"] = input_node.module_id
         module_attrs["parent.stage"] = input_node.stage_id
     else:
         if stage_provides:
             for label in stage_provides:
-                if params is not None and label in params:
-                    provides[label] = str(params[label])
-                else:
-                    provides[label] = module_id
+                provides[label] = _resolve_label_value(
+                    label, module_provides, params, module_id
+                )
 
         if params is not None and "dataset" in params:
             provides.setdefault("dataset", str(params["dataset"]))
@@ -1087,6 +1111,7 @@ def _generate_explicit_snakefile(
                         module_id=module_id,
                         input_node=input_node,
                         params=params,
+                        module_provides=getattr(module, "provides", None),
                     )
 
                     outputs = []

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -113,6 +113,18 @@ def format_pydantic_errors(e: PydanticValidationError) -> str:
         "first upstream input × parameter expansion for each module."
     ),
 )
+@click.option(
+    "--until",
+    "until_stage",
+    default=None,
+    type=str,
+    help=(
+        "Stop the pipeline at and including the named stage. "
+        "Stages declared after the named stage in the benchmark YAML are "
+        "pruned from the resolved DAG, and metric collectors whose inputs "
+        "reference pruned stages are skipped."
+    ),
+)
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def run(
@@ -127,6 +139,7 @@ def run(
     yes_flag,
     use_remote_storage,
     module_filter,
+    until_stage,
     snakemake_args,
 ):
     """Run a benchmark.
@@ -170,6 +183,14 @@ def run(
             f"-m {module_filter}: single execution path, first param expansion only."
         )
 
+    if module_filter and until_stage:
+        log_error_and_quit(
+            logger,
+            "--until and -m/--module cannot be combined: -m already truncates "
+            "the DAG at the target module's stage.",
+        )
+        return
+
     _run_benchmark(
         benchmark_path=benchmark,
         cores=cores,
@@ -181,6 +202,7 @@ def run(
         unpinned=unpinned,
         use_remote_storage=use_remote_storage,
         module_filter=module_filter,
+        until_stage=until_stage,
         snakemake_args=list(snakemake_args),
     )
 
@@ -196,6 +218,7 @@ def _run_benchmark(
     unpinned=False,
     use_remote_storage=False,
     module_filter=None,
+    until_stage=None,
     snakemake_args=None,
 ):
     """Run a full benchmark, or a single-module sub-graph when module_filter is set."""
@@ -227,17 +250,22 @@ def _run_benchmark(
     populate_git_cache(b, quiet=use_clean_ui, cores=cores)
 
     # Step 2: Generate explicit Snakefile
-    _generate_explicit_snakefile(
-        benchmark=b,
-        benchmark_yaml_path=benchmark_path_abs,
-        out_dir=out_dir_path,
-        cores=cores,
-        quiet=use_clean_ui,
-        start_time=start_time,
-        dirty=dirty,
-        unpinned=unpinned,
-        module_filter=module_filter,
-    )
+    try:
+        _generate_explicit_snakefile(
+            benchmark=b,
+            benchmark_yaml_path=benchmark_path_abs,
+            out_dir=out_dir_path,
+            cores=cores,
+            quiet=use_clean_ui,
+            start_time=start_time,
+            dirty=dirty,
+            unpinned=unpinned,
+            module_filter=module_filter,
+            until_stage=until_stage,
+        )
+    except ValueError as e:
+        log_error_and_quit(logger, str(e))
+        return
 
     # Write run manifest
     write_run_manifest(output_dir=out_dir_path)
@@ -601,6 +629,49 @@ def _select_input_nodes(
     return [n for n in resolved_nodes if n.stage_id == deepest_stage_id]
 
 
+def _apply_until_filter(stages, until_stage):
+    """Truncate a stage list to include only stages up to and including `until_stage`.
+
+    Returns the original sequence as a list when `until_stage` is None.
+    Raises ValueError when the named stage is not present.
+    """
+    stages = list(stages)
+    if until_stage is None:
+        return stages
+    for idx, stage in enumerate(stages):
+        if stage.id == until_stage:
+            return stages[: idx + 1]
+    available = ", ".join(s.id for s in stages)
+    raise ValueError(
+        f"--until: stage '{until_stage}' not found. Available stages: {available}"
+    )
+
+
+def _filter_collectors_by_stages(collectors, included_stage_ids, benchmark):
+    """Drop metric collectors whose declared inputs reference pruned stages.
+
+    Returns a tuple (kept, dropped_ids). A collector is dropped when any of its
+    declared input ids resolves to a stage outside `included_stage_ids` (or to
+    no stage at all — that case is left to the regular collector resolver to
+    warn about).
+    """
+    kept = []
+    dropped = []
+    for c in collectors or []:
+        keep = True
+        for input_ref in c.inputs:
+            input_id = input_ref if isinstance(input_ref, str) else input_ref.id
+            stage = benchmark.get_stage_by_output(input_id)
+            if stage is not None and stage.id not in included_stage_ids:
+                keep = False
+                break
+        if keep:
+            kept.append(c)
+        else:
+            dropped.append(c.id)
+    return kept, dropped
+
+
 def _satisfies_requires(requires: dict, input_node) -> bool:
     """Return True if the input_node's lineage satisfies all requires constraints."""
     if not input_node.template_context:
@@ -623,6 +694,7 @@ def _generate_explicit_snakefile(
     dirty: bool = False,
     unpinned: bool = False,
     module_filter: Optional[str] = None,
+    until_stage: Optional[str] = None,
 ):
     """Generate explicit Snakefile from resolved modules."""
     from omnibenchmark.cli.progress import ProgressDisplay
@@ -805,7 +877,12 @@ def _generate_explicit_snakefile(
             "first expansion only."
         )
     else:
-        stages_to_expand = benchmark.model.stages
+        stages_to_expand = _apply_until_filter(benchmark.model.stages, until_stage)
+        if until_stage is not None:
+            logger.info(
+                f"--until {until_stage}: expanding {len(stages_to_expand)} stage(s) "
+                f"(up to and including '{until_stage}')."
+            )
 
     resolved_nodes = []
     output_to_nodes = {}
@@ -1056,9 +1133,20 @@ def _generate_explicit_snakefile(
 
     # Resolve metric collectors (skip in -m module mode)
     if not module_filter:
+        collectors_to_resolve = benchmark.model.get_metric_collectors()
+        if until_stage is not None:
+            included_ids = {s.id for s in stages_to_expand}
+            collectors_to_resolve, dropped = _filter_collectors_by_stages(
+                collectors_to_resolve, included_ids, benchmark.model
+            )
+            for cid in dropped:
+                logger.info(
+                    f"--until {until_stage}: skipping metric collector "
+                    f"'{cid}' (references pruned stages)."
+                )
         try:
             collector_nodes = resolve_metric_collectors(
-                metric_collectors=benchmark.model.get_metric_collectors(),
+                metric_collectors=collectors_to_resolve,
                 resolved_nodes=resolved_nodes,
                 benchmark=benchmark.model,
                 resolver=resolver,

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -500,6 +500,16 @@ class Module(DescribableEntity, SoftwareEnvironmentReference):
             "silently pruned from the resolved DAG."
         ),
     )
+    provides: Optional[Dict[str, str]] = Field(
+        None,
+        description=(
+            "Explicit benchmark-local label bindings for this module. Maps "
+            "label name → value. Takes precedence over the parameter-name "
+            "matching fallback. Use this to keep label routing out of the "
+            "module's CLI parameter contract — modules stay reusable across "
+            "benchmarks that use different label vocabularies."
+        ),
+    )
     resources: Optional[Resources] = Field(
         None,
         description="Resource requirements (overrides stage-level resources)",

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -562,6 +562,16 @@ class Stage(DescribableEntity):
     resources: Optional[Resources] = Field(
         None, description="Resource requirements for rules in this stage"
     )
+    provides: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Lineage labels this stage advertises to downstream modules. "
+            "For each label, every node of this stage carries a value, taken "
+            "from a same-named parameter if present, otherwise the module id. "
+            "Downstream modules can gate on these labels via `requires:`. "
+            "Distinct from gather/collector bindings (out of scope here)."
+        ),
+    )
 
     @field_validator("outputs")
     @classmethod
@@ -1225,10 +1235,17 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
                     if collector.software_environment is None:
                         collector.software_environment = sole_env_id
 
-        # Gate api_version-introduced fields. `requires_capabilities` was
-        # introduced in 0.6.0 and must not be used by older specs.
+        # Gate api_version-introduced fields. `requires_capabilities` and
+        # `Stage.provides` were introduced in 0.6.0 and must not be used by
+        # older specs.
         if self.api_version < APIVersion.V0_6_0:
             for stage in self.stages:
+                if stage.provides:
+                    raise ValueError(
+                        f"Stage '{stage.id}' uses `provides`, which requires "
+                        f"api_version ≥ 0.6.0 (this benchmark declares "
+                        f"{self.api_version.value})."
+                    )
                 for module in stage.modules:
                     if module.requires_capabilities:
                         raise ValueError(

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -129,10 +129,11 @@ class APIVersion(str, Enum):
     V0_3_0 = "0.3.0"
     V0_4_0 = "0.4.0"
     V0_5_0 = "0.5.0"
+    V0_6_0 = "0.6.0"
 
     @classmethod
     def latest(cls) -> "APIVersion":
-        return cls.V0_5_0
+        return cls.V0_6_0
 
     @classmethod
     def supported_versions(cls) -> set[str]:
@@ -488,6 +489,15 @@ class Module(DescribableEntity, SoftwareEnvironmentReference):
             "Explicit upstream plugs. Maps provides-label → module-id. "
             "This module is wired only to the specified ancestor node for each "
             "named label."
+        ),
+    )
+    requires_capabilities: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Host capabilities required to run this module (e.g. 'gpu', "
+            "'large_mem'). At run time, modules whose required set is not a "
+            "subset of the capabilities provided via `--capability` are "
+            "silently pruned from the resolved DAG."
         ),
     )
     resources: Optional[Resources] = Field(
@@ -1214,6 +1224,18 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
                 for collector in self.metric_collectors:
                     if collector.software_environment is None:
                         collector.software_environment = sole_env_id
+
+        # Gate api_version-introduced fields. `requires_capabilities` was
+        # introduced in 0.6.0 and must not be used by older specs.
+        if self.api_version < APIVersion.V0_6_0:
+            for stage in self.stages:
+                for module in stage.modules:
+                    if module.requires_capabilities:
+                        raise ValueError(
+                            f"Module '{module.id}' uses `requires_capabilities`, "
+                            f"which requires api_version ≥ 0.6.0 "
+                            f"(this benchmark declares {self.api_version.value})."
+                        )
 
         # Call the pure model validation from the validator base class
         self.validate_model_structure()

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -18,6 +18,7 @@ from omnibenchmark.cli.run import (
     _satisfies_requires,
     _apply_until_filter,
     _filter_collectors_by_stages,
+    _module_satisfies_capabilities,
     run,
 )
 from omnibenchmark.git.prefetch import populate_git_cache
@@ -961,3 +962,59 @@ class TestUntilCliConflict:
                 )
         assert result.exit_code != 0
         assert any("cannot be combined" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _module_satisfies_capabilities
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubModule:
+    id: str
+    requires_capabilities: list = None
+
+
+@pytest.mark.short
+class TestModuleSatisfiesCapabilities:
+    def test_no_required_capabilities_always_satisfies(self):
+        m = _StubModule("M1", requires_capabilities=None)
+        assert _module_satisfies_capabilities(m, set()) is True
+        assert _module_satisfies_capabilities(m, {"gpu"}) is True
+
+    def test_empty_required_list_always_satisfies(self):
+        m = _StubModule("M1", requires_capabilities=[])
+        assert _module_satisfies_capabilities(m, set()) is True
+
+    def test_single_required_capability_present(self):
+        m = _StubModule("M1", requires_capabilities=["gpu"])
+        assert _module_satisfies_capabilities(m, {"gpu"}) is True
+
+    def test_single_required_capability_missing(self):
+        m = _StubModule("M1", requires_capabilities=["gpu"])
+        assert _module_satisfies_capabilities(m, set()) is False
+        assert _module_satisfies_capabilities(m, {"large_mem"}) is False
+
+    def test_multiple_required_all_present(self):
+        m = _StubModule("M1", requires_capabilities=["gpu", "large_mem"])
+        assert _module_satisfies_capabilities(m, {"gpu", "large_mem"}) is True
+
+    def test_multiple_required_partially_present(self):
+        m = _StubModule("M1", requires_capabilities=["gpu", "large_mem"])
+        assert _module_satisfies_capabilities(m, {"gpu"}) is False
+
+    def test_extra_available_capabilities_ignored(self):
+        m = _StubModule("M1", requires_capabilities=["gpu"])
+        assert _module_satisfies_capabilities(m, {"gpu", "large_mem", "ssd"}) is True
+
+    def test_none_available_treated_as_empty(self):
+        m_no_req = _StubModule("M1", requires_capabilities=None)
+        m_req = _StubModule("M2", requires_capabilities=["gpu"])
+        assert _module_satisfies_capabilities(m_no_req, None) is True
+        assert _module_satisfies_capabilities(m_req, None) is False
+
+    def test_module_without_attribute(self):
+        # Older Module objects from cache may lack the attribute entirely.
+        m = type("Bare", (), {"id": "M1"})()
+        assert _module_satisfies_capabilities(m, set()) is True
+        assert _module_satisfies_capabilities(m, {"gpu"}) is True

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -14,6 +14,7 @@ from omnibenchmark.cli.run import (
     _run_snakemake,
     _substitute_params_in_path,
     _build_template_context,
+    _resolve_label_value,
     _select_input_nodes,
     _satisfies_requires,
     _apply_until_filter,
@@ -1117,3 +1118,122 @@ stages:
         node = _make_input_node("small", "data", template_context=ctx)
         m = b.stages[1].modules[0]
         assert _satisfies_requires(m.requires, node) is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_label_value (precedence chain)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestResolveLabelValue:
+    """Module-level provides > params > module_id fallback."""
+
+    def test_module_provides_wins_over_params(self):
+        result = _resolve_label_value(
+            "dataset_size",
+            module_provides={"dataset_size": "lg"},
+            params=Params({"dataset_size": "sm"}),
+            module_id="huge",
+        )
+        assert result == "lg"
+
+    def test_module_provides_wins_over_module_id(self):
+        result = _resolve_label_value(
+            "dataset_size",
+            module_provides={"dataset_size": "lg"},
+            params=None,
+            module_id="huge",
+        )
+        assert result == "lg"
+
+    def test_params_used_when_module_provides_unset(self):
+        result = _resolve_label_value(
+            "dataset_size",
+            module_provides=None,
+            params=Params({"dataset_size": "sm"}),
+            module_id="huge",
+        )
+        assert result == "sm"
+
+    def test_params_used_when_module_provides_lacks_label(self):
+        result = _resolve_label_value(
+            "dataset_size",
+            module_provides={"other_label": "x"},
+            params=Params({"dataset_size": "sm"}),
+            module_id="huge",
+        )
+        assert result == "sm"
+
+    def test_module_id_fallback_when_nothing_set(self):
+        result = _resolve_label_value(
+            "dataset_size",
+            module_provides=None,
+            params=None,
+            module_id="huge",
+        )
+        assert result == "huge"
+
+    def test_module_id_fallback_with_empty_dicts(self):
+        result = _resolve_label_value(
+            "dataset_size",
+            module_provides={},
+            params=Params({}),
+            module_id="huge",
+        )
+        assert result == "huge"
+
+    def test_value_coerced_to_string(self):
+        # parameters can be ints/floats; provides values too
+        assert (
+            _resolve_label_value(
+                "n",
+                module_provides={"n": 42},
+                params=None,
+                module_id="m",
+            )
+            == "42"
+        )
+
+
+@pytest.mark.short
+class TestBuildTemplateContextWithModuleProvides:
+    """End-to-end behavior of _build_template_context with module.provides."""
+
+    def test_module_provides_overrides_param_at_root(self):
+        stage = _make_stage("data", provides=["dataset_size"])
+        ctx = _build_template_context(
+            stage,
+            "huge",
+            params=Params({"dataset_size": "sm"}),
+            module_provides={"dataset_size": "lg"},
+        )
+        assert ctx.provides["dataset_size"] == "lg"
+
+    def test_module_provides_overrides_at_child_node(self):
+        parent_ctx = TemplateContext(
+            provides={"dataset_size": "lg"},
+            module_attrs={"id": "huge", "stage": "data"},
+        )
+        input_node = _make_input_node("huge", "data", template_context=parent_ctx)
+        stage = _make_stage("methods", provides=["method_kind"])
+        ctx = _build_template_context(
+            stage,
+            "fast_method",
+            input_node=input_node,
+            module_provides={"method_kind": "approximate"},
+        )
+        # downstream label overridden
+        assert ctx.provides["method_kind"] == "approximate"
+        # upstream label still flows through unchanged
+        assert ctx.provides["dataset_size"] == "lg"
+
+    def test_no_module_provides_falls_back_to_existing_chain(self):
+        stage = _make_stage("data", provides=["dataset_size"])
+        ctx = _build_template_context(
+            stage,
+            "huge",
+            params=Params({"dataset_size": "lg"}),
+            module_provides=None,
+        )
+        assert ctx.provides["dataset_size"] == "lg"

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -1018,3 +1018,102 @@ class TestModuleSatisfiesCapabilities:
         m = type("Bare", (), {"id": "M1"})()
         assert _module_satisfies_capabilities(m, set()) is True
         assert _module_satisfies_capabilities(m, {"gpu"}) is True
+
+
+# ---------------------------------------------------------------------------
+# Stage.provides → Module.requires end-to-end (real model, not stubs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestProvidesRequiresIntegration:
+    """Exercises the full chain: parsed Benchmark → context build → require gate."""
+
+    YAML = """
+id: lineage_smoke
+description: smoke test for stage.provides → module.requires
+version: "1.0"
+benchmarker: x
+api_version: "0.6.0"
+software_backend: host
+software_environments:
+  host: {description: h}
+stages:
+  - id: data
+    provides: [dataset_size]
+    modules:
+      - id: small
+        software_environment: host
+        repository: {url: https://example.com/r, commit: abc1234}
+        parameters:
+          - dataset_size: sm
+      - id: huge
+        software_environment: host
+        repository: {url: https://example.com/r, commit: abc1234}
+        parameters:
+          - dataset_size: lg
+    outputs:
+      - {id: data.raw, path: D1.json}
+  - id: methods
+    inputs: [data.raw]
+    modules:
+      - id: M_lg_only
+        software_environment: host
+        requires: {dataset_size: lg}
+        repository: {url: https://example.com/r, commit: abc1234}
+    outputs:
+      - {id: methods.result, path: M1.json}
+"""
+
+    def _parse(self):
+        from omnibenchmark.model import Benchmark
+
+        return Benchmark.from_yaml(self.YAML)
+
+    def test_stage_provides_survives_parse(self):
+        b = self._parse()
+        assert b.stages[0].provides == ["dataset_size"]
+
+    def test_data_node_carries_label_value_from_params(self):
+        """A data node built with `dataset_size: lg` carries that in provides."""
+        b = self._parse()
+        data_stage = b.stages[0]
+        # huge module has dataset_size: lg
+        huge_params = Params.expand_from_parameter(
+            b.stages[0].modules[1].parameters[0]
+        )[0]
+        ctx = _build_template_context(data_stage, "huge", params=huge_params)
+        assert ctx.provides.get("dataset_size") == "lg"
+
+    def test_data_node_label_defaults_to_module_id_without_param(self):
+        """If a label has no matching param, it defaults to the module id."""
+        # A stage that provides a label with no corresponding param.
+        b = self._parse()
+        data_stage = b.stages[0]
+        ctx = _build_template_context(data_stage, "small")  # no params
+        # small does not have a `dataset_size` param either way, so label
+        # falls back to module_id "small"
+        assert ctx.provides.get("dataset_size") == "small"
+
+    def test_requires_matches_lg_node(self):
+        b = self._parse()
+        data_stage = b.stages[0]
+        huge_params = Params.expand_from_parameter(
+            b.stages[0].modules[1].parameters[0]
+        )[0]
+        ctx = _build_template_context(data_stage, "huge", params=huge_params)
+        node = _make_input_node("huge", "data", template_context=ctx)
+        # Module M_lg_only has requires: {dataset_size: lg}
+        m = b.stages[1].modules[0]
+        assert _satisfies_requires(m.requires, node) is True
+
+    def test_requires_rejects_sm_node(self):
+        b = self._parse()
+        data_stage = b.stages[0]
+        small_params = Params.expand_from_parameter(
+            b.stages[0].modules[0].parameters[0]
+        )[0]
+        ctx = _build_template_context(data_stage, "small", params=small_params)
+        node = _make_input_node("small", "data", template_context=ctx)
+        m = b.stages[1].modules[0]
+        assert _satisfies_requires(m.requires, node) is False

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -1,6 +1,7 @@
 """Short unit tests for cli/run.py pure and near-pure helper functions."""
 
 import pytest
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from pydantic import ValidationError as PydanticValidationError
@@ -15,6 +16,8 @@ from omnibenchmark.cli.run import (
     _build_template_context,
     _select_input_nodes,
     _satisfies_requires,
+    _apply_until_filter,
+    _filter_collectors_by_stages,
     run,
 )
 from omnibenchmark.git.prefetch import populate_git_cache
@@ -786,3 +789,175 @@ def test_run_benchmark_remote_storage_true_bool_appended(tmp_path):
         _, kwargs = mock_snakemake.call_args
         extra = kwargs["extra_snakemake_args"]
         assert "--use-conda" in extra
+
+
+# ---------------------------------------------------------------------------
+# _apply_until_filter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubStage:
+    id: str
+
+
+@pytest.mark.short
+class TestApplyUntilFilter:
+    def _stages(self, *ids):
+        return [_StubStage(i) for i in ids]
+
+    def test_none_returns_all_stages_as_list(self):
+        stages = self._stages("a", "b", "c")
+        result = _apply_until_filter(stages, None)
+        assert [s.id for s in result] == ["a", "b", "c"]
+        # must be a fresh list, not the same object
+        assert result is not stages
+
+    def test_initial_stage_keeps_only_first(self):
+        result = _apply_until_filter(self._stages("a", "b", "c"), "a")
+        assert [s.id for s in result] == ["a"]
+
+    def test_middle_stage_includes_named(self):
+        result = _apply_until_filter(self._stages("a", "b", "c", "d"), "b")
+        assert [s.id for s in result] == ["a", "b"]
+
+    def test_terminal_stage_returns_full_list(self):
+        result = _apply_until_filter(self._stages("a", "b", "c"), "c")
+        assert [s.id for s in result] == ["a", "b", "c"]
+
+    def test_unknown_stage_raises(self):
+        with pytest.raises(ValueError, match="stage 'nope' not found"):
+            _apply_until_filter(self._stages("a", "b"), "nope")
+
+    def test_unknown_stage_lists_available(self):
+        with pytest.raises(ValueError, match="a, b"):
+            _apply_until_filter(self._stages("a", "b"), "missing")
+
+    def test_empty_stages_with_until_raises(self):
+        with pytest.raises(ValueError):
+            _apply_until_filter([], "anything")
+
+    def test_empty_stages_without_until_returns_empty(self):
+        assert _apply_until_filter([], None) == []
+
+
+# ---------------------------------------------------------------------------
+# _filter_collectors_by_stages
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubCollector:
+    id: str
+    inputs: list
+
+
+@pytest.mark.short
+class TestFilterCollectorsByStages:
+    def _benchmark(self, output_to_stage):
+        """Build a stub benchmark whose get_stage_by_output returns mapped stages."""
+        bench = MagicMock()
+        bench.get_stage_by_output.side_effect = lambda oid: output_to_stage.get(oid)
+        return bench
+
+    def test_keeps_collector_when_all_inputs_in_included_stages(self):
+        bench = self._benchmark({"methods.result": _StubStage("methods")})
+        collectors = [_StubCollector("MC1", inputs=["methods.result"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data", "methods"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC1"]
+        assert dropped == []
+
+    def test_drops_collector_when_any_input_in_pruned_stage(self):
+        bench = self._benchmark(
+            {
+                "methods.result": _StubStage("methods"),
+                "data.raw": _StubStage("data"),
+            }
+        )
+        collectors = [_StubCollector("MC1", inputs=["methods.result", "data.raw"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == ["MC1"]
+
+    def test_unknown_input_does_not_drop(self):
+        # Unknown outputs are left to the regular collector resolver to warn about.
+        bench = self._benchmark({})
+        collectors = [_StubCollector("MC1", inputs=["unknown.id"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC1"]
+        assert dropped == []
+
+    def test_handles_iofile_inputs(self):
+        # Inputs may be IOFile objects (with `.id`) rather than bare strings.
+        from types import SimpleNamespace
+
+        bench = self._benchmark({"methods.result": _StubStage("methods")})
+        iofile = SimpleNamespace(id="methods.result")
+        collectors = [_StubCollector("MC1", inputs=[iofile])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == ["MC1"]
+
+    def test_empty_collector_list(self):
+        bench = self._benchmark({})
+        kept, dropped = _filter_collectors_by_stages(
+            [], included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == []
+
+    def test_none_collector_list(self):
+        bench = self._benchmark({})
+        kept, dropped = _filter_collectors_by_stages(
+            None, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == []
+
+    def test_partial_pruning_keeps_unrelated_collector(self):
+        bench = self._benchmark(
+            {
+                "methods.result": _StubStage("methods"),
+                "data.raw": _StubStage("data"),
+            }
+        )
+        collectors = [
+            _StubCollector("MC1", inputs=["methods.result"]),
+            _StubCollector("MC2", inputs=["data.raw"]),
+        ]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC2"]
+        assert dropped == ["MC1"]
+
+
+# ---------------------------------------------------------------------------
+# CLI conflict guard: --until + -m
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestUntilCliConflict:
+    def test_until_and_module_are_exclusive(self, caplog):
+        import logging
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("dummy.yaml").write_text("name: dummy")
+            with caplog.at_level(logging.ERROR, logger="omnibenchmark"):
+                result = runner.invoke(
+                    run,
+                    ["dummy.yaml", "-m", "M1", "--until", "methods"],
+                    catch_exceptions=False,
+                )
+        assert result.exit_code != 0
+        assert any("cannot be combined" in record.message for record in caplog.records)

--- a/tests/e2e/configs/09_capabilities.yaml
+++ b/tests/e2e/configs/09_capabilities.yaml
@@ -1,0 +1,35 @@
+id: LinearArithmeticWithCapabilities
+description: Linear pipeline exercising capability-gated module pruning
+version: "1.0"
+benchmarker: "E2E Test Suite"
+api_version: "0.6.0"
+software_backend: host
+
+software_environments:
+  host:
+    description: "Host environment for direct execution"
+
+stages:
+  - id: data
+    modules:
+      - id: D1
+        name: "Dataset 1 - CPU-only, always runs"
+        software_environment: "host"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - evaluate: "1+1"
+
+      - id: D2_gpu
+        name: "Dataset 2 - GPU-gated"
+        software_environment: "host"
+        requires_capabilities: [gpu]
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - evaluate: "2+2"
+    outputs:
+      - id: data.raw
+        path: "{dataset}_data.json"

--- a/tests/e2e/configs/10_lineage_provides.yaml
+++ b/tests/e2e/configs/10_lineage_provides.yaml
@@ -1,0 +1,57 @@
+id: LinearArithmeticWithLineageProvides
+description: Lineage gating via Stage.provides + Module.requires
+version: "1.0"
+benchmarker: "E2E Test Suite"
+api_version: "0.6.0"
+software_backend: host
+
+software_environments:
+  host:
+    description: "Host environment for direct execution"
+
+stages:
+  - id: data
+    provides: [dataset_size]
+    modules:
+      - id: small
+        name: "Small dataset"
+        software_environment: "host"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - evaluate: "1+1"
+            dataset_size: "sm"
+
+      - id: huge
+        name: "Huge dataset"
+        software_environment: "host"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - evaluate: "9+9"
+            dataset_size: "lg"
+    outputs:
+      - id: data.raw
+        path: "{dataset}_data.json"
+
+  - id: methods
+    inputs:
+      - data.raw
+    modules:
+      - id: M_lg_only
+        name: "Method that only runs on large datasets"
+        software_environment: "host"
+        requires:
+          dataset_size: "lg"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - evaluate: "input+10"
+            input: "data.raw"
+            kind: "method"
+    outputs:
+      - id: methods.result
+        path: "{dataset}_method.json"

--- a/tests/e2e/configs/10_lineage_provides.yaml
+++ b/tests/e2e/configs/10_lineage_provides.yaml
@@ -1,5 +1,5 @@
 id: LinearArithmeticWithLineageProvides
-description: Lineage gating via Stage.provides + Module.requires
+description: Lineage gating via Stage.provides + Module.provides + Module.requires
 version: "1.0"
 benchmarker: "E2E Test Suite"
 api_version: "0.6.0"
@@ -16,22 +16,26 @@ stages:
       - id: small
         name: "Small dataset"
         software_environment: "host"
+        # Recommended form: explicit benchmark-local label binding,
+        # no pollution of the module's CLI parameter contract.
+        provides:
+          dataset_size: "sm"
         repository:
           url: bundles/dummymodule_4ff8427.bundle
           commit: 4ff8427
         parameters:
           - evaluate: "1+1"
-            dataset_size: "sm"
 
       - id: huge
         name: "Huge dataset"
         software_environment: "host"
+        provides:
+          dataset_size: "lg"
         repository:
           url: bundles/dummymodule_4ff8427.bundle
           commit: 4ff8427
         parameters:
           - evaluate: "9+9"
-            dataset_size: "lg"
     outputs:
       - id: data.raw
         path: "{dataset}_data.json"

--- a/tests/e2e/test_03_data_preprocessing_methods_metrics.py
+++ b/tests/e2e/test_03_data_preprocessing_methods_metrics.py
@@ -34,3 +34,77 @@ def test_data_preprocessing_methods_metrics_pipeline(
     runner.verify_output_file_count(2, "*_data.json")  # 2 data files
     runner.verify_output_file_count(4, "*_preprocessed*.json")  # 4 preprocessing files
     runner.verify_output_file_count(8, "*_method*.json")  # 8 method result files
+
+
+@pytest.mark.e2e
+def test_until_preprocessing_truncates_pipeline(
+    data_preprocessing_methods_metrics_config, tmp_path, bundled_repos, keep_files
+):
+    """`--until preprocessing` runs data + preprocessing only; methods/metrics pruned."""
+    from tests.e2e.common import (
+        E2ETestRunner,
+        filter_files_excluding_symlinked_dirs,
+    )
+
+    runner = E2ETestRunner(tmp_path, keep_files)
+    config_file_in_tmp = runner.setup_test_environment(
+        data_preprocessing_methods_metrics_config,
+        "03_data_preprocessing_methods_metrics.yaml",
+    )
+
+    runner.execute_cli_command(
+        config_file_in_tmp,
+        ["--continue-on-error", "--until", "preprocessing"],
+    )
+
+    # data + preprocessing outputs are produced
+    data_files = filter_files_excluding_symlinked_dirs(runner.out_dir, "*_data.json")
+    preproc_files = filter_files_excluding_symlinked_dirs(
+        runner.out_dir, "*_preprocessed*.json"
+    )
+    assert len(data_files) >= 2, f"expected ≥2 data files, got {len(data_files)}"
+    assert (
+        len(preproc_files) >= 4
+    ), f"expected ≥4 preprocessing files, got {len(preproc_files)}"
+
+    # methods stage and metric collector outputs must NOT be produced
+    method_files = filter_files_excluding_symlinked_dirs(
+        runner.out_dir, "*_method*.json"
+    )
+    metrics_files = filter_files_excluding_symlinked_dirs(
+        runner.out_dir, "metrics.json"
+    )
+    assert method_files == [], f"unexpected method outputs: {method_files}"
+    assert metrics_files == [], f"unexpected metrics outputs: {metrics_files}"
+
+
+@pytest.mark.e2e
+def test_until_unknown_stage_errors(
+    data_preprocessing_methods_metrics_config, tmp_path, bundled_repos
+):
+    """`--until <unknown>` exits non-zero with a helpful message."""
+    from tests.cli.cli_setup import OmniCLISetup
+
+    runner_tmp = tmp_path / "out"
+    config_in_tmp = tmp_path / "03_data_preprocessing_methods_metrics.yaml"
+    import shutil
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(data_preprocessing_methods_metrics_config, config_in_tmp)
+
+    with OmniCLISetup() as omni:
+        result = omni.call(
+            [
+                "run",
+                str(config_in_tmp),
+                "--out-dir",
+                str(runner_tmp),
+                "--until",
+                "no_such_stage",
+            ],
+            cwd=str(tmp_path),
+        )
+
+    assert result.returncode != 0, "expected non-zero exit"
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "no_such_stage" in combined

--- a/tests/e2e/test_09_capabilities.py
+++ b/tests/e2e/test_09_capabilities.py
@@ -1,0 +1,93 @@
+"""E2E tests for `--capability` capability-gated module pruning."""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def capabilities_config():
+    """Path to the capabilities-gated benchmark config."""
+    return Path(__file__).parent / "configs" / "09_capabilities.yaml"
+
+
+@pytest.mark.e2e
+def test_capability_gated_module_pruned_by_default(
+    capabilities_config, tmp_path, bundled_repos, keep_files
+):
+    """Without `--capability`, the GPU-gated module is pruned; only D1 runs."""
+    from tests.e2e.common import (
+        E2ETestRunner,
+        filter_files_excluding_symlinked_dirs,
+    )
+
+    runner = E2ETestRunner(tmp_path, keep_files)
+    config_in_tmp = runner.setup_test_environment(
+        capabilities_config, "09_capabilities.yaml"
+    )
+
+    runner.execute_cli_command(config_in_tmp, ["--continue-on-error"])
+
+    data_files = filter_files_excluding_symlinked_dirs(runner.out_dir, "*_data.json")
+    assert (
+        len(data_files) == 1
+    ), f"expected 1 data output, got {len(data_files)}: {data_files}"
+    assert any("D1" in str(p) for p in data_files)
+    assert not any(
+        "D2_gpu" in str(p) for p in data_files
+    ), f"D2_gpu output should be pruned: {data_files}"
+
+
+@pytest.mark.e2e
+def test_capability_gated_module_runs_when_capability_provided(
+    capabilities_config, tmp_path, bundled_repos, keep_files
+):
+    """With `--capability gpu`, both D1 and D2_gpu run."""
+    from tests.e2e.common import (
+        E2ETestRunner,
+        filter_files_excluding_symlinked_dirs,
+    )
+
+    runner = E2ETestRunner(tmp_path, keep_files)
+    config_in_tmp = runner.setup_test_environment(
+        capabilities_config, "09_capabilities.yaml"
+    )
+
+    runner.execute_cli_command(
+        config_in_tmp,
+        ["--continue-on-error", "--capability", "gpu"],
+    )
+
+    data_files = filter_files_excluding_symlinked_dirs(runner.out_dir, "*_data.json")
+    assert (
+        len(data_files) == 2
+    ), f"expected 2 data outputs, got {len(data_files)}: {data_files}"
+    assert any("D1" in str(p) for p in data_files)
+    assert any("D2_gpu" in str(p) for p in data_files)
+
+
+@pytest.mark.e2e
+def test_unrelated_capability_does_not_unprune(
+    capabilities_config, tmp_path, bundled_repos, keep_files
+):
+    """`--capability foo` does not satisfy the gpu gate; D2_gpu still pruned."""
+    from tests.e2e.common import (
+        E2ETestRunner,
+        filter_files_excluding_symlinked_dirs,
+    )
+
+    runner = E2ETestRunner(tmp_path, keep_files)
+    config_in_tmp = runner.setup_test_environment(
+        capabilities_config, "09_capabilities.yaml"
+    )
+
+    runner.execute_cli_command(
+        config_in_tmp,
+        ["--continue-on-error", "--capability", "foo"],
+    )
+
+    data_files = filter_files_excluding_symlinked_dirs(runner.out_dir, "*_data.json")
+    assert (
+        len(data_files) == 1
+    ), f"expected 1 data output, got {len(data_files)}: {data_files}"
+    assert not any("D2_gpu" in str(p) for p in data_files)

--- a/tests/e2e/test_10_lineage_provides.py
+++ b/tests/e2e/test_10_lineage_provides.py
@@ -1,0 +1,64 @@
+"""E2E tests for `Stage.provides` → `Module.requires` lineage gating.
+
+Uses --dry to assert on the generated Snakefile rather than running
+modules; this avoids a quirk where the legacy dummy bundle's filename
+convention (--name = module_id) does not match path templates under
+api_version >= 0.5 for non-data stages. The lineage-gate behavior we
+care about (which rules are created vs pruned) is fully observable in
+the generated Snakefile.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def lineage_provides_config():
+    """Path to the lineage-gating benchmark config."""
+    return Path(__file__).parent / "configs" / "10_lineage_provides.yaml"
+
+
+def _read_snakefile(out_dir: Path) -> str:
+    snakefile = out_dir / "Snakefile"
+    assert snakefile.exists(), f"Snakefile not generated at {snakefile}"
+    return snakefile.read_text()
+
+
+@pytest.mark.e2e
+def test_requires_label_match_keeps_only_matching_lineage(
+    lineage_provides_config, tmp_path, bundled_repos, keep_files
+):
+    """`requires: {dataset_size: lg}` keeps only the `huge` execution path."""
+    from tests.e2e.common import E2ETestRunner
+
+    runner = E2ETestRunner(tmp_path, keep_files)
+    config_in_tmp = runner.setup_test_environment(
+        lineage_provides_config, "10_lineage_provides.yaml"
+    )
+
+    # --dry: generate Snakefile, do not execute.
+    runner.execute_cli_command(config_in_tmp, ["--dry"])
+
+    snakefile = _read_snakefile(runner.out_dir)
+
+    # Both data nodes must be present (the gate is downstream).
+    assert "data/small/" in snakefile, "small data rule missing"
+    assert "data/huge/" in snakefile, "huge data rule missing"
+
+    # The methods rule for the matching lineage must be present.
+    assert "methods/M_lg_only" in snakefile, "M_lg_only rule missing entirely"
+
+    # Critical: the methods rule must run only off the `huge` branch.
+    # Rule output paths nest the lineage; the small branch must not appear
+    # under any methods rule.
+    methods_lines = [
+        line for line in snakefile.splitlines() if "methods/M_lg_only" in line
+    ]
+    assert methods_lines, "expected at least one methods rule line"
+    huge_branch = any("huge" in line for line in methods_lines)
+    small_branch = any("/small/" in line for line in methods_lines)
+    assert huge_branch, f"M_lg_only should run on huge lineage; saw: {methods_lines}"
+    assert (
+        not small_branch
+    ), f"M_lg_only must NOT run on small lineage; saw: {methods_lines}"

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -351,6 +351,40 @@ class TestCoreEntities:
         )
         assert bench.stages[0].modules[0].requires_capabilities == ["gpu"]
 
+    def test_stage_provides_default_none(self):
+        """A Stage without `provides` parses with the field unset."""
+        from tests.model.factories import make_stage
+
+        stage = make_stage(id="data")
+        assert stage.provides is None
+
+    def test_stage_provides_list(self):
+        """`provides` is parsed as a list of label names."""
+        from tests.model.factories import make_stage
+
+        stage = make_stage(id="data", provides=["dataset_size", "treatment"])
+        assert stage.provides == ["dataset_size", "treatment"]
+
+    def test_stage_provides_rejected_below_v0_6(self):
+        """`Stage.provides` is gated on api_version ≥ 0.6.0."""
+        from tests.model.factories import make_benchmark, make_stage
+
+        with pytest.raises(ValueError, match="provides"):
+            make_benchmark(
+                api_version=APIVersion.V0_5_0,
+                stages=[make_stage(id="data", provides=["dataset_size"])],
+            )
+
+    def test_stage_provides_accepted_at_v0_6(self):
+        """At api_version 0.6.0 `Stage.provides` is accepted."""
+        from tests.model.factories import make_benchmark, make_stage
+
+        bench = make_benchmark(
+            api_version=APIVersion.V0_6_0,
+            stages=[make_stage(id="data", provides=["dataset_size"])],
+        )
+        assert bench.stages[0].provides == ["dataset_size"]
+
     def test_has_environment_reference(self):
         """Test has_environment_reference method."""
         module = make_module(software_environment="env1")

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -83,14 +83,17 @@ class TestEnums:
         assert APIVersion.V0_2_0.value == "0.2.0"
         assert APIVersion.V0_3_0.value == "0.3.0"
         assert APIVersion.V0_4_0.value == "0.4.0"
+        assert APIVersion.V0_5_0.value == "0.5.0"
+        assert APIVersion.V0_6_0.value == "0.6.0"
 
-        assert APIVersion.latest() == "0.5.0"
+        assert APIVersion.latest() == "0.6.0"
         assert set(APIVersion.supported_versions()) == {
             "0.1.0",
             "0.2.0",
             "0.3.0",
             "0.4.0",
             "0.5.0",
+            "0.6.0",
         }
 
     def test_software_backend_enum(self):
@@ -313,6 +316,40 @@ class TestCoreEntities:
         assert module.outputs is not None
         assert len(module.outputs) == 2
         assert module.outputs[0].id == "out1"
+
+    def test_module_requires_capabilities_default_none(self):
+        """A Module without `requires_capabilities` parses with the field unset."""
+        module = make_module(id="no_caps")
+        assert module.requires_capabilities is None
+
+    def test_module_requires_capabilities_list(self):
+        """`requires_capabilities` is parsed as a list of strings."""
+        module = make_module(
+            id="gpu_module", requires_capabilities=["gpu", "large_mem"]
+        )
+        assert module.requires_capabilities == ["gpu", "large_mem"]
+
+    def test_requires_capabilities_rejected_below_v0_6(self):
+        """`requires_capabilities` is gated on api_version ≥ 0.6.0."""
+        from tests.model.factories import make_benchmark, make_stage
+
+        gpu_module = make_module(id="gpu_mod", requires_capabilities=["gpu"])
+        with pytest.raises(ValueError, match="requires_capabilities"):
+            make_benchmark(
+                api_version=APIVersion.V0_5_0,
+                stages=[make_stage(id="data", modules=[gpu_module])],
+            )
+
+    def test_requires_capabilities_accepted_at_v0_6(self):
+        """At api_version 0.6.0 the field is accepted."""
+        from tests.model.factories import make_benchmark, make_stage
+
+        gpu_module = make_module(id="gpu_mod", requires_capabilities=["gpu"])
+        bench = make_benchmark(
+            api_version=APIVersion.V0_6_0,
+            stages=[make_stage(id="data", modules=[gpu_module])],
+        )
+        assert bench.stages[0].modules[0].requires_capabilities == ["gpu"]
 
     def test_has_environment_reference(self):
         """Test has_environment_reference method."""
@@ -559,10 +596,10 @@ stages:
           commit: "abc123"
         outputs:
           - id: "cleaned_data"
-            path: "output/cleaned.csv"
+            path: "cleaned.csv"
     outputs:
       - id: "cleaned_data"
-        path: "output/cleaned.csv"
+        path: "cleaned.csv"
 metric_collectors:
   - id: performance_metrics
     name: "Performance Metrics"
@@ -572,13 +609,13 @@ metric_collectors:
       commit: "ghi789"
     inputs:
       - id: "cleaned_data"
-        path: "output/cleaned.csv"
+        path: "cleaned.csv"
     outputs:
       - id: "metrics_report"
-        path: "metrics/report.html"
+        path: "report.html"
 outputs:
   - id: "final_report"
-    path: "final/report.pdf"
+    path: "report.pdf"
 """
         yaml_file = tmp_path / "integration.yaml"
         yaml_file.write_text(yaml_content)

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -385,6 +385,19 @@ class TestCoreEntities:
         )
         assert bench.stages[0].provides == ["dataset_size"]
 
+    def test_module_provides_default_none(self):
+        """A Module without `provides` parses with the field unset."""
+        module = make_module(id="m_no_provides")
+        assert module.provides is None
+
+    def test_module_provides_dict(self):
+        """`Module.provides` is parsed as a label → value dict."""
+        module = make_module(
+            id="huge",
+            provides={"dataset_size": "lg", "tier": "expensive"},
+        )
+        assert module.provides == {"dataset_size": "lg", "tier": "expensive"}
+
     def test_has_environment_reference(self):
         """Test has_environment_reference method."""
         module = make_module(software_environment="env1")


### PR DESCRIPTION
## Ticket

#331

## Description

Introduces api 0.6 (with the gate rationale); three independent-but-related primitives that share a selector vocabulary; design in docs/design/008-filtering.md; deferred items called out explicitly (gather, partition syntax, env/rc capability sources, negative filtering).

## Remarks for the reviewer:

Have a look at design docs first.