### PR TITLE
feat: add OpenTelemetry support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 
 ## [0.6.0](UNRELEASED)
 
+- feat: add opentelemetry support
 - feat: output path templates now support `{name}`, `{module.name}`, `{module.stage}`, and `{params.KEY}`; `{name}` always resolves to the current module's own ID (never inherited)
 
 ## [0.5.3](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.3) (Jun 15th 2026)
@@ -27,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - fix: raise warning for disjoint keys (Closes: #313)
 - fix: clearer error on missing entrypoint (Closes: #321)
 - fix: truncate filename to avoid hitting filesystem limits (#334)
-- chore(pkg): unpink snakemake dependency (#269)
+- chore(pkg): unpin snakemake dependency (#269)
 
 ## [0.5.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.0) (Apr 23th 2026)
 

--- a/docs/design/007-output-layout.md
+++ b/docs/design/007-output-layout.md
@@ -21,7 +21,7 @@
 
 Every `ob run` invocation materialises a tree of files under the configured output directory (default: `out/`). The layout of that tree — which subdirectories exist, what each one contains, and how the files relate to each other — is implicit in the implementation and has never been formally documented.
 
-Additionally, there is no lightweight, structured record of the *execution environment* in which a benchmark was run. The telemetry system (006) captures a rich distributed trace, but requires `--telemetry json` to be enabled. A minimal "who ran this, on what machine, when" record should always be written, regardless of whether telemetry is active.
+Additionally, there is no lightweight, structured record of the *execution environment* in which a benchmark was run. The telemetry system (006) captures a rich distributed trace, but requires `--telemetry` to be enabled. A minimal "who ran this, on what machine, when" record should always be written, regardless of whether telemetry is active.
 
 This document:
 
@@ -63,7 +63,7 @@ out/                               # configurable via --out-dir
 ├── .modules/                      # checked-out module source trees (git cache worktrees)
 │   └── <repo>/<commit>/           # one directory per (repository, commit) pair
 │
-├── telemetry.jsonl                # OTLP JSON Lines trace (only when --telemetry json)
+├── telemetry.jsonl                # OTLP JSON Lines trace (only when --telemetry)
 │
 └── <stage_id>/                    # benchmark outputs, one top-level dir per stage
     └── <module_id>/
@@ -84,7 +84,7 @@ out/                               # configurable via --out-dir
 | `.logs/snakemake_<ts>.log` | Full stdout/stderr from the Snakemake process. Timestamped to allow multiple runs in the same output dir. | Yes |
 | `.logs/<rule>.log` | Per-rule output captured by `tee` inside the shell command. | Only for executed rules |
 | `.modules/` | Source trees for resolved modules. Populated during the resolution phase. | Yes |
-| `telemetry.jsonl` | OTLP-compatible distributed trace (see 006). | Only with `--telemetry json` |
+| `telemetry.jsonl` | OTLP-compatible distributed trace (see 006). | Only with `--telemetry` |
 | `<stage>/` | Stage output directories, nested by `module_id/param_hash/`. | After execution |
 
 ### Notes on output nesting
@@ -154,7 +154,7 @@ The run UUID correlates with the OTLP `trace_id` in `telemetry.jsonl` when telem
 
 ### 4.4 Relationship to telemetry
 
-When `--telemetry json` is active:
+When `--telemetry` is active:
 
 - `manifest.json` `run_id` = `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` (UUID4 with dashes)
 - `telemetry.jsonl` `trace_id` = same UUID in 32-char hex (no dashes)

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -559,6 +559,22 @@ stages:
 
 This is useful when a single module is run with multiple parameter sweeps and each run's output must be stored at a distinct path.
 
+## Collect telemetry from a run
+
+`ob run` can emit OpenTelemetry traces and events covering benchmark setup, DAG construction, and per-job execution. Pass `--telemetry` to enable OTLP/JSON Lines output:
+
+```bash
+# Emit telemetry to stdout (disables the Rich progress display)
+ob run benchmark.yaml --telemetry
+
+# Write telemetry to a file instead, keeping the progress display active
+ob run benchmark.yaml --telemetry --telemetry-output run.jsonl
+```
+
+Each line is a self-contained JSON record (span or event) following the OTLP schema, suitable for ingestion by any OpenTelemetry-compatible backend.
+
+For interactive inspection of a telemetry stream — live progress, span timelines, and run summaries — see [obmon](https://github.com/omnibenchmark/obmon), a companion TUI that consumes the JSON Lines produced by `--telemetry`.
+
 ## Use local module repositories
 
 Local Git repositories can be referenced directly in the `url` field of benchmarking YAML manifestos, without the need to push to GitHub, GitLab, Bitbucket, or any other remote. To ensure changes are tracked, remember to stage them with `git add` and commit them with `git commit` in the local repository. It is recommended to specify full paths (beginning with `/`) to the local Git repository (i.e. `/home/user/repos/data` in the example below).

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import time
+from collections import deque
 from pathlib import Path
 from typing import Optional
 
@@ -118,6 +119,18 @@ def format_pydantic_errors(e: PydanticValidationError) -> str:
         "first upstream input × parameter expansion for each module."
     ),
 )
+@click.option(
+    "--telemetry",
+    is_flag=True,
+    default=False,
+    help="Emit OTLP telemetry as JSON Lines to stdout (disables Rich progress).",
+)
+@click.option(
+    "--telemetry-output",
+    type=click.Path(),
+    default=None,
+    help="Write telemetry to file instead of stdout. Allows Rich progress to remain active. Implies --telemetry.",
+)
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def run(
@@ -132,6 +145,8 @@ def run(
     yes_flag,
     use_remote_storage,
     module_filter,
+    telemetry,
+    telemetry_output,
     snakemake_args,
 ):
     """Run a benchmark.
@@ -153,6 +168,7 @@ def run(
       ob run benchmark.yaml --dirty            # Allow local paths with uncommitted changes
       ob run benchmark.yaml --unpinned         # Allow branch refs on remote repos
       ob run benchmark.yaml -m M1              # Dev mode: run only module M1
+      ob run benchmark.yaml --telemetry         # Emit OTLP/JSONL telemetry to stdout
       ob run benchmark.yaml -- --rerun-triggers mtime  # Pass flags to snakemake
       ob run benchmark.yaml -- --forceall      # Force re-run all rules
     """
@@ -186,6 +202,8 @@ def run(
         unpinned=unpinned,
         use_remote_storage=use_remote_storage,
         module_filter=module_filter,
+        telemetry=telemetry,
+        telemetry_output=telemetry_output,
         snakemake_args=list(snakemake_args),
     )
 
@@ -201,6 +219,8 @@ def _run_benchmark(
     unpinned=False,
     use_remote_storage=False,
     module_filter=None,
+    telemetry=None,
+    telemetry_output=None,
     snakemake_args=None,
 ):
     """Run a full benchmark, or a single-module sub-graph when module_filter is set."""
@@ -208,6 +228,12 @@ def _run_benchmark(
 
     out_dir = out_dir if out_dir else "out"
     out_dir_path = Path(out_dir)
+
+    # --telemetry-output implies --telemetry.
+    telemetry = telemetry or bool(telemetry_output)
+
+    # Telemetry to stdout disables Rich progress (they would compete for stdout).
+    use_telemetry_stdout = telemetry and not telemetry_output
 
     try:
         benchmark_path_abs = Path(benchmark_path).resolve()
@@ -228,11 +254,26 @@ def _run_benchmark(
 
     use_clean_ui = not debug
 
+    # Suppress logging when streaming telemetry to stdout (would interleave with JSONL).
+    if use_telemetry_stdout:
+        logging.getLogger("omnibenchmark").setLevel(logging.WARNING)
+
+    # Setup telemetry emitter early so pre-snakemake phases are traced.
+    telemetry_emitter = None
+    if telemetry:
+        from omnibenchmark.telemetry import TelemetryEmitter
+
+        if telemetry_output:
+            telemetry_emitter = TelemetryEmitter(output=Path(telemetry_output))
+        else:
+            telemetry_emitter = TelemetryEmitter()  # stdout
+
     # Step 1: Populate git cache (fetch all repos)
+    resolution_start_ns = int(time.time() * 1_000_000_000)
     populate_git_cache(b, quiet=use_clean_ui, cores=cores)
 
     # Step 2: Generate explicit Snakefile
-    _generate_explicit_snakefile(
+    resolved_nodes = _generate_explicit_snakefile(
         benchmark=b,
         benchmark_yaml_path=benchmark_path_abs,
         out_dir=out_dir_path,
@@ -243,6 +284,28 @@ def _run_benchmark(
         unpinned=unpinned,
         module_filter=module_filter,
     )
+
+    # Initialize telemetry with resolved nodes and emit module-resolution span
+    if telemetry_emitter and resolved_nodes:
+        stages = [{"id": s.id, "name": s.name or s.id} for s in b.model.stages]
+        telemetry_emitter.emit_manifest(
+            benchmark_name=b.model.get_name(),
+            benchmark_version=b.model.get_version(),
+            benchmark_author=b.model.get_author(),
+            software_backend=str(b.get_benchmark_software_backend().value),
+            cores=cores,
+            stages=stages,
+            resolved_nodes=resolved_nodes,
+        )
+        resolution_end_ns = int(time.time() * 1_000_000_000)
+        telemetry_emitter.emit_phase_span(
+            name="setup: module resolution",
+            phase="module_resolution",
+            setup_type="resolution",
+            output=f"Resolved {len(resolved_nodes)} nodes",
+            start_time_ns=resolution_start_ns,
+            end_time_ns=resolution_end_ns,
+        )
 
     # Write run manifest
     write_run_manifest(output_dir=out_dir_path)
@@ -282,6 +345,9 @@ def _run_benchmark(
         software_backend=b.get_benchmark_software_backend(),
         debug=debug,
         extra_snakemake_args=extra_args,
+        telemetry_emitter=telemetry_emitter,
+        benchmark=b,
+        resolved_nodes=resolved_nodes,
     )
 
 
@@ -303,8 +369,23 @@ def _run_snakemake(
     software_backend: SoftwareBackendEnum,
     debug: bool,
     extra_snakemake_args: Optional[list] = None,
+    telemetry_emitter=None,
+    benchmark: Optional[BenchmarkExecution] = None,
+    resolved_nodes: Optional[list] = None,
 ):
-    """Run snakemake on the generated Snakefile."""
+    """Run snakemake on the generated Snakefile.
+
+    Args:
+        out_dir: Output directory containing the Snakefile.
+        cores: Number of cores to use.
+        continue_on_error: Whether to continue on job failures.
+        software_backend: Software backend (determines --use-conda etc.).
+        debug: Whether to enable verbose output (shows full output instead of progress).
+        extra_snakemake_args: Extra args appended to the snakemake command line.
+        telemetry_emitter: Pre-initialized TelemetryEmitter (or None).
+        benchmark: BenchmarkExecution instance (for telemetry metadata).
+        resolved_nodes: List of ResolvedNode objects (for telemetry manifest).
+    """
     from omnibenchmark.progress import ProgressDisplay, InteractiveProgress
     from datetime import datetime
     import re
@@ -323,6 +404,12 @@ def _run_snakemake(
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     log_file = logs_dir / f"snakemake_{timestamp}.log"
+
+    # Detect whether the emitter is streaming to stdout. If so, suppress Rich UI.
+    use_telemetry_stdout = (
+        telemetry_emitter is not None
+        and getattr(telemetry_emitter, "_file_handle", None) is sys.stdout
+    )
 
     # Prefer snakemake co-located with the current Python executable (pixi/conda env)
     import shutil
@@ -370,7 +457,8 @@ def _run_snakemake(
     original_dir = os.getcwd()
     os.chdir(out_dir)
 
-    summary_console = ProgressDisplay().console
+    # No Rich console when telemetry is competing for stdout.
+    summary_console = None if use_telemetry_stdout else ProgressDisplay().console
 
     try:
         if debug:
@@ -382,7 +470,141 @@ def _run_snakemake(
 
             with open(log_file, "r", encoding="utf-8", errors="replace") as f:
                 print(f.read())
+        elif use_telemetry_stdout:
+            # Telemetry-to-stdout mode: no Rich progress, just emit telemetry events.
+            # use_telemetry_stdout is derived from telemetry_emitter, so it's set here.
+            assert telemetry_emitter is not None
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+
+            rule_start_pattern = re.compile(r"rule ([\w.]+):")
+            job_error_pattern = re.compile(r"Error in rule ([\w.]+):")
+            localrule_pattern = re.compile(r"localrule ([\w.]+):")
+
+            current_rule: Optional[str] = None
+            completed_jobs = 0
+            failed_rules: list[str] = []
+
+            # Buffers for telemetry payloads.
+            rule_output_buffer: deque = deque(maxlen=100)
+            capturing_error = False
+            error_lines: list[str] = []
+
+            setup_buffer: list[str] = []
+            first_rule_seen = False
+            setup_start_ns = int(time.time() * 1_000_000_000)
+            telemetry_emitter.emit_phase_started(
+                "environment preparation", "environment_setup"
+            )
+
+            assert process.stdout is not None
+            with open(log_file, "w") as f:
+                for line in process.stdout:
+                    f.write(line)
+                    f.flush()
+
+                    line_stripped = line.strip()
+
+                    if not first_rule_seen:
+                        setup_buffer.append(line_stripped)
+                    else:
+                        rule_output_buffer.append(line_stripped)
+
+                    if capturing_error:
+                        error_lines.append(line_stripped)
+
+                    match = rule_start_pattern.search(line) or localrule_pattern.search(
+                        line
+                    )
+                    if match:
+                        if not first_rule_seen:
+                            setup_end_ns = int(time.time() * 1_000_000_000)
+                            telemetry_emitter.emit_setup_span(
+                                "\n".join(setup_buffer),
+                                setup_start_ns,
+                                setup_end_ns,
+                            )
+                            first_rule_seen = True
+
+                        current_rule = normalize_rule_name(match.group(1))
+                        rule_output_buffer.clear()
+                        telemetry_emitter.rule_started(current_rule)
+
+                    if (
+                        "Finished job" in line
+                        or "Finished jobid" in line
+                        or "Nothing to be done" in line
+                    ):
+                        completed_jobs += 1
+                        if current_rule:
+                            snakemake_output = "\n".join(rule_output_buffer)
+                            rule_log = _read_rule_log(Path("."), current_rule)
+                            full_output = (
+                                f"{snakemake_output}\n--- Command Output ---\n{rule_log}"
+                                if rule_log
+                                else snakemake_output
+                            )
+                            telemetry_emitter.rule_completed(
+                                current_rule, stdout=full_output
+                            )
+                        rule_output_buffer.clear()
+
+                    err_match = job_error_pattern.search(line)
+                    if err_match:
+                        failed_rule = normalize_rule_name(err_match.group(1))
+                        if failed_rule not in failed_rules:
+                            failed_rules.append(failed_rule)
+                        capturing_error = True
+                        error_lines = [line_stripped]
+
+                    if capturing_error and (
+                        line_stripped == ""
+                        or "Shutting down" in line
+                        or "Error executing rule" in line
+                    ):
+                        if failed_rules:
+                            snakemake_output = "\n".join(rule_output_buffer)
+                            rule_log = _read_rule_log(Path("."), failed_rules[-1])
+                            stderr = (
+                                f"{snakemake_output}\n--- Command Output ---\n{rule_log}"
+                                if rule_log
+                                else (snakemake_output or "\n".join(error_lines))
+                            )
+                            telemetry_emitter.rule_failed(
+                                failed_rules[-1],
+                                f"Error in rule {failed_rules[-1]}",
+                                stderr=stderr,
+                            )
+                        capturing_error = False
+                        error_lines = []
+
+            process.wait()
+            result = process
+
+            # Edge case: no rules ever ran — still emit a setup span.
+            if not first_rule_seen and setup_buffer:
+                setup_end_ns = int(time.time() * 1_000_000_000)
+                telemetry_emitter.emit_setup_span(
+                    "\n".join(setup_buffer), setup_start_ns, setup_end_ns
+                )
+
+            telemetry_emitter.benchmark_completed(
+                success=(result.returncode == 0),
+                message=(
+                    f"Completed {completed_jobs} jobs"
+                    if result.returncode == 0
+                    else f"Failed with {len(failed_rules)} error(s)"
+                ),
+            )
         else:
+            # summary_console is only None when use_telemetry_stdout is True,
+            # which is handled by the elif branches above; pyright can't see that.
+            assert summary_console is not None
             summary_console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
             summary_console.print(f"[dim]Log file: {log_file}[/dim]")
             summary_console.print()
@@ -406,6 +628,18 @@ def _run_snakemake(
             total_jobs = None
             current_rule = None
 
+            # Telemetry buffers (only used when telemetry_emitter is set).
+            rule_output_buffer: deque = deque(maxlen=100)
+            capturing_error = False
+            error_lines: list[str] = []
+            setup_buffer: list[str] = []
+            first_rule_seen = False
+            setup_start_ns = int(time.time() * 1_000_000_000)
+            if telemetry_emitter:
+                telemetry_emitter.emit_phase_started(
+                    "environment preparation", "environment_setup"
+                )
+
             setup_status = summary_console.status("Setting up...")
             setup_status.start()
 
@@ -419,6 +653,14 @@ def _run_snakemake(
                         progress.check_keyboard()
 
                     line_stripped = line.strip()
+
+                    if telemetry_emitter:
+                        if not first_rule_seen:
+                            setup_buffer.append(line_stripped)
+                        else:
+                            rule_output_buffer.append(line_stripped)
+                        if capturing_error:
+                            error_lines.append(line_stripped)
 
                     if line_stripped.startswith("total") and total_jobs is None:
                         parts = line_stripped.split()
@@ -437,15 +679,41 @@ def _run_snakemake(
 
                     match = rule_start_pattern.search(line)
                     if match:
+                        if telemetry_emitter and not first_rule_seen:
+                            setup_end_ns = int(time.time() * 1_000_000_000)
+                            telemetry_emitter.emit_setup_span(
+                                "\n".join(setup_buffer),
+                                setup_start_ns,
+                                setup_end_ns,
+                            )
+                            first_rule_seen = True
+
                         current_rule = normalize_rule_name(match.group(1))
+                        if telemetry_emitter:
+                            rule_output_buffer.clear()
                         if progress:
                             progress.update(current_rule=current_rule)
+                        if telemetry_emitter:
+                            telemetry_emitter.rule_started(current_rule)
 
                     match = localrule_pattern.search(line)
                     if match:
+                        if telemetry_emitter and not first_rule_seen:
+                            setup_end_ns = int(time.time() * 1_000_000_000)
+                            telemetry_emitter.emit_setup_span(
+                                "\n".join(setup_buffer),
+                                setup_start_ns,
+                                setup_end_ns,
+                            )
+                            first_rule_seen = True
+
                         current_rule = normalize_rule_name(match.group(1))
+                        if telemetry_emitter:
+                            rule_output_buffer.clear()
                         if progress:
                             progress.update(current_rule=current_rule)
+                        if telemetry_emitter:
+                            telemetry_emitter.rule_started(current_rule)
 
                     if (
                         "Finished job" in line
@@ -454,12 +722,57 @@ def _run_snakemake(
                     ):
                         if progress:
                             progress.update(advance=1)
+                        if telemetry_emitter and current_rule:
+                            snakemake_output = "\n".join(rule_output_buffer)
+                            rule_log = _read_rule_log(Path("."), current_rule)
+                            full_output = (
+                                f"{snakemake_output}\n--- Command Output ---\n{rule_log}"
+                                if rule_log
+                                else snakemake_output
+                            )
+                            telemetry_emitter.rule_completed(
+                                current_rule, stdout=full_output
+                            )
+                            rule_output_buffer.clear()
 
                     match = job_error_pattern.search(line)
                     if match:
                         failed_rule = normalize_rule_name(match.group(1))
                         if progress:
                             progress.add_failed_rule(failed_rule)
+                        if telemetry_emitter:
+                            capturing_error = True
+                            error_lines = [line_stripped]
+
+                    if (
+                        telemetry_emitter
+                        and capturing_error
+                        and (
+                            line_stripped == ""
+                            or "Shutting down" in line
+                            or "Error executing rule" in line
+                        )
+                    ):
+                        if error_lines:
+                            err_match = job_error_pattern.search(error_lines[0])
+                            if err_match:
+                                failed_rule_name = normalize_rule_name(
+                                    err_match.group(1)
+                                )
+                                snakemake_output = "\n".join(rule_output_buffer)
+                                rule_log = _read_rule_log(Path("."), failed_rule_name)
+                                stderr = (
+                                    f"{snakemake_output}\n--- Command Output ---\n{rule_log}"
+                                    if rule_log
+                                    else (snakemake_output or "\n".join(error_lines))
+                                )
+                                telemetry_emitter.rule_failed(
+                                    failed_rule_name,
+                                    f"Error in rule {failed_rule_name}",
+                                    stderr=stderr,
+                                )
+                        capturing_error = False
+                        error_lines = []
 
             process.wait()
             result = process
@@ -467,11 +780,28 @@ def _run_snakemake(
             if setup_status:
                 setup_status.stop()
 
+            # Edge case: no rules ran — still emit a setup span.
+            if telemetry_emitter and not first_rule_seen and setup_buffer:
+                setup_end_ns = int(time.time() * 1_000_000_000)
+                telemetry_emitter.emit_setup_span(
+                    "\n".join(setup_buffer), setup_start_ns, setup_end_ns
+                )
+
             completed_jobs = progress.completed if progress else 0
             failed_rules = progress.failed_rules if progress else []
 
             if progress:
                 progress.finish()
+
+            if telemetry_emitter:
+                telemetry_emitter.benchmark_completed(
+                    success=(result.returncode == 0),
+                    message=(
+                        f"Completed {completed_jobs} jobs"
+                        if result.returncode == 0
+                        else f"Failed with {len(failed_rules)} error(s)"
+                    ),
+                )
 
             if result.returncode == 0:
                 summary_console.print(
@@ -496,7 +826,8 @@ def _run_snakemake(
                 summary_console.print(f"[dim]See full log: {log_file}[/dim]")
 
         if result.returncode == 0:
-            if not debug:
+            if not debug and not use_telemetry_stdout:
+                assert summary_console is not None
                 summary_console.print()
             logger.info("Benchmark run completed successfully.")
             sys.exit(0)

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -19,6 +19,7 @@ from omnibenchmark.backend._metadata import save_metadata
 from omnibenchmark.backend.snakemake import SnakemakeGenerator
 from omnibenchmark.core import BenchmarkExecution
 from omnibenchmark.core._paths import (
+    truncate_filename,
     truncate_path_filename,
     collect_path_exclusions,
     is_lineage_excluded,
@@ -353,7 +354,7 @@ def _run_benchmark(
 
 def _read_rule_log(out_dir: Path, rule_name: str) -> Optional[str]:
     """Read the per-rule log file if it exists."""
-    log_path = out_dir / ".logs" / f"{rule_name}.log"
+    log_path = out_dir / ".logs" / truncate_filename(f"{rule_name}.log")
     if log_path.exists():
         try:
             return log_path.read_text()

--- a/omnibenchmark/telemetry/README.md
+++ b/omnibenchmark/telemetry/README.md
@@ -1,0 +1,166 @@
+# Omnibenchmark Telemetry
+
+OTLP-compatible telemetry for observing benchmark execution in OpenTelemetry backends (Aspire Dashboard, Jaeger, etc.).
+
+## Overview
+
+The telemetry module emits structured JSON Lines (NDJSON) following the OpenTelemetry Protocol (OTLP) format. This allows you to:
+
+- View the benchmark DAG as a browseable span hierarchy
+- Monitor rule execution status (pending → running → completed/failed)
+- Capture stdout/stderr from rule execution
+- Pipe telemetry over SSH from remote execution (e.g., Slurm clusters)
+
+## Span Hierarchy
+
+The benchmark structure is represented as nested spans:
+
+```
+benchmark: my_benchmark (root span)
+├── setup: module resolution
+├── setup: environment preparation
+├── stage: datasets
+│   ├── module: iris_loader
+│   │   └── rule: datasets_iris_abc123
+│   └── module: wine_loader
+│       └── rule: datasets_wine_def456
+├── stage: methods
+│   └── module: kmeans
+│       ├── rule: methods_kmeans_iris_abc123
+│       └── rule: methods_kmeans_wine_def456
+└── stage: metrics
+    └── ...
+```
+
+## Quick Start
+
+### 1. Run Benchmark with Telemetry
+
+Write a JSONL trace file (Rich progress UI stays active):
+
+```bash
+ob run benchmark.yaml --telemetry --telemetry-output telemetry.jsonl
+```
+
+Or stream to stdout (disables Rich progress, suitable for piping):
+
+```bash
+ob run benchmark.yaml --telemetry | ...
+```
+
+### 2. Consume Telemetry
+
+The JSONL stream is consumed by [`obmon`](https://github.com/omnibenchmark/obmon),
+which tails the file (or reads stdout) and provides the dashboard / OTLP
+forwarding. See the obmon README for setup.
+
+## Output Format
+
+The telemetry output is JSON Lines (NDJSON) with one OTLP TracesData object per line:
+
+```json
+{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"omnibenchmark"}}]},"scopeSpans":[{"scope":{"name":"omnibenchmark.telemetry","version":"1.0.0"},"spans":[{"traceId":"abc123...","spanId":"def456...","name":"benchmark: my_benchmark","kind":2,"status":{"code":0},"attributes":[...]}]}]}]}
+```
+
+### Span Attributes
+
+**Benchmark span:**
+- `benchmark.name` - Benchmark identifier
+- `benchmark.version` - Semantic version
+- `benchmark.author` - Author name
+- `benchmark.total_rules` - Total number of rules
+- `benchmark.software_backend` - conda, apptainer, docker, etc.
+- `benchmark.cores` - Number of CPU cores
+
+**Stage span:**
+- `stage.id` - Stage identifier
+- `stage.name` - Human-readable name
+- `stage.module_count` - Number of modules in stage
+- `stage.rule_count` - Number of rules in stage
+
+**Rule span:**
+- `rule.name` - Snakemake rule name
+- `rule.stage_id` - Parent stage
+- `rule.module_id` - Module identifier
+- `rule.node_id` - Full node identifier
+- `rule.inputs` - Input file paths
+- `rule.outputs` - Output file paths
+- `rule.parameters` - JSON-encoded parameters
+
+### Span Status
+
+- `code: 0` (UNSET) - Pending, not yet started
+- `code: 1` (OK) - Completed successfully
+- `code: 2` (ERROR) - Failed with error
+
+### Span Events
+
+Rule spans include events for:
+- `stdout` - Captured standard output
+- `stderr` - Captured standard error
+- `exception` - Error message on failure
+
+## Programmatic Usage
+
+```python
+from omnibenchmark.telemetry import TelemetryEmitter
+
+# Create emitter (defaults to stdout)
+emitter = TelemetryEmitter()
+
+# Or write to file
+emitter = TelemetryEmitter(output=Path("telemetry.jsonl"))
+
+# Emit the manifest (full DAG) upfront
+emitter.emit_manifest(
+    benchmark_name="my_benchmark",
+    benchmark_version="1.0.0",
+    benchmark_author="Jane Doe",
+    software_backend="conda",
+    cores=4,
+    stages=[{"id": "datasets", "name": "Datasets"}, ...],
+    resolved_nodes=resolved_nodes,
+)
+
+# Stream execution updates
+emitter.rule_started("datasets_iris_abc123")
+emitter.rule_completed("datasets_iris_abc123", stdout="...", stderr="...")
+# or
+emitter.rule_failed("datasets_wine_def456", error="FileNotFoundError", stderr="...")
+
+# Mark completion
+emitter.benchmark_completed(success=True)
+```
+
+## Troubleshooting
+
+### No spans appearing in dashboard
+
+1. Check the collector is receiving data:
+   ```bash
+   # Use debug exporter to see incoming spans
+   docker logs <collector_container>
+   ```
+
+2. Verify JSON format:
+   ```bash
+   ob run benchmark.yaml --telemetry | head -1 | jq .
+   ```
+
+3. Check OTLP endpoint is reachable:
+   ```bash
+   curl -v http://localhost:4318/v1/traces
+   ```
+
+### Spans not showing hierarchy
+
+Ensure parent-child relationships are preserved:
+- All spans share the same `traceId`
+- Child spans have `parentSpanId` pointing to their parent
+- Spans are emitted in order (parent before children)
+
+### Large stdout/stderr truncation
+
+By default, stdout/stderr are captured in full. For very large outputs, consider:
+- Configuring max capture size in the emitter
+- Using log aggregation for detailed output

--- a/omnibenchmark/telemetry/__init__.py
+++ b/omnibenchmark/telemetry/__init__.py
@@ -1,0 +1,37 @@
+"""
+Telemetry module for omnibenchmark.
+
+Provides OTLP-compatible structured logging that can be piped to
+OpenTelemetry backends (Aspire Dashboard, Jaeger, etc.).
+
+The telemetry output represents the benchmark DAG as a span hierarchy:
+
+    benchmark_run (root span)
+    ├── setup: module resolution
+    ├── setup: environment preparation
+    ├── stage: datasets
+    │   └── module: ...
+    │       └── rule: datasets_iris_abc123
+    ├── stage: methods
+    │   └── module: ...
+    │       └── rule: methods_kmeans_iris_...
+    └── stage: metrics
+        └── ...
+
+Usage:
+    from omnibenchmark.telemetry import TelemetryEmitter
+
+    emitter = TelemetryEmitter(output=sys.stdout)
+    emitter.emit_manifest(benchmark, resolved_nodes)
+
+    # During execution:
+    emitter.rule_started(rule_name, node_id)
+    emitter.rule_completed(rule_name, node_id, stdout, stderr)
+    emitter.rule_failed(rule_name, node_id, error, stdout, stderr)
+"""
+
+from omnibenchmark.telemetry.emitter import TelemetryEmitter
+from omnibenchmark.telemetry.events import SpanStatus
+from omnibenchmark.telemetry.spans import SpanBuilder
+
+__all__ = ["TelemetryEmitter", "SpanBuilder", "SpanStatus"]

--- a/omnibenchmark/telemetry/emitter.py
+++ b/omnibenchmark/telemetry/emitter.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, Optional, Union
 
+from omnibenchmark.benchmark._paths import truncate_filename
 from omnibenchmark.telemetry.events import (
     Span,
     SpanStatus,
@@ -275,7 +276,7 @@ class TelemetryEmitter:
                 "parameters": node.get_parameter_json()
                 if hasattr(node, "get_parameter_json")
                 else None,
-                "log_file": f".logs/{rule_name}.log",  # Per-rule log file path
+                "log_file": f".logs/{truncate_filename(rule_name + '.log')}",
                 "start_time": None,
                 "end_time": None,
                 "status": SpanStatus.UNSET,

--- a/omnibenchmark/telemetry/emitter.py
+++ b/omnibenchmark/telemetry/emitter.py
@@ -473,8 +473,12 @@ class TelemetryEmitter:
             self._modules[module_key]["has_failures"] = True
             self._maybe_emit_module(module_key)
 
-    def _emit_rule_span(self, rule_name: str):
-        """Emit a completed rule span."""
+    def _emit_rule_span(self, rule_name: str, skipped: bool = False):
+        """Emit a completed rule span.
+
+        When ``skipped`` is true, the span is tagged ``rule.skipped`` so
+        consumers can distinguish cached/unrun rules from real executions.
+        """
         rule = self._rules[rule_name]
         stage_id = rule["stage_id"]
         module_id = rule["module_id"]
@@ -494,6 +498,8 @@ class TelemetryEmitter:
             Attribute("rule.node_id", rule["node_id"]),
             Attribute("rule.param_id", rule["param_id"]),
         ]
+        if skipped:
+            attributes.append(Attribute("rule.skipped", True))
 
         if rule["outputs"]:
             attributes.append(Attribute("rule.outputs", rule["outputs"]))
@@ -702,8 +708,28 @@ class TelemetryEmitter:
             self._emitted_stages.add(stage_id)
 
     def benchmark_completed(self, success: bool, message: str = ""):
-        """Emit any remaining modules, stages, and the benchmark root span."""
+        """Emit any remaining rules, modules, stages, and the benchmark root span.
+
+        Rules that were initialized but never observed running (cached by
+        snakemake, or otherwise skipped) are emitted as zero-duration spans
+        with a ``rule.skipped`` attribute so the trace reflects the full DAG
+        rather than only the work this run performed.
+        """
         end_time = now_ns()
+
+        # Emit a skipped span for every rule that never started.
+        for rule_name, rule in self._rules.items():
+            if rule_name in self._emitted_rules:
+                continue
+            rule["start_time"] = end_time
+            rule["end_time"] = end_time
+            rule["status"] = SpanStatus.UNSET
+            self._emit_rule_span(rule_name, skipped=True)
+            self._emitted_rules.add(rule_name)
+
+            module_key = (rule["stage_id"], rule["module_id"])
+            if module_key in self._modules:
+                self._modules[module_key]["completed_rules"] += 1
 
         # Emit any modules that haven't been emitted yet
         for module_key in self._modules:

--- a/omnibenchmark/telemetry/emitter.py
+++ b/omnibenchmark/telemetry/emitter.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, Optional, Union
 
-from omnibenchmark.benchmark._paths import truncate_filename
+from omnibenchmark.core._paths import truncate_filename
 from omnibenchmark.telemetry.events import (
     Span,
     SpanStatus,

--- a/omnibenchmark/telemetry/emitter.py
+++ b/omnibenchmark/telemetry/emitter.py
@@ -1,0 +1,745 @@
+"""
+OTLP JSON emitter for telemetry data.
+
+Outputs OTLP-compatible JSON Lines (NDJSON) that can be:
+- Piped to OTLP collectors (Aspire Dashboard, Jaeger, etc.)
+- Written to a .jsonl file
+- Sent via HTTP to an OTLP endpoint
+
+Spans are emitted only when they complete (with start and end times),
+building up the trace hierarchy progressively as rules finish.
+
+Hierarchy:
+    benchmark
+    └── stage
+        └── module (groups rules by module_id within a stage)
+            └── rule (one per parameter combination)
+"""
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import IO, Optional, Union
+
+from omnibenchmark.telemetry.events import (
+    Span,
+    SpanStatus,
+    SpanKind,
+    Attribute,
+    SpanEvent,
+    LogRecord,
+    SeverityNumber,
+    generate_trace_id,
+    generate_span_id,
+    now_ns,
+)
+
+
+@dataclass
+class TelemetryEmitter:
+    """
+    Emits OTLP-compatible telemetry as JSON Lines.
+
+    Spans are emitted only when they complete, preserving hierarchy through
+    parent span IDs. The trace builds up progressively:
+    - Rules emit when they complete
+    - Modules emit when all their rules complete
+    - Stages emit when all their modules complete
+    - Benchmark emits at the very end
+
+    Usage:
+        emitter = TelemetryEmitter(output=Path("telemetry.jsonl"))
+
+        # Initialize with benchmark info (doesn't emit yet)
+        emitter.init_benchmark(name, version, stages, resolved_nodes)
+
+        # As rules execute:
+        emitter.rule_started("rule_name")
+        emitter.rule_completed("rule_name")  # Emits the rule span
+
+        # At the end:
+        emitter.benchmark_completed(success=True)  # Emits remaining hierarchy
+    """
+
+    output: Union[IO, Path, None] = None
+    service_name: str = "omnibenchmark"
+    service_version: str = "0.1.0"
+
+    _file_handle: Optional[IO] = None
+    _owns_handle: bool = False
+
+    # Trace-wide ID
+    _trace_id: str = field(default_factory=generate_trace_id)
+
+    # Benchmark span info
+    _benchmark_span_id: str = field(default_factory=generate_span_id)
+    _benchmark_name: str = ""
+    _benchmark_version: str = ""
+    _benchmark_author: str = ""
+    _benchmark_start_time: int = 0
+    _total_rules: int = 0
+    _software_backend: str = ""
+    _cores: int = 1
+
+    # Stage tracking: stage_id -> {span_id, name, start_time, modules: set, completed_modules: int, has_failures}
+    _stages: dict = field(default_factory=dict)
+
+    # Module tracking: (stage_id, module_id) -> {span_id, start_time, rule_count, completed_rules, has_failures}
+    _modules: dict = field(default_factory=dict)
+
+    # Rule tracking: rule_name -> {span_id, stage_id, module_id, node_id, inputs, outputs, params, start_time, ...}
+    _rules: dict = field(default_factory=dict)
+
+    # Track what's been emitted
+    _emitted_rules: set = field(default_factory=set)
+    _emitted_modules: set = field(default_factory=set)
+    _emitted_stages: set = field(default_factory=set)
+
+    def __post_init__(self):
+        if self.output is None:
+            self._file_handle = sys.stdout
+            self._owns_handle = False
+        elif isinstance(self.output, Path):
+            self._file_handle = open(self.output, "w")
+            self._owns_handle = True
+        else:
+            self._file_handle = self.output
+            self._owns_handle = False
+
+    def close(self):
+        """Close the output file if we own it."""
+        if self._owns_handle and self._file_handle:
+            self._file_handle.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def _emit_span(self, span: Span):
+        """Emit a single span as an OTLP JSON line."""
+        traces_data = {
+            "resourceSpans": [
+                {
+                    "resource": {
+                        "attributes": [
+                            {
+                                "key": "service.name",
+                                "value": {"stringValue": self.service_name},
+                            },
+                            {
+                                "key": "service.version",
+                                "value": {"stringValue": self.service_version},
+                            },
+                        ]
+                    },
+                    "scopeSpans": [
+                        {
+                            "scope": {
+                                "name": "omnibenchmark.telemetry",
+                                "version": "1.0.0",
+                            },
+                            "spans": [span.to_otlp()],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        line = json.dumps(traces_data, separators=(",", ":"))
+        assert self._file_handle is not None  # set in __post_init__
+        self._file_handle.write(line + "\n")
+        self._file_handle.flush()
+
+    def _emit_log(self, log: LogRecord):
+        """Emit a single log record as an OTLP JSON line."""
+        logs_data = {
+            "resourceLogs": [
+                {
+                    "resource": {
+                        "attributes": [
+                            {
+                                "key": "service.name",
+                                "value": {"stringValue": self.service_name},
+                            },
+                            {
+                                "key": "service.version",
+                                "value": {"stringValue": self.service_version},
+                            },
+                        ]
+                    },
+                    "scopeLogs": [
+                        {
+                            "scope": {
+                                "name": "omnibenchmark.telemetry",
+                                "version": "1.0.0",
+                            },
+                            "logRecords": [log.to_otlp()],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        line = json.dumps(logs_data, separators=(",", ":"))
+        assert self._file_handle is not None  # set in __post_init__
+        self._file_handle.write(line + "\n")
+        self._file_handle.flush()
+
+    def init_benchmark(
+        self,
+        benchmark_name: str,
+        benchmark_version: str,
+        benchmark_author: str,
+        software_backend: str,
+        cores: int,
+        stages: list[dict],
+        resolved_nodes: list,
+    ):
+        """
+        Initialize benchmark metadata. Does NOT emit spans yet.
+
+        Spans will be emitted as rules complete, building up the hierarchy.
+        """
+        self._benchmark_name = benchmark_name
+        self._benchmark_version = benchmark_version
+        self._benchmark_author = benchmark_author
+        self._software_backend = software_backend
+        self._cores = cores
+        self._benchmark_start_time = now_ns()
+        self._total_rules = len(resolved_nodes)
+
+        # Group nodes by stage and module
+        nodes_by_stage: dict[str, list] = {}
+        nodes_by_module: dict[tuple, list] = {}  # (stage_id, module_id) -> nodes
+
+        for node in resolved_nodes:
+            stage_id = node.stage_id
+            module_id = node.module_id
+
+            if stage_id not in nodes_by_stage:
+                nodes_by_stage[stage_id] = []
+            nodes_by_stage[stage_id].append(node)
+
+            module_key = (stage_id, module_id)
+            if module_key not in nodes_by_module:
+                nodes_by_module[module_key] = []
+            nodes_by_module[module_key].append(node)
+
+        # Initialize stage tracking
+        for stage in stages:
+            stage_id = stage.get("id") or stage.get("stage_id") or ""
+            stage_name = stage.get("name", stage_id)
+            stage_nodes = nodes_by_stage.get(stage_id, [])
+            module_ids = set(n.module_id for n in stage_nodes)
+
+            self._stages[stage_id] = {
+                "span_id": generate_span_id(),
+                "name": stage_name,
+                "start_time": None,
+                "modules": module_ids,
+                "module_count": len(module_ids),
+                "completed_modules": 0,
+                "has_failures": False,
+            }
+
+        # Initialize module tracking
+        for (stage_id, module_id), nodes in nodes_by_module.items():
+            self._modules[(stage_id, module_id)] = {
+                "span_id": generate_span_id(),
+                "stage_id": stage_id,
+                "module_id": module_id,
+                "start_time": None,
+                "rule_count": len(nodes),
+                "completed_rules": 0,
+                "has_failures": False,
+            }
+
+        # Initialize rule tracking
+        for node in resolved_nodes:
+            # Rule name must match Snakefile's _sanitize_rule_name(node.id)
+            rule_name = node.id.replace("-", "_").replace(".", "_")
+            if rule_name and not rule_name[0].isalpha():
+                rule_name = "rule_" + rule_name
+
+            self._rules[rule_name] = {
+                "span_id": generate_span_id(),
+                "stage_id": node.stage_id,
+                "module_id": node.module_id,
+                "node_id": node.id,
+                "param_id": node.param_id,
+                "inputs": node.inputs if hasattr(node, "inputs") else {},
+                "outputs": node.outputs if hasattr(node, "outputs") else [],
+                "parameters": node.get_parameter_json()
+                if hasattr(node, "get_parameter_json")
+                else None,
+                "log_file": f".logs/{rule_name}.log",  # Per-rule log file path
+                "start_time": None,
+                "end_time": None,
+                "status": SpanStatus.UNSET,
+                "error": None,
+                "stdout": None,
+                "stderr": None,
+            }
+
+    # Keep emit_manifest as alias for backward compatibility
+    def emit_manifest(self, **kwargs):
+        """Alias for init_benchmark (backward compatibility)."""
+        self.init_benchmark(**kwargs)
+
+    def get_rule_log_file(self, rule_name: str) -> Optional[str]:
+        """Get the log file path for a rule (relative to out_dir)."""
+        if rule_name in self._rules:
+            return self._rules[rule_name]["log_file"]
+        return None
+
+    def emit_setup_span(
+        self,
+        output: str,
+        start_time_ns: Optional[int] = None,
+        end_time_ns: Optional[int] = None,
+    ):
+        """Emit a setup span for environment preparation (conda, apptainer, etc.)."""
+        self.emit_phase_span(
+            name="setup: environment preparation",
+            phase="environment_setup",
+            setup_type="environment",
+            output=output,
+            start_time_ns=start_time_ns,
+            end_time_ns=end_time_ns,
+        )
+
+    def emit_phase_started(self, name: str, phase: str):
+        """Emit a log record signalling that a phase has started.
+
+        This lets the dashboard show activity immediately, before the phase
+        span is emitted (which requires both start and end times).
+        """
+        self._emit_log(
+            LogRecord(
+                trace_id=self._trace_id,
+                span_id=self._benchmark_span_id,
+                body=f"Started: {name}",
+                severity=SeverityNumber.INFO,
+                severity_text="setup",
+                timestamp_ns=now_ns(),
+                attributes=[
+                    Attribute("phase", phase),
+                    Attribute("phase.status", "started"),
+                ],
+            )
+        )
+
+    def emit_phase_span(
+        self,
+        name: str,
+        phase: str,
+        setup_type: str,
+        output: str = "",
+        start_time_ns: Optional[int] = None,
+        end_time_ns: Optional[int] = None,
+    ):
+        """Emit a span for a benchmark phase (resolution, environment setup, etc.).
+
+        Args:
+            name: Human-readable span name (e.g., "setup: module resolution")
+            phase: Phase identifier for log attribute (e.g., "module_resolution")
+            setup_type: Setup type attribute value (e.g., "resolution")
+            output: Captured output text for the phase
+            start_time_ns: Phase start time in nanoseconds
+            end_time_ns: Phase end time in nanoseconds
+        """
+        span = Span(
+            trace_id=self._trace_id,
+            span_id=generate_span_id(),
+            parent_span_id=self._benchmark_span_id,
+            name=name,
+            kind=SpanKind.INTERNAL,
+            start_time_ns=start_time_ns or self._benchmark_start_time,
+            end_time_ns=end_time_ns or now_ns(),
+            status=SpanStatus.OK,
+            attributes=[
+                Attribute("setup.type", setup_type),
+            ],
+        )
+        self._emit_span(span)
+
+        # Also emit as structured log for easy viewing
+        if output:
+            self._emit_log(
+                LogRecord(
+                    trace_id=self._trace_id,
+                    span_id=span.span_id,
+                    body=output,
+                    severity=SeverityNumber.INFO,
+                    severity_text="setup",
+                    timestamp_ns=end_time_ns or now_ns(),
+                    attributes=[
+                        Attribute("phase", phase),
+                    ],
+                )
+            )
+
+    def rule_started(self, rule_name: str):
+        """Record when a rule starts (doesn't emit yet)."""
+        if rule_name not in self._rules:
+            return
+
+        rule = self._rules[rule_name]
+        rule["start_time"] = now_ns()
+
+        stage_id = rule["stage_id"]
+        module_id = rule["module_id"]
+        module_key = (stage_id, module_id)
+
+        # Mark module start time if not set
+        if (
+            module_key in self._modules
+            and self._modules[module_key]["start_time"] is None
+        ):
+            self._modules[module_key]["start_time"] = now_ns()
+
+        # Mark stage start time if not set
+        if stage_id in self._stages and self._stages[stage_id]["start_time"] is None:
+            self._stages[stage_id]["start_time"] = now_ns()
+
+    def rule_completed(
+        self,
+        rule_name: str,
+        stdout: Optional[str] = None,
+        stderr: Optional[str] = None,
+    ):
+        """Mark rule as completed and emit its span."""
+        if rule_name not in self._rules or rule_name in self._emitted_rules:
+            return
+
+        rule = self._rules[rule_name]
+        rule["end_time"] = now_ns()
+        rule["status"] = SpanStatus.OK
+        rule["stdout"] = stdout
+        rule["stderr"] = stderr
+
+        if rule["start_time"] is None:
+            rule["start_time"] = rule["end_time"]
+
+        # Emit the rule span
+        self._emit_rule_span(rule_name)
+        self._emitted_rules.add(rule_name)
+
+        # Update module tracking
+        stage_id = rule["stage_id"]
+        module_id = rule["module_id"]
+        module_key = (stage_id, module_id)
+
+        if module_key in self._modules:
+            self._modules[module_key]["completed_rules"] += 1
+            self._maybe_emit_module(module_key)
+
+    def rule_failed(
+        self,
+        rule_name: str,
+        error: str,
+        stdout: Optional[str] = None,
+        stderr: Optional[str] = None,
+    ):
+        """Mark rule as failed and emit its span."""
+        if rule_name not in self._rules or rule_name in self._emitted_rules:
+            return
+
+        rule = self._rules[rule_name]
+        rule["end_time"] = now_ns()
+        rule["status"] = SpanStatus.ERROR
+        rule["error"] = error
+        rule["stdout"] = stdout
+        rule["stderr"] = stderr
+
+        if rule["start_time"] is None:
+            rule["start_time"] = rule["end_time"]
+
+        # Emit the rule span
+        self._emit_rule_span(rule_name)
+        self._emitted_rules.add(rule_name)
+
+        # Update module tracking
+        stage_id = rule["stage_id"]
+        module_id = rule["module_id"]
+        module_key = (stage_id, module_id)
+
+        if module_key in self._modules:
+            self._modules[module_key]["completed_rules"] += 1
+            self._modules[module_key]["has_failures"] = True
+            self._maybe_emit_module(module_key)
+
+    def _emit_rule_span(self, rule_name: str):
+        """Emit a completed rule span."""
+        rule = self._rules[rule_name]
+        stage_id = rule["stage_id"]
+        module_id = rule["module_id"]
+        module_key = (stage_id, module_id)
+
+        # Parent is the module span
+        parent_span_id = (
+            self._modules[module_key]["span_id"]
+            if module_key in self._modules
+            else self._benchmark_span_id
+        )
+
+        attributes = [
+            Attribute("rule.name", rule_name),
+            Attribute("rule.stage_id", stage_id),
+            Attribute("rule.module_id", module_id),
+            Attribute("rule.node_id", rule["node_id"]),
+            Attribute("rule.param_id", rule["param_id"]),
+        ]
+
+        if rule["outputs"]:
+            attributes.append(Attribute("rule.outputs", rule["outputs"]))
+        if rule["inputs"]:
+            attributes.append(Attribute("rule.inputs", list(rule["inputs"].values())))
+        if rule["parameters"]:
+            attributes.append(Attribute("rule.parameters", rule["parameters"]))
+        if rule["error"]:
+            attributes.append(Attribute("error.type", "RuleExecutionError"))
+
+        events = []
+        if rule["stdout"]:
+            events.append(
+                SpanEvent(
+                    name="stdout",
+                    timestamp_ns=rule["end_time"],
+                    attributes=[Attribute("output", rule["stdout"])],
+                )
+            )
+        if rule["stderr"]:
+            events.append(
+                SpanEvent(
+                    name="stderr",
+                    timestamp_ns=rule["end_time"],
+                    attributes=[Attribute("output", rule["stderr"])],
+                )
+            )
+        if rule["error"]:
+            events.append(
+                SpanEvent(
+                    name="exception",
+                    timestamp_ns=rule["end_time"],
+                    attributes=[Attribute("exception.message", rule["error"])],
+                )
+            )
+
+        span = Span(
+            trace_id=self._trace_id,
+            span_id=rule["span_id"],
+            parent_span_id=parent_span_id,
+            name=f"rule: {rule_name}",
+            kind=SpanKind.INTERNAL,
+            start_time_ns=rule["start_time"],
+            end_time_ns=rule["end_time"],
+            status=rule["status"],
+            status_message=rule["error"] or "",
+            attributes=attributes,
+            events=events,
+        )
+
+        self._emit_span(span)
+
+        # Emit structured logs for stdout/stderr (correlated with the span)
+        if rule["stdout"]:
+            self._emit_log(
+                LogRecord(
+                    trace_id=self._trace_id,
+                    span_id=rule["span_id"],
+                    body=rule["stdout"],
+                    severity=SeverityNumber.INFO,
+                    severity_text="stdout",
+                    timestamp_ns=rule["end_time"],
+                    attributes=[
+                        Attribute("rule.name", rule_name),
+                        Attribute("stream", "stdout"),
+                    ],
+                )
+            )
+
+        if rule["stderr"]:
+            # Use ERROR severity if the rule failed, WARN otherwise
+            severity = (
+                SeverityNumber.ERROR
+                if rule["status"] == SpanStatus.ERROR
+                else SeverityNumber.WARN
+            )
+            self._emit_log(
+                LogRecord(
+                    trace_id=self._trace_id,
+                    span_id=rule["span_id"],
+                    body=rule["stderr"],
+                    severity=severity,
+                    severity_text="stderr",
+                    timestamp_ns=rule["end_time"],
+                    attributes=[
+                        Attribute("rule.name", rule_name),
+                        Attribute("stream", "stderr"),
+                    ],
+                )
+            )
+
+        # Emit a prominent ERROR log for failed rules so they stand out in
+        # the Structured Logs view (separate from the stderr stream log).
+        if rule["status"] == SpanStatus.ERROR and rule["error"]:
+            self._emit_log(
+                LogRecord(
+                    trace_id=self._trace_id,
+                    span_id=rule["span_id"],
+                    body=f"FAILED: {rule_name} — {rule['error']}",
+                    severity=SeverityNumber.ERROR,
+                    severity_text="ERROR",
+                    timestamp_ns=rule["end_time"],
+                    attributes=[
+                        Attribute("rule.name", rule_name),
+                        Attribute("error.type", "RuleExecutionError"),
+                        Attribute("rule.stage_id", rule["stage_id"]),
+                        Attribute("rule.module_id", rule["module_id"]),
+                    ],
+                )
+            )
+
+    def _maybe_emit_module(self, module_key: tuple):
+        """Emit module span if all its rules are complete."""
+        if module_key in self._emitted_modules:
+            return
+
+        module = self._modules[module_key]
+        if module["completed_rules"] >= module["rule_count"]:
+            self._emit_module_span(module_key)
+            self._emitted_modules.add(module_key)
+
+            # Update stage tracking
+            stage_id = module["stage_id"]
+            if stage_id in self._stages:
+                self._stages[stage_id]["completed_modules"] += 1
+                if module["has_failures"]:
+                    self._stages[stage_id]["has_failures"] = True
+                self._maybe_emit_stage(stage_id)
+
+    def _emit_module_span(self, module_key: tuple):
+        """Emit a completed module span."""
+        module = self._modules[module_key]
+        stage_id = module["stage_id"]
+        end_time = now_ns()
+
+        # Parent is the stage span
+        parent_span_id = (
+            self._stages[stage_id]["span_id"]
+            if stage_id in self._stages
+            else self._benchmark_span_id
+        )
+
+        has_failures = module["has_failures"]
+        span = Span(
+            trace_id=self._trace_id,
+            span_id=module["span_id"],
+            parent_span_id=parent_span_id,
+            name=f"module: {module['module_id']}",
+            kind=SpanKind.INTERNAL,
+            start_time_ns=module["start_time"] or self._benchmark_start_time,
+            end_time_ns=end_time,
+            status=SpanStatus.ERROR if has_failures else SpanStatus.OK,
+            status_message=f"One or more rules failed in {module['module_id']}"
+            if has_failures
+            else "",
+            attributes=[
+                Attribute("module.id", module["module_id"]),
+                Attribute("module.stage_id", stage_id),
+                Attribute("module.rule_count", module["rule_count"]),
+            ],
+        )
+
+        self._emit_span(span)
+
+    def _maybe_emit_stage(self, stage_id: str):
+        """Emit stage span if all its modules are complete."""
+        if stage_id in self._emitted_stages:
+            return
+
+        stage = self._stages[stage_id]
+        if stage["completed_modules"] >= stage["module_count"]:
+            self._emit_stage_span(stage_id)
+            self._emitted_stages.add(stage_id)
+
+    def _emit_stage_span(self, stage_id: str):
+        """Emit a completed stage span."""
+        stage = self._stages[stage_id]
+        end_time = now_ns()
+
+        has_failures = stage["has_failures"]
+        span = Span(
+            trace_id=self._trace_id,
+            span_id=stage["span_id"],
+            parent_span_id=self._benchmark_span_id,
+            name=f"stage: {stage['name']}",
+            kind=SpanKind.INTERNAL,
+            start_time_ns=stage["start_time"] or self._benchmark_start_time,
+            end_time_ns=end_time,
+            status=SpanStatus.ERROR if has_failures else SpanStatus.OK,
+            status_message=f"One or more modules failed in stage {stage['name']}"
+            if has_failures
+            else "",
+            attributes=[
+                Attribute("stage.id", stage_id),
+                Attribute("stage.name", stage["name"]),
+                Attribute("stage.module_count", stage["module_count"]),
+            ],
+        )
+
+        self._emit_span(span)
+
+    def stage_completed(self, stage_id: str):
+        """Manually mark a stage as completed and emit it."""
+        if stage_id not in self._emitted_stages:
+            self._emit_stage_span(stage_id)
+            self._emitted_stages.add(stage_id)
+
+    def benchmark_completed(self, success: bool, message: str = ""):
+        """Emit any remaining modules, stages, and the benchmark root span."""
+        end_time = now_ns()
+
+        # Emit any modules that haven't been emitted yet
+        for module_key in self._modules:
+            if module_key not in self._emitted_modules:
+                self._emit_module_span(module_key)
+                self._emitted_modules.add(module_key)
+
+        # Emit any stages that haven't been emitted yet
+        for stage_id in self._stages:
+            if stage_id not in self._emitted_stages:
+                self._emit_stage_span(stage_id)
+                self._emitted_stages.add(stage_id)
+
+        # Emit the benchmark root span
+        span = Span(
+            trace_id=self._trace_id,
+            span_id=self._benchmark_span_id,
+            parent_span_id=None,
+            name=f"{self._benchmark_name}-{self._benchmark_version}",
+            kind=SpanKind.SERVER,
+            start_time_ns=self._benchmark_start_time,
+            end_time_ns=end_time,
+            status=SpanStatus.OK if success else SpanStatus.ERROR,
+            status_message=message,
+            attributes=[
+                Attribute("benchmark.name", self._benchmark_name),
+                Attribute("benchmark.version", self._benchmark_version),
+                Attribute("benchmark.author", self._benchmark_author),
+                Attribute("benchmark.total_rules", self._total_rules),
+                Attribute("benchmark.software_backend", self._software_backend),
+                Attribute("benchmark.cores", self._cores),
+            ],
+        )
+
+        self._emit_span(span)
+
+    @property
+    def trace_id(self) -> str:
+        """Get the trace ID for this run."""
+        return self._trace_id

--- a/omnibenchmark/telemetry/events.py
+++ b/omnibenchmark/telemetry/events.py
@@ -1,0 +1,202 @@
+"""
+Event types and schema for OTLP-compatible telemetry.
+
+This module defines the data structures that map to OpenTelemetry's
+trace model: spans, attributes, status, and events.
+"""
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any, Optional
+import time
+import uuid
+
+
+class SpanKind(IntEnum):
+    """OpenTelemetry span kinds."""
+
+    INTERNAL = 1
+    SERVER = 2
+    CLIENT = 3
+    PRODUCER = 4
+    CONSUMER = 5
+
+
+class SpanStatus(IntEnum):
+    """OpenTelemetry span status codes."""
+
+    UNSET = 0  # Pending / not yet determined
+    OK = 1  # Completed successfully
+    ERROR = 2  # Failed
+
+
+@dataclass
+class Attribute:
+    """A key-value attribute for spans."""
+
+    key: str
+    value: Any
+
+    def to_otlp(self) -> dict:
+        """Convert to OTLP attribute format."""
+        v = self.value
+        if isinstance(v, bool):
+            return {"key": self.key, "value": {"boolValue": v}}
+        elif isinstance(v, int):
+            return {"key": self.key, "value": {"intValue": str(v)}}
+        elif isinstance(v, float):
+            return {"key": self.key, "value": {"doubleValue": v}}
+        elif isinstance(v, (list, tuple)):
+            # Array of strings
+            return {
+                "key": self.key,
+                "value": {
+                    "arrayValue": {"values": [{"stringValue": str(x)} for x in v]}
+                },
+            }
+        else:
+            return {"key": self.key, "value": {"stringValue": str(v)}}
+
+
+@dataclass
+class SpanEvent:
+    """An event within a span (e.g., log line, error)."""
+
+    name: str
+    timestamp_ns: int
+    attributes: list[Attribute] = field(default_factory=list)
+
+    def to_otlp(self) -> dict:
+        return {
+            "timeUnixNano": str(self.timestamp_ns),
+            "name": self.name,
+            "attributes": [a.to_otlp() for a in self.attributes],
+        }
+
+
+@dataclass
+class Span:
+    """
+    An OTLP-compatible span representing a unit of work.
+
+    In omnibenchmark, spans represent:
+    - The entire benchmark run (root)
+    - Individual stages
+    - Individual rules/jobs
+    """
+
+    trace_id: str
+    span_id: str
+    parent_span_id: Optional[str]
+    name: str
+    kind: SpanKind = SpanKind.INTERNAL
+    start_time_ns: Optional[int] = None
+    end_time_ns: Optional[int] = None
+    status: SpanStatus = SpanStatus.UNSET
+    status_message: str = ""
+    attributes: list[Attribute] = field(default_factory=list)
+    events: list[SpanEvent] = field(default_factory=list)
+
+    def to_otlp(self) -> dict:
+        """Convert to OTLP span format."""
+        # Add otel.status_code / otel.status_description for backends that
+        # rely on semantic-convention attributes (Aspire Dashboard, etc.)
+        extra_attrs: list[Attribute] = []
+        if self.status == SpanStatus.ERROR:
+            extra_attrs.append(Attribute("otel.status_code", "ERROR"))
+            if self.status_message:
+                extra_attrs.append(
+                    Attribute("otel.status_description", self.status_message)
+                )
+        elif self.status == SpanStatus.OK:
+            extra_attrs.append(Attribute("otel.status_code", "OK"))
+
+        all_attrs = self.attributes + extra_attrs
+
+        span = {
+            "traceId": self.trace_id,
+            "spanId": self.span_id,
+            "name": self.name,
+            "kind": int(self.kind),
+            "status": {
+                "code": int(self.status),
+            },
+            "attributes": [a.to_otlp() for a in all_attrs],
+        }
+
+        if self.parent_span_id:
+            span["parentSpanId"] = self.parent_span_id
+
+        if self.start_time_ns:
+            span["startTimeUnixNano"] = str(self.start_time_ns)
+
+        if self.end_time_ns:
+            span["endTimeUnixNano"] = str(self.end_time_ns)
+
+        if self.status_message:
+            span["status"]["message"] = self.status_message
+
+        if self.events:
+            span["events"] = [e.to_otlp() for e in self.events]
+
+        return span
+
+
+def generate_trace_id() -> str:
+    """Generate a 32-character hex trace ID (16 bytes)."""
+    return uuid.uuid4().hex  # uuid4().hex is already 32 chars
+
+
+def generate_span_id() -> str:
+    """Generate a 16-character hex span ID (8 bytes)."""
+    return uuid.uuid4().hex[:16]
+
+
+def now_ns() -> int:
+    """Current time in nanoseconds since Unix epoch."""
+    return int(time.time() * 1_000_000_000)
+
+
+class SeverityNumber(IntEnum):
+    """OpenTelemetry log severity numbers."""
+
+    UNSPECIFIED = 0
+    TRACE = 1
+    DEBUG = 5
+    INFO = 9
+    WARN = 13
+    ERROR = 17
+    FATAL = 21
+
+
+@dataclass
+class LogRecord:
+    """
+    An OTLP-compatible log record.
+
+    Log records can be correlated with spans via trace_id and span_id.
+    """
+
+    trace_id: str
+    span_id: str
+    body: str
+    severity: SeverityNumber = SeverityNumber.INFO
+    severity_text: str = ""
+    timestamp_ns: Optional[int] = None
+    attributes: list[Attribute] = field(default_factory=list)
+
+    def to_otlp(self) -> dict:
+        """Convert to OTLP log record format."""
+        record = {
+            "timeUnixNano": str(self.timestamp_ns or now_ns()),
+            "severityNumber": int(self.severity),
+            "body": {"stringValue": self.body},
+            "attributes": [a.to_otlp() for a in self.attributes],
+            "traceId": self.trace_id,
+            "spanId": self.span_id,
+        }
+
+        if self.severity_text:
+            record["severityText"] = self.severity_text
+
+        return record

--- a/omnibenchmark/telemetry/spans.py
+++ b/omnibenchmark/telemetry/spans.py
@@ -1,0 +1,284 @@
+"""
+Span hierarchy builder for benchmark DAG.
+
+Converts the benchmark structure (stages, modules, rules) into
+a hierarchy of OTLP spans that can be browsed in OpenTelemetry backends.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from omnibenchmark.telemetry.events import (
+    Span,
+    SpanKind,
+    SpanStatus,
+    Attribute,
+    SpanEvent,
+    generate_trace_id,
+    generate_span_id,
+    now_ns,
+)
+
+
+@dataclass
+class SpanBuilder:
+    """
+    Builds and manages the span hierarchy for a benchmark run.
+
+    Hierarchy:
+        benchmark (root)
+        ├── stage_1
+        │   ├── rule_1a
+        │   └── rule_1b
+        ├── stage_2
+        │   ├── rule_2a
+        │   └── rule_2b
+        └── ...
+    """
+
+    trace_id: str = field(default_factory=generate_trace_id)
+    service_name: str = "omnibenchmark"
+
+    # Root span for the benchmark
+    _root_span: Optional[Span] = None
+
+    # Stage spans keyed by stage_id
+    _stage_spans: dict[str, Span] = field(default_factory=dict)
+
+    # Rule spans keyed by rule_name (full snakemake rule name)
+    _rule_spans: dict[str, Span] = field(default_factory=dict)
+
+    # Mapping from rule_name to stage_id for hierarchy
+    _rule_to_stage: dict[str, str] = field(default_factory=dict)
+
+    def create_benchmark_span(
+        self,
+        benchmark_name: str,
+        benchmark_version: str,
+        benchmark_author: str,
+        total_rules: int,
+        software_backend: str,
+        cores: int,
+    ) -> Span:
+        """Create the root span for the benchmark run."""
+        self._root_span = Span(
+            trace_id=self.trace_id,
+            span_id=generate_span_id(),
+            parent_span_id=None,
+            name=f"benchmark: {benchmark_name}",
+            kind=SpanKind.SERVER,
+            start_time_ns=now_ns(),
+            status=SpanStatus.UNSET,
+            attributes=[
+                Attribute("benchmark.name", benchmark_name),
+                Attribute("benchmark.version", benchmark_version),
+                Attribute("benchmark.author", benchmark_author),
+                Attribute("benchmark.total_rules", total_rules),
+                Attribute("benchmark.software_backend", software_backend),
+                Attribute("benchmark.cores", cores),
+                Attribute("service.name", self.service_name),
+            ],
+        )
+        return self._root_span
+
+    def create_stage_span(
+        self,
+        stage_id: str,
+        stage_name: Optional[str] = None,
+        module_count: int = 0,
+        rule_count: int = 0,
+    ) -> Span:
+        """Create a span for a benchmark stage."""
+        if not self._root_span:
+            raise RuntimeError("Must create benchmark span before stage spans")
+
+        span = Span(
+            trace_id=self.trace_id,
+            span_id=generate_span_id(),
+            parent_span_id=self._root_span.span_id,
+            name=f"stage: {stage_name or stage_id}",
+            kind=SpanKind.INTERNAL,
+            status=SpanStatus.UNSET,
+            attributes=[
+                Attribute("stage.id", stage_id),
+                Attribute("stage.name", stage_name or stage_id),
+                Attribute("stage.module_count", module_count),
+                Attribute("stage.rule_count", rule_count),
+            ],
+        )
+        self._stage_spans[stage_id] = span
+        return span
+
+    def create_rule_span(
+        self,
+        rule_name: str,
+        stage_id: str,
+        module_id: str,
+        node_id: str,
+        inputs: dict[str, str],
+        outputs: list[str],
+        parameters: Optional[str] = None,
+    ) -> Span:
+        """Create a span for an individual rule/job."""
+        parent_span = self._stage_spans.get(stage_id)
+        if not parent_span:
+            # Fallback to root if stage not found
+            parent_span = self._root_span
+
+        if not parent_span:
+            raise RuntimeError("Must create benchmark span before rule spans")
+
+        attributes = [
+            Attribute("rule.name", rule_name),
+            Attribute("rule.stage_id", stage_id),
+            Attribute("rule.module_id", module_id),
+            Attribute("rule.node_id", node_id),
+            Attribute("rule.outputs", outputs),
+        ]
+
+        if inputs:
+            attributes.append(Attribute("rule.inputs", list(inputs.values())))
+
+        if parameters:
+            attributes.append(Attribute("rule.parameters", parameters))
+
+        span = Span(
+            trace_id=self.trace_id,
+            span_id=generate_span_id(),
+            parent_span_id=parent_span.span_id,
+            name=f"rule: {rule_name}",
+            kind=SpanKind.INTERNAL,
+            status=SpanStatus.UNSET,
+            attributes=attributes,
+        )
+
+        self._rule_spans[rule_name] = span
+        self._rule_to_stage[rule_name] = stage_id
+        return span
+
+    def get_all_spans(self) -> list[Span]:
+        """Get all spans in hierarchy order (root, stages, rules)."""
+        spans = []
+        if self._root_span:
+            spans.append(self._root_span)
+        spans.extend(self._stage_spans.values())
+        spans.extend(self._rule_spans.values())
+        return spans
+
+    def mark_rule_started(self, rule_name: str) -> Optional[Span]:
+        """Mark a rule as started (set start time)."""
+        span = self._rule_spans.get(rule_name)
+        if span:
+            span.start_time_ns = now_ns()
+            # Also mark parent stage as started if not already
+            stage_id = self._rule_to_stage.get(rule_name)
+            if stage_id:
+                stage_span = self._stage_spans.get(stage_id)
+                if stage_span and not stage_span.start_time_ns:
+                    stage_span.start_time_ns = now_ns()
+        return span
+
+    def mark_rule_completed(
+        self,
+        rule_name: str,
+        stdout: Optional[str] = None,
+        stderr: Optional[str] = None,
+    ) -> Optional[Span]:
+        """Mark a rule as successfully completed."""
+        span = self._rule_spans.get(rule_name)
+        if span:
+            span.end_time_ns = now_ns()
+            span.status = SpanStatus.OK
+
+            if stdout:
+                span.events.append(
+                    SpanEvent(
+                        name="stdout",
+                        timestamp_ns=span.end_time_ns,
+                        attributes=[Attribute("output", stdout)],
+                    )
+                )
+
+            if stderr:
+                span.events.append(
+                    SpanEvent(
+                        name="stderr",
+                        timestamp_ns=span.end_time_ns,
+                        attributes=[Attribute("output", stderr)],
+                    )
+                )
+        return span
+
+    def mark_rule_failed(
+        self,
+        rule_name: str,
+        error: str,
+        stdout: Optional[str] = None,
+        stderr: Optional[str] = None,
+    ) -> Optional[Span]:
+        """Mark a rule as failed."""
+        span = self._rule_spans.get(rule_name)
+        if span:
+            span.end_time_ns = now_ns()
+            span.status = SpanStatus.ERROR
+            span.status_message = error
+
+            span.events.append(
+                SpanEvent(
+                    name="exception",
+                    timestamp_ns=span.end_time_ns,
+                    attributes=[Attribute("exception.message", error)],
+                )
+            )
+
+            if stdout:
+                span.events.append(
+                    SpanEvent(
+                        name="stdout",
+                        timestamp_ns=span.end_time_ns,
+                        attributes=[Attribute("output", stdout)],
+                    )
+                )
+
+            if stderr:
+                span.events.append(
+                    SpanEvent(
+                        name="stderr",
+                        timestamp_ns=span.end_time_ns,
+                        attributes=[Attribute("output", stderr)],
+                    )
+                )
+        return span
+
+    def mark_stage_completed(self, stage_id: str) -> Optional[Span]:
+        """Mark a stage as completed (all its rules finished)."""
+        span = self._stage_spans.get(stage_id)
+        if span:
+            span.end_time_ns = now_ns()
+            # Check if any rules in this stage failed
+            has_failures = any(
+                self._rule_spans[r].status == SpanStatus.ERROR
+                for r, s in self._rule_to_stage.items()
+                if s == stage_id and r in self._rule_spans
+            )
+            span.status = SpanStatus.ERROR if has_failures else SpanStatus.OK
+        return span
+
+    def mark_benchmark_completed(
+        self, success: bool, message: str = ""
+    ) -> Optional[Span]:
+        """Mark the benchmark run as completed."""
+        if self._root_span:
+            self._root_span.end_time_ns = now_ns()
+            self._root_span.status = SpanStatus.OK if success else SpanStatus.ERROR
+            if message:
+                self._root_span.status_message = message
+        return self._root_span
+
+    def get_rule_span(self, rule_name: str) -> Optional[Span]:
+        """Get a rule span by name."""
+        return self._rule_spans.get(rule_name)
+
+    def get_stage_span(self, stage_id: str) -> Optional[Span]:
+        """Get a stage span by ID."""
+        return self._stage_spans.get(stage_id)

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -930,6 +930,217 @@ def test_populate_git_cache_commit_lookup_keyerror(tmp_path):
         mock_fetch.assert_called_once()
 
 
+# ---------------------------------------------------------------------------
+# _run_snakemake — telemetry-stdout streaming branch
+# ---------------------------------------------------------------------------
+
+
+def _fake_popen_factory(lines, returncode=0):
+    """Build a Popen-shaped MagicMock whose stdout yields the given lines."""
+
+    fake = MagicMock()
+    fake.stdout = iter(lines)
+    fake.returncode = returncode
+    fake.wait = MagicMock(return_value=returncode)
+    return fake
+
+
+@pytest.mark.short
+def test_run_snakemake_telemetry_stdout_stream(tmp_path):
+    """Drive the elif use_telemetry_stdout branch end-to-end with a fake subprocess."""
+    import sys as _sys
+    from omnibenchmark.telemetry import TelemetryEmitter
+
+    (tmp_path / "Snakefile").write_text("rule all: input: []")
+
+    # Emit telemetry to stdout so the elif branch is selected.
+    emitter = TelemetryEmitter()  # output=None → stdout
+    assert emitter._file_handle is _sys.stdout
+
+    snakemake_lines = [
+        "Building DAG of jobs...\n",
+        "rule my_rule:\n",
+        "    input: a.txt\n",
+        "Finished job 0\n",
+        "Error in rule bad_rule:\n",
+        "    line\n",
+        "Shutting down\n",
+    ]
+    fake_proc = _fake_popen_factory(snakemake_lines, returncode=0)
+
+    with (
+        patch("omnibenchmark.cli.run.subprocess.Popen", return_value=fake_proc),
+        patch.object(emitter, "rule_started") as rs,
+        patch.object(emitter, "rule_completed") as rc,
+        patch.object(emitter, "rule_failed") as rf,
+        patch.object(emitter, "emit_setup_span") as es,
+        patch.object(emitter, "benchmark_completed") as bc,
+        patch.object(emitter, "emit_phase_started"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        _run_snakemake(
+            out_dir=tmp_path,
+            cores=1,
+            continue_on_error=False,
+            software_backend=SoftwareBackendEnum.host,
+            debug=False,
+            telemetry_emitter=emitter,
+        )
+
+    # Successful return code → exit 0
+    assert exc_info.value.code == 0
+    started = {c.args[0] for c in rs.call_args_list}
+    assert "my_rule" in started
+    rc.assert_called()
+    rf.assert_called()
+    es.assert_called_once()  # setup span emitted at first rule
+    bc.assert_called_once()
+    assert bc.call_args.kwargs["success"] is True
+
+
+@pytest.mark.short
+def test_run_snakemake_telemetry_stdout_no_rules_still_emits_setup(tmp_path):
+    """When no rules ever run, the setup span is still flushed at the end."""
+    import sys as _sys
+    from omnibenchmark.telemetry import TelemetryEmitter
+
+    (tmp_path / "Snakefile").write_text("rule all: input: []")
+    emitter = TelemetryEmitter()
+    assert emitter._file_handle is _sys.stdout
+
+    fake_proc = _fake_popen_factory(
+        ["Building DAG of jobs...\n", "Nothing to be done\n"], returncode=1
+    )
+
+    with (
+        patch("omnibenchmark.cli.run.subprocess.Popen", return_value=fake_proc),
+        patch.object(emitter, "emit_setup_span") as es,
+        patch.object(emitter, "benchmark_completed") as bc,
+        patch.object(emitter, "emit_phase_started"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        _run_snakemake(
+            out_dir=tmp_path,
+            cores=1,
+            continue_on_error=False,
+            software_backend=SoftwareBackendEnum.host,
+            debug=False,
+            telemetry_emitter=emitter,
+        )
+
+    assert exc_info.value.code == 1
+    es.assert_called_once()
+    assert bc.call_args.kwargs["success"] is False
+
+
+@pytest.mark.short
+def test_run_snakemake_telemetry_to_file_uses_progress_branch(tmp_path):
+    """Telemetry to a file (not stdout) takes the Rich-progress else branch."""
+    from omnibenchmark.telemetry import TelemetryEmitter
+
+    (tmp_path / "Snakefile").write_text("rule all: input: []")
+    telemetry_path = tmp_path / "telemetry.jsonl"
+    emitter = TelemetryEmitter(output=telemetry_path)
+
+    snakemake_lines = [
+        "Building DAG of jobs...\n",
+        "total 2\n",
+        "rule first:\n",
+        "    input: a.txt\n",
+        "Finished job 0\n",
+        "localrule second:\n",
+        "Finished job 1\n",
+        "Error in rule failing:\n",
+        "    boom\n",
+        "Shutting down\n",
+    ]
+    fake_proc = _fake_popen_factory(snakemake_lines, returncode=0)
+
+    fake_progress = MagicMock()
+    fake_progress.completed = 2
+    fake_progress.failed_rules = ["failing"]
+
+    with (
+        patch("omnibenchmark.cli.run.subprocess.Popen", return_value=fake_proc),
+        patch(
+            "omnibenchmark.cli.progress.InteractiveProgress",
+            return_value=fake_progress,
+        ),
+        patch("omnibenchmark.cli.progress.ProgressDisplay") as mock_pd,
+        patch.object(emitter, "rule_started") as rs,
+        patch.object(emitter, "rule_completed") as rc,
+        patch.object(emitter, "rule_failed") as rf,
+        patch.object(emitter, "emit_setup_span") as es,
+        patch.object(emitter, "benchmark_completed") as bc,
+        patch.object(emitter, "emit_phase_started"),
+        pytest.raises(SystemExit),
+    ):
+        # Console.status returns a context-manager-like helper
+        mock_pd.return_value.console.status.return_value = MagicMock()
+        _run_snakemake(
+            out_dir=tmp_path,
+            cores=1,
+            continue_on_error=False,
+            software_backend=SoftwareBackendEnum.host,
+            debug=False,
+            telemetry_emitter=emitter,
+        )
+
+    started = {c.args[0] for c in rs.call_args_list}
+    assert {"first", "second"} <= started
+    rc.assert_called()
+    rf.assert_called()
+    es.assert_called_once()
+    bc.assert_called_once()
+
+
+@pytest.mark.short
+def test_run_benchmark_telemetry_output_path_writes_file(tmp_path):
+    """--telemetry-output should produce a .jsonl file and not block Rich."""
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "Snakefile").write_text("rule all: input: []")
+    telemetry_path = tmp_path / "telemetry.jsonl"
+
+    with (
+        patch("omnibenchmark.cli.run.BenchmarkExecution") as mock_be,
+        patch("omnibenchmark.cli.run.populate_git_cache"),
+        patch(
+            "omnibenchmark.cli.run._generate_explicit_snakefile",
+            return_value=[],  # no resolved nodes → emit_manifest skipped
+        ),
+        patch("omnibenchmark.cli.run.write_run_manifest"),
+        patch("omnibenchmark.cli.run._run_snakemake") as mock_snakemake,
+    ):
+        mock_b = MagicMock()
+        mock_b.get_benchmark_software_backend.return_value = SoftwareBackendEnum.host
+        mock_be.return_value = mock_b
+        _run_benchmark(
+            benchmark_path="tests/data/mock_benchmark.yaml",
+            cores=1,
+            dry=False,
+            continue_on_error=False,
+            out_dir=str(out),
+            debug=False,
+            dirty=False,
+            telemetry_output=str(telemetry_path),
+        )
+
+    # Emitter should have been forwarded to _run_snakemake
+    _, kwargs = mock_snakemake.call_args
+    assert kwargs["telemetry_emitter"] is not None
+    assert kwargs["telemetry_emitter"]._file_handle is not None
+
+
+@pytest.mark.short
+def test_run_command_telemetry_flag_forwarded():
+    with patch("omnibenchmark.cli.run._run_benchmark") as mock_rb:
+        runner = CliRunner()
+        runner.invoke(run, ["tests/data/mock_benchmark.yaml", "--telemetry"])
+        mock_rb.assert_called_once()
+        assert mock_rb.call_args.kwargs.get("telemetry") is True
+
+
 @pytest.mark.short
 def test_run_benchmark_remote_storage_true_bool_appended(tmp_path):
     """A True boolean value in storage args should add a bare --flag."""

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -110,6 +110,19 @@ class TestReadRuleLog:
         result = _read_rule_log(tmp_path, "my_rule")
         assert result == "some log content"
 
+    def test_reads_truncated_log_for_long_rule_name(self, tmp_path):
+        from omnibenchmark.benchmark._paths import truncate_filename
+
+        long_rule = "a_" * 200  # 400 chars, well over the 255 byte cap
+        log_dir = tmp_path / ".logs"
+        log_dir.mkdir()
+        truncated_name = truncate_filename(f"{long_rule}.log")
+        assert truncated_name != f"{long_rule}.log"
+        (log_dir / truncated_name).write_text("truncated log content")
+
+        result = _read_rule_log(tmp_path, long_rule)
+        assert result == "truncated log content"
+
     def test_returns_none_on_read_error(self, tmp_path):
         log_dir = tmp_path / ".logs"
         log_dir.mkdir()

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -111,7 +111,7 @@ class TestReadRuleLog:
         assert result == "some log content"
 
     def test_reads_truncated_log_for_long_rule_name(self, tmp_path):
-        from omnibenchmark.benchmark._paths import truncate_filename
+        from omnibenchmark.core._paths import truncate_filename
 
         long_rule = "a_" * 200  # 400 chars, well over the 255 byte cap
         log_dir = tmp_path / ".logs"
@@ -1063,10 +1063,10 @@ def test_run_snakemake_telemetry_to_file_uses_progress_branch(tmp_path):
     with (
         patch("omnibenchmark.cli.run.subprocess.Popen", return_value=fake_proc),
         patch(
-            "omnibenchmark.cli.progress.InteractiveProgress",
+            "omnibenchmark.progress.InteractiveProgress",
             return_value=fake_progress,
         ),
-        patch("omnibenchmark.cli.progress.ProgressDisplay") as mock_pd,
+        patch("omnibenchmark.progress.ProgressDisplay") as mock_pd,
         patch.object(emitter, "rule_started") as rs,
         patch.object(emitter, "rule_completed") as rc,
         patch.object(emitter, "rule_failed") as rf,

--- a/tests/telemetry/test_emitter.py
+++ b/tests/telemetry/test_emitter.py
@@ -11,9 +11,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import pytest
 
 from omnibenchmark.telemetry.emitter import TelemetryEmitter
 from omnibenchmark.telemetry.events import SpanStatus
+
+pytestmark = pytest.mark.short
 
 
 # ---------------------------------------------------------------------------

--- a/tests/telemetry/test_emitter.py
+++ b/tests/telemetry/test_emitter.py
@@ -428,6 +428,32 @@ class TestEdgeCases:
         assert before == after == 1
 
 
+class TestSkippedRulesOnCompletion:
+    def test_unrun_rules_emitted_as_skipped(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+
+        # Only run one of the three rules; the other two are "cached".
+        emitter.rule_completed("S1_M1_p0")
+        emitter.benchmark_completed(success=True)
+
+        rule_spans = [s for s in _spans(buf) if s["name"].startswith("rule:")]
+        # All three rules should appear, distributed across their modules.
+        assert len(rule_spans) == 3
+        skipped = [
+            s
+            for s in rule_spans
+            if any(a["key"] == "rule.skipped" for a in s["attributes"])
+        ]
+        assert len(skipped) == 2
+        # Skipped rules still parent to the right module
+        m1_id = emitter._modules[("S1", "M1")]["span_id"]
+        m2_id = emitter._modules[("S1", "M2")]["span_id"]
+        parent_ids = {s["parentSpanId"] for s in skipped}
+        assert parent_ids <= {m1_id, m2_id}
+
+
 class TestMisc:
     def test_trace_id_is_stable(self):
         emitter = _make_emitter()

--- a/tests/telemetry/test_emitter.py
+++ b/tests/telemetry/test_emitter.py
@@ -1,0 +1,433 @@
+"""Behavioral tests for TelemetryEmitter.
+
+These cover the OTLP JSON Lines output: hierarchy emission ordering,
+parenting, status propagation, and the auxiliary log records emitted
+alongside spans.
+"""
+
+import io
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+from omnibenchmark.telemetry.emitter import TelemetryEmitter
+from omnibenchmark.telemetry.events import SpanStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeNode:
+    id: str
+    stage_id: str
+    module_id: str
+    param_id: str = ""
+    inputs: Dict[str, str] = field(default_factory=dict)
+    outputs: List[str] = field(default_factory=list)
+    _params: Optional[str] = None
+
+    def get_parameter_json(self) -> Optional[str]:
+        return self._params
+
+
+def _make_emitter(buf: Optional[io.StringIO] = None) -> TelemetryEmitter:
+    return TelemetryEmitter(output=buf or io.StringIO())
+
+
+def _lines(buf: io.StringIO) -> List[Dict[str, Any]]:
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line]
+
+
+def _spans(buf: io.StringIO) -> List[Dict[str, Any]]:
+    out = []
+    for entry in _lines(buf):
+        for rs in entry.get("resourceSpans", []):
+            for ss in rs.get("scopeSpans", []):
+                out.extend(ss.get("spans", []))
+    return out
+
+
+def _logs(buf: io.StringIO) -> List[Dict[str, Any]]:
+    out = []
+    for entry in _lines(buf):
+        for rl in entry.get("resourceLogs", []):
+            for sl in rl.get("scopeLogs", []):
+                out.extend(sl.get("logRecords", []))
+    return out
+
+
+def _attrs(span_or_log: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten OTLP attributes into a plain dict."""
+    flat = {}
+    for a in span_or_log.get("attributes", []):
+        v = a["value"]
+        flat[a["key"]] = next(iter(v.values()))
+    return flat
+
+
+def _init_simple(emitter: TelemetryEmitter) -> List[FakeNode]:
+    """Stage S1 with module M1 (2 rules) and module M2 (1 rule)."""
+    nodes = [
+        FakeNode(id="S1-M1-p0", stage_id="S1", module_id="M1", outputs=["a.txt"]),
+        FakeNode(id="S1-M1-p1", stage_id="S1", module_id="M1"),
+        FakeNode(id="S1-M2-p0", stage_id="S1", module_id="M2"),
+    ]
+    emitter.init_benchmark(
+        benchmark_name="bench",
+        benchmark_version="1.0",
+        benchmark_author="me",
+        software_backend="conda",
+        cores=2,
+        stages=[{"id": "S1", "name": "stage-one"}],
+        resolved_nodes=nodes,
+    )
+    return nodes
+
+
+# ---------------------------------------------------------------------------
+# Output sink configuration
+# ---------------------------------------------------------------------------
+
+
+class TestOutputSink:
+    def test_defaults_to_stdout(self, capsys):
+        emitter = TelemetryEmitter()
+        emitter.init_benchmark(
+            benchmark_name="b",
+            benchmark_version="0",
+            benchmark_author="",
+            software_backend="host",
+            cores=1,
+            stages=[],
+            resolved_nodes=[],
+        )
+        emitter.benchmark_completed(success=True)
+        captured = capsys.readouterr()
+        assert '"resourceSpans"' in captured.out
+
+    def test_writes_to_path(self, tmp_path: Path):
+        out = tmp_path / "telemetry.jsonl"
+        with TelemetryEmitter(output=out) as emitter:
+            _init_simple(emitter)
+            emitter.benchmark_completed(success=True)
+        assert out.exists()
+        # Each line is valid JSON
+        for line in out.read_text().splitlines():
+            json.loads(line)
+
+    def test_close_is_idempotent_on_external_handle(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        emitter.close()  # should not close caller-owned buf
+        assert not buf.closed
+
+    def test_context_manager_closes_owned_path(self, tmp_path: Path):
+        out = tmp_path / "t.jsonl"
+        with TelemetryEmitter(output=out) as emitter:
+            handle = emitter._file_handle
+        assert handle.closed
+
+
+# ---------------------------------------------------------------------------
+# init_benchmark / metadata
+# ---------------------------------------------------------------------------
+
+
+class TestInitBenchmark:
+    def test_groups_rules_by_stage_and_module(self):
+        emitter = _make_emitter()
+        _init_simple(emitter)
+        assert set(emitter._stages.keys()) == {"S1"}
+        assert emitter._stages["S1"]["module_count"] == 2
+        assert set(emitter._modules.keys()) == {("S1", "M1"), ("S1", "M2")}
+        assert emitter._modules[("S1", "M1")]["rule_count"] == 2
+        assert emitter._modules[("S1", "M2")]["rule_count"] == 1
+        assert len(emitter._rules) == 3
+
+    def test_rule_name_sanitization_matches_snakefile_rule(self):
+        emitter = _make_emitter()
+        emitter.init_benchmark(
+            benchmark_name="b",
+            benchmark_version="0",
+            benchmark_author="",
+            software_backend="host",
+            cores=1,
+            stages=[{"id": "S"}],
+            resolved_nodes=[FakeNode(id="1.weird-id", stage_id="S", module_id="M")],
+        )
+        # Leading digit triggers "rule_" prefix; dots/dashes become underscores.
+        assert "rule_1_weird_id" in emitter._rules
+
+    def test_emit_manifest_alias(self):
+        emitter = _make_emitter()
+        emitter.emit_manifest(
+            benchmark_name="b",
+            benchmark_version="0",
+            benchmark_author="",
+            software_backend="host",
+            cores=1,
+            stages=[],
+            resolved_nodes=[],
+        )
+        assert emitter._benchmark_name == "b"
+
+    def test_get_rule_log_file_returns_path_for_known_rule(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        path = emitter.get_rule_log_file("S1_M1_p0")
+        assert path == ".logs/S1_M1_p0.log"
+
+    def test_get_rule_log_file_returns_none_for_unknown(self):
+        emitter = _make_emitter()
+        _init_simple(emitter)
+        assert emitter.get_rule_log_file("does-not-exist") is None
+
+    def test_stage_id_can_come_from_stage_id_key(self):
+        emitter = _make_emitter()
+        emitter.init_benchmark(
+            benchmark_name="b",
+            benchmark_version="0",
+            benchmark_author="",
+            software_backend="host",
+            cores=1,
+            stages=[{"stage_id": "alt"}],
+            resolved_nodes=[FakeNode(id="x", stage_id="alt", module_id="M")],
+        )
+        assert "alt" in emitter._stages
+
+
+# ---------------------------------------------------------------------------
+# Phase / setup spans
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseSpans:
+    def test_emit_setup_span_writes_internal_span(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.emit_setup_span(output="set up conda")
+        spans = _spans(buf)
+        assert len(spans) == 1
+        assert spans[0]["name"] == "setup: environment preparation"
+        assert _attrs(spans[0])["setup.type"] == "environment"
+        # Output text becomes a structured log
+        logs = _logs(buf)
+        assert any(log["body"]["stringValue"] == "set up conda" for log in logs)
+
+    def test_emit_phase_span_without_output_emits_no_log(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.emit_phase_span(
+            name="setup: resolve",
+            phase="resolution",
+            setup_type="resolution",
+        )
+        assert len(_spans(buf)) == 1
+        assert _logs(buf) == []
+
+    def test_emit_phase_started_emits_log_only(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.emit_phase_started(name="resolve", phase="resolution")
+        assert _spans(buf) == []
+        logs = _logs(buf)
+        assert len(logs) == 1
+        attrs = _attrs(logs[0])
+        assert attrs["phase"] == "resolution"
+        assert attrs["phase.status"] == "started"
+
+
+# ---------------------------------------------------------------------------
+# Rule lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRuleLifecycle:
+    def test_rule_started_for_unknown_rule_is_noop(self):
+        emitter = _make_emitter()
+        _init_simple(emitter)
+        emitter.rule_started("unknown")  # must not raise
+        # No timing recorded anywhere
+        assert all(m["start_time"] is None for m in emitter._modules.values())
+
+    def test_rule_completed_emits_rule_span_with_parent_module(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.rule_started("S1_M1_p0")
+        emitter.rule_completed("S1_M1_p0", stdout="hello", stderr="warn")
+
+        spans = _spans(buf)
+        rule_spans = [s for s in spans if s["name"].startswith("rule:")]
+        assert len(rule_spans) == 1
+        rs = rule_spans[0]
+        # Parent is the module span we stashed at init time
+        assert rs["parentSpanId"] == emitter._modules[("S1", "M1")]["span_id"]
+        # Status OK and outputs/stdout reflected
+        assert rs["status"]["code"] == SpanStatus.OK.value
+        # Outputs are array-valued; just verify the attribute is present
+        assert any(a["key"] == "rule.outputs" for a in rs["attributes"])
+        # Events include stdout + stderr
+        ev_names = [e["name"] for e in rs.get("events", [])]
+        assert "stdout" in ev_names and "stderr" in ev_names
+
+        # Stdout / stderr also surface as structured logs
+        log_severities = {log["severityText"] for log in _logs(buf)}
+        assert "stdout" in log_severities
+        # Successful rule => stderr log severity is WARN, not ERROR
+        assert "stderr" in log_severities
+
+    def test_rule_completed_on_unknown_rule_is_noop(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.rule_completed("unknown")
+        assert _spans(buf) == []
+
+    def test_rule_completed_is_idempotent(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.rule_completed("S1_M1_p0")
+        emitter.rule_completed("S1_M1_p0")  # second call should be skipped
+        rule_spans = [s for s in _spans(buf) if s["name"].startswith("rule:")]
+        assert len(rule_spans) == 1
+
+    def test_rule_failed_marks_module_and_emits_error_log(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.rule_failed("S1_M2_p0", error="boom", stderr="trace")
+
+        rule_spans = [s for s in _spans(buf) if s["name"].startswith("rule:")]
+        assert rule_spans[0]["status"]["code"] == SpanStatus.ERROR.value
+        # Prominent ERROR log carries the failure summary
+        error_logs = [log for log in _logs(buf) if log.get("severityText") == "ERROR"]
+        assert any(
+            "FAILED: S1_M2_p0" in log["body"]["stringValue"] for log in error_logs
+        )
+        # Module span is emitted (M2 has only one rule) and marked ERROR
+        module_spans = [s for s in _spans(buf) if s["name"].startswith("module:")]
+        assert any(s["status"]["code"] == SpanStatus.ERROR.value for s in module_spans)
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy emission
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchyEmission:
+    def test_module_emitted_only_after_all_rules_complete(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+
+        emitter.rule_completed("S1_M1_p0")
+        # M1 still has one outstanding rule; module span must not be emitted yet
+        assert not [s for s in _spans(buf) if s["name"].startswith("module:")]
+
+        emitter.rule_completed("S1_M1_p1")
+        module_spans = [s for s in _spans(buf) if s["name"].startswith("module:")]
+        assert len(module_spans) == 1
+        assert module_spans[0]["name"] == "module: M1"
+        # Stage still pending (M2 not done yet)
+        assert not [s for s in _spans(buf) if s["name"].startswith("stage:")]
+
+    def test_benchmark_completed_flushes_pending_modules_and_stages(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        # No rules at all completed
+        emitter.benchmark_completed(success=True)
+        names = [s["name"] for s in _spans(buf)]
+        assert "module: M1" in names
+        assert "module: M2" in names
+        assert "stage: stage-one" in names
+        assert any(n.startswith("bench-1.0") for n in names)
+
+    def test_benchmark_completed_failure_status(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.benchmark_completed(success=False, message="aborted")
+        root = [s for s in _spans(buf) if s["name"].startswith("bench-")][0]
+        assert root["status"]["code"] == SpanStatus.ERROR.value
+        assert root["status"].get("message") == "aborted"
+
+    def test_stage_completed_emits_stage_span_once(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.stage_completed("S1")
+        emitter.stage_completed("S1")  # second call no-ops
+        stage_spans = [s for s in _spans(buf) if s["name"].startswith("stage:")]
+        assert len(stage_spans) == 1
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_rule_failed_on_unknown_is_noop(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        emitter.rule_failed("nope", error="boom")
+        assert _spans(buf) == []
+
+    def test_rule_span_includes_inputs_and_parameters_when_present(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        emitter.init_benchmark(
+            benchmark_name="b",
+            benchmark_version="0",
+            benchmark_author="",
+            software_backend="host",
+            cores=1,
+            stages=[{"id": "S"}],
+            resolved_nodes=[
+                FakeNode(
+                    id="r0",
+                    stage_id="S",
+                    module_id="M",
+                    inputs={"in1": "/tmp/x.txt"},
+                    _params='{"k": 1}',
+                )
+            ],
+        )
+        emitter.rule_completed("r0")
+        rule_span = [s for s in _spans(buf) if s["name"].startswith("rule:")][0]
+        keys = {a["key"] for a in rule_span["attributes"]}
+        assert "rule.inputs" in keys
+        assert "rule.parameters" in keys
+
+    def test_stage_completed_after_natural_emission_is_noop(self):
+        buf = io.StringIO()
+        emitter = TelemetryEmitter(output=buf)
+        _init_simple(emitter)
+        # Drive everything to completion through the natural path
+        for name in ("S1_M1_p0", "S1_M1_p1", "S1_M2_p0"):
+            emitter.rule_completed(name)
+        before = len([s for s in _spans(buf) if s["name"].startswith("stage:")])
+        emitter.stage_completed("S1")  # already emitted naturally
+        after = len([s for s in _spans(buf) if s["name"].startswith("stage:")])
+        assert before == after == 1
+
+
+class TestMisc:
+    def test_trace_id_is_stable(self):
+        emitter = _make_emitter()
+        assert emitter.trace_id == emitter._trace_id
+        # Trace IDs are 32-char hex per OTLP
+        assert len(emitter.trace_id) == 32

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -1,0 +1,275 @@
+"""Behavioral tests for omnibenchmark.telemetry.events.
+
+Tests focus on observable OTLP output and identifier guarantees, not the
+specific dispatch ladder used inside to_otlp().
+"""
+
+import time
+
+
+from omnibenchmark.telemetry.events import (
+    Attribute,
+    LogRecord,
+    SeverityNumber,
+    Span,
+    SpanEvent,
+    SpanKind,
+    SpanStatus,
+    generate_span_id,
+    generate_trace_id,
+    now_ns,
+)
+
+
+# ---------------------------------------------------------------------------
+# Attribute serialization
+# ---------------------------------------------------------------------------
+
+
+class TestAttributeToOtlp:
+    def test_string_value(self):
+        out = Attribute("k", "hello").to_otlp()
+        assert out == {"key": "k", "value": {"stringValue": "hello"}}
+
+    def test_bool_is_not_serialized_as_int(self):
+        # bool is an int subclass in Python; OTLP must distinguish them.
+        assert Attribute("k", True).to_otlp() == {
+            "key": "k",
+            "value": {"boolValue": True},
+        }
+        assert Attribute("k", False).to_otlp() == {
+            "key": "k",
+            "value": {"boolValue": False},
+        }
+
+    def test_int_is_serialized_as_string(self):
+        # OTLP requires intValue to be a string (int64 wire format).
+        out = Attribute("count", 42).to_otlp()
+        assert out == {"key": "count", "value": {"intValue": "42"}}
+        assert isinstance(out["value"]["intValue"], str)
+
+    def test_float_value(self):
+        out = Attribute("ratio", 1.5).to_otlp()
+        assert out == {"key": "ratio", "value": {"doubleValue": 1.5}}
+
+    def test_list_serialized_as_string_array(self):
+        out = Attribute("files", ["a.txt", "b.txt"]).to_otlp()
+        assert out == {
+            "key": "files",
+            "value": {
+                "arrayValue": {
+                    "values": [
+                        {"stringValue": "a.txt"},
+                        {"stringValue": "b.txt"},
+                    ]
+                }
+            },
+        }
+
+    def test_tuple_serialized_same_as_list(self):
+        from_list = Attribute("x", ["a", "b"]).to_otlp()
+        from_tuple = Attribute("x", ("a", "b")).to_otlp()
+        assert from_list == from_tuple
+
+    def test_list_of_ints_is_stringified(self):
+        out = Attribute("ids", [1, 2, 3]).to_otlp()
+        values = out["value"]["arrayValue"]["values"]
+        assert values == [
+            {"stringValue": "1"},
+            {"stringValue": "2"},
+            {"stringValue": "3"},
+        ]
+
+    def test_unknown_type_falls_back_to_string(self):
+        class Custom:
+            def __str__(self):
+                return "custom!"
+
+        out = Attribute("k", Custom()).to_otlp()
+        assert out == {"key": "k", "value": {"stringValue": "custom!"}}
+
+    def test_none_falls_back_to_string(self):
+        out = Attribute("k", None).to_otlp()
+        assert out == {"key": "k", "value": {"stringValue": "None"}}
+
+
+# ---------------------------------------------------------------------------
+# SpanEvent serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSpanEventToOtlp:
+    def test_round_trip_shape(self):
+        ev = SpanEvent(
+            name="stdout",
+            timestamp_ns=123,
+            attributes=[Attribute("output", "hi")],
+        )
+        out = ev.to_otlp()
+        assert out["name"] == "stdout"
+        assert out["timeUnixNano"] == "123"  # OTLP requires string
+        assert out["attributes"] == [{"key": "output", "value": {"stringValue": "hi"}}]
+
+    def test_no_attributes_yields_empty_list(self):
+        out = SpanEvent(name="x", timestamp_ns=1).to_otlp()
+        assert out["attributes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Span serialization
+# ---------------------------------------------------------------------------
+
+
+def _make_span(**overrides) -> Span:
+    base = dict(
+        trace_id="t" * 32,
+        span_id="s" * 16,
+        parent_span_id=None,
+        name="root",
+    )
+    base.update(overrides)
+    return Span(**base)
+
+
+class TestSpanToOtlp:
+    def test_required_fields_always_present(self):
+        out = _make_span().to_otlp()
+        assert out["traceId"] == "t" * 32
+        assert out["spanId"] == "s" * 16
+        assert out["name"] == "root"
+        assert out["kind"] == int(SpanKind.INTERNAL)
+        assert out["status"] == {"code": int(SpanStatus.UNSET)}
+        assert out["attributes"] == []
+
+    def test_optional_fields_omitted_when_unset(self):
+        out = _make_span().to_otlp()
+        assert "parentSpanId" not in out
+        assert "startTimeUnixNano" not in out
+        assert "endTimeUnixNano" not in out
+        assert "events" not in out
+        assert "message" not in out["status"]
+
+    def test_parent_included_when_set(self):
+        out = _make_span(parent_span_id="p" * 16).to_otlp()
+        assert out["parentSpanId"] == "p" * 16
+
+    def test_times_serialized_as_strings(self):
+        out = _make_span(start_time_ns=10, end_time_ns=20).to_otlp()
+        assert out["startTimeUnixNano"] == "10"
+        assert out["endTimeUnixNano"] == "20"
+
+    def test_kind_uses_int_value(self):
+        out = _make_span(kind=SpanKind.SERVER).to_otlp()
+        assert out["kind"] == int(SpanKind.SERVER)
+
+    def test_error_status_adds_semantic_attributes(self):
+        out = _make_span(status=SpanStatus.ERROR, status_message="boom").to_otlp()
+        attr_pairs = {a["key"]: a["value"] for a in out["attributes"]}
+        assert attr_pairs["otel.status_code"] == {"stringValue": "ERROR"}
+        assert attr_pairs["otel.status_description"] == {"stringValue": "boom"}
+        assert out["status"]["code"] == int(SpanStatus.ERROR)
+        assert out["status"]["message"] == "boom"
+
+    def test_error_without_message_omits_description(self):
+        out = _make_span(status=SpanStatus.ERROR).to_otlp()
+        keys = {a["key"] for a in out["attributes"]}
+        assert "otel.status_code" in keys
+        assert "otel.status_description" not in keys
+        assert "message" not in out["status"]
+
+    def test_ok_status_adds_semantic_code(self):
+        out = _make_span(status=SpanStatus.OK).to_otlp()
+        keys = {a["key"]: a["value"] for a in out["attributes"]}
+        assert keys["otel.status_code"] == {"stringValue": "OK"}
+
+    def test_unset_status_adds_no_semantic_attributes(self):
+        out = _make_span(status=SpanStatus.UNSET).to_otlp()
+        assert out["attributes"] == []
+
+    def test_user_attributes_preserved_alongside_semantic_ones(self):
+        out = _make_span(
+            status=SpanStatus.OK,
+            attributes=[Attribute("custom.key", "v")],
+        ).to_otlp()
+        keys = [a["key"] for a in out["attributes"]]
+        assert "custom.key" in keys
+        assert "otel.status_code" in keys
+
+    def test_events_serialized_when_present(self):
+        ev = SpanEvent(name="stdout", timestamp_ns=5)
+        out = _make_span(events=[ev]).to_otlp()
+        assert out["events"] == [ev.to_otlp()]
+
+
+# ---------------------------------------------------------------------------
+# LogRecord serialization
+# ---------------------------------------------------------------------------
+
+
+class TestLogRecordToOtlp:
+    def test_basic_shape(self):
+        rec = LogRecord(
+            trace_id="t" * 32,
+            span_id="s" * 16,
+            body="hello",
+            severity=SeverityNumber.WARN,
+            timestamp_ns=42,
+        )
+        out = rec.to_otlp()
+        assert out["traceId"] == "t" * 32
+        assert out["spanId"] == "s" * 16
+        assert out["body"] == {"stringValue": "hello"}
+        assert out["severityNumber"] == int(SeverityNumber.WARN)
+        assert out["timeUnixNano"] == "42"
+
+    def test_severity_text_only_emitted_when_set(self):
+        out = LogRecord(
+            trace_id="t" * 32, span_id="s" * 16, body="x", timestamp_ns=1
+        ).to_otlp()
+        assert "severityText" not in out
+
+        out2 = LogRecord(
+            trace_id="t" * 32,
+            span_id="s" * 16,
+            body="x",
+            timestamp_ns=1,
+            severity_text="WARN",
+        ).to_otlp()
+        assert out2["severityText"] == "WARN"
+
+    def test_missing_timestamp_uses_current_time(self, monkeypatch):
+        monkeypatch.setattr("omnibenchmark.telemetry.events.now_ns", lambda: 999)
+        out = LogRecord(trace_id="t" * 32, span_id="s" * 16, body="x").to_otlp()
+        assert out["timeUnixNano"] == "999"
+
+
+# ---------------------------------------------------------------------------
+# ID and time helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIdGenerators:
+    def test_trace_id_is_32_hex_chars(self):
+        tid = generate_trace_id()
+        assert len(tid) == 32
+        int(tid, 16)  # parses as hex
+
+    def test_span_id_is_16_hex_chars(self):
+        sid = generate_span_id()
+        assert len(sid) == 16
+        int(sid, 16)
+
+    def test_ids_are_unique_across_calls(self):
+        traces = {generate_trace_id() for _ in range(50)}
+        spans = {generate_span_id() for _ in range(50)}
+        assert len(traces) == 50
+        assert len(spans) == 50
+
+
+class TestNowNs:
+    def test_returns_nanoseconds_close_to_wall_clock(self):
+        expected = time.time() * 1_000_000_000
+        actual = now_ns()
+        # Within 1 second of wall clock.
+        assert abs(actual - expected) < 1_000_000_000
+        assert isinstance(actual, int)

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -6,6 +6,7 @@ specific dispatch ladder used inside to_otlp().
 
 import time
 
+import pytest
 
 from omnibenchmark.telemetry.events import (
     Attribute,
@@ -19,6 +20,8 @@ from omnibenchmark.telemetry.events import (
     generate_trace_id,
     now_ns,
 )
+
+pytestmark = pytest.mark.short
 
 
 # ---------------------------------------------------------------------------

--- a/tests/telemetry/test_spans.py
+++ b/tests/telemetry/test_spans.py
@@ -9,6 +9,8 @@ import pytest
 from omnibenchmark.telemetry.events import SpanStatus
 from omnibenchmark.telemetry.spans import SpanBuilder
 
+pytestmark = pytest.mark.short
+
 
 def _attrs(span) -> dict:
     """Flatten a span's attributes to {key: value} for easy assertions."""

--- a/tests/telemetry/test_spans.py
+++ b/tests/telemetry/test_spans.py
@@ -1,0 +1,389 @@
+"""Behavioral tests for SpanBuilder.
+
+Focus on the observable outcomes — span hierarchy, attribute presence, and
+status transitions — rather than internal storage details.
+"""
+
+import pytest
+
+from omnibenchmark.telemetry.events import SpanStatus
+from omnibenchmark.telemetry.spans import SpanBuilder
+
+
+def _attrs(span) -> dict:
+    """Flatten a span's attributes to {key: value} for easy assertions."""
+    return {a.key: a.value for a in span.attributes}
+
+
+def _make_builder_with_root() -> SpanBuilder:
+    b = SpanBuilder()
+    b.create_benchmark_span(
+        benchmark_name="bench",
+        benchmark_version="1.0",
+        benchmark_author="me",
+        total_rules=3,
+        software_backend="conda",
+        cores=4,
+    )
+    return b
+
+
+# ---------------------------------------------------------------------------
+# Root benchmark span
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkSpan:
+    def test_root_has_no_parent_and_carries_metadata(self):
+        b = SpanBuilder()
+        root = b.create_benchmark_span(
+            benchmark_name="bench",
+            benchmark_version="1.0",
+            benchmark_author="me",
+            total_rules=3,
+            software_backend="conda",
+            cores=4,
+        )
+
+        assert root.parent_span_id is None
+        assert root.trace_id == b.trace_id
+        assert root.start_time_ns is not None
+        assert root.status == SpanStatus.UNSET
+        assert "bench" in root.name
+
+        attrs = _attrs(root)
+        assert attrs["benchmark.name"] == "bench"
+        assert attrs["benchmark.version"] == "1.0"
+        assert attrs["benchmark.author"] == "me"
+        assert attrs["benchmark.total_rules"] == 3
+        assert attrs["benchmark.software_backend"] == "conda"
+        assert attrs["benchmark.cores"] == 4
+        assert attrs["service.name"] == "omnibenchmark"
+
+    def test_custom_service_name_is_used(self):
+        b = SpanBuilder(service_name="my-svc")
+        root = b.create_benchmark_span("b", "1", "a", 0, "host", 1)
+        assert _attrs(root)["service.name"] == "my-svc"
+
+
+# ---------------------------------------------------------------------------
+# Stage spans
+# ---------------------------------------------------------------------------
+
+
+class TestStageSpan:
+    def test_stage_requires_root(self):
+        b = SpanBuilder()
+        with pytest.raises(RuntimeError):
+            b.create_stage_span("s1")
+
+    def test_stage_is_child_of_root(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1", stage_name="Stage One")
+
+        assert stage.parent_span_id == b.get_all_spans()[0].span_id
+        assert stage.trace_id == b.trace_id
+        assert "Stage One" in stage.name
+        assert stage.status == SpanStatus.UNSET
+        # Stage start is set lazily when first rule starts.
+        assert stage.start_time_ns is None
+
+    def test_stage_name_defaults_to_id(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1")
+        assert "s1" in stage.name
+        assert _attrs(stage)["stage.name"] == "s1"
+
+    def test_stage_attributes_record_counts(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1", module_count=2, rule_count=5)
+        attrs = _attrs(stage)
+        assert attrs["stage.id"] == "s1"
+        assert attrs["stage.module_count"] == 2
+        assert attrs["stage.rule_count"] == 5
+
+    def test_get_stage_span_round_trip(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1")
+        assert b.get_stage_span("s1") is stage
+        assert b.get_stage_span("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# Rule spans
+# ---------------------------------------------------------------------------
+
+
+class TestRuleSpan:
+    def test_rule_is_child_of_stage(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1")
+        rule = b.create_rule_span(
+            rule_name="r1",
+            stage_id="s1",
+            module_id="m1",
+            node_id="n1",
+            inputs={"in": "data.tsv"},
+            outputs=["out.tsv"],
+        )
+        assert rule.parent_span_id == stage.span_id
+        assert rule.trace_id == b.trace_id
+
+    def test_rule_falls_back_to_root_when_stage_missing(self):
+        b = _make_builder_with_root()
+        root_id = b.get_all_spans()[0].span_id
+        rule = b.create_rule_span(
+            rule_name="r1",
+            stage_id="unknown-stage",
+            module_id="m1",
+            node_id="n1",
+            inputs={},
+            outputs=["out.tsv"],
+        )
+        assert rule.parent_span_id == root_id
+
+    def test_rule_without_root_raises(self):
+        b = SpanBuilder()
+        with pytest.raises(RuntimeError):
+            b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+
+    def test_rule_attributes_include_core_metadata(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span(
+            rule_name="r1",
+            stage_id="s1",
+            module_id="m1",
+            node_id="n1",
+            inputs={"in": "data.tsv"},
+            outputs=["out.tsv"],
+        )
+        attrs = _attrs(rule)
+        assert attrs["rule.name"] == "r1"
+        assert attrs["rule.stage_id"] == "s1"
+        assert attrs["rule.module_id"] == "m1"
+        assert attrs["rule.node_id"] == "n1"
+        assert attrs["rule.outputs"] == ["out.tsv"]
+
+    def test_inputs_attribute_omitted_when_empty(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span("r1", "s1", "m1", "n1", {}, ["out.tsv"])
+        assert "rule.inputs" not in _attrs(rule)
+
+    def test_inputs_attribute_records_values_only(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span(
+            "r1",
+            "s1",
+            "m1",
+            "n1",
+            inputs={"a": "x.tsv", "b": "y.tsv"},
+            outputs=["out.tsv"],
+        )
+        # Behavior: inputs values are exposed; we don't care about order.
+        assert set(_attrs(rule)["rule.inputs"]) == {"x.tsv", "y.tsv"}
+
+    def test_parameters_attribute_only_when_supplied(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        without = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        assert "rule.parameters" not in _attrs(without)
+
+        b2 = _make_builder_with_root()
+        b2.create_stage_span("s1")
+        with_params = b2.create_rule_span(
+            "r2", "s1", "m1", "n1", {}, [], parameters="k=1"
+        )
+        assert _attrs(with_params)["rule.parameters"] == "k=1"
+
+    def test_get_rule_span_round_trip(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        assert b.get_rule_span("r1") is rule
+        assert b.get_rule_span("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy view
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllSpans:
+    def test_empty_builder_returns_no_spans(self):
+        assert SpanBuilder().get_all_spans() == []
+
+    def test_hierarchy_order_is_root_then_stages_then_rules(self):
+        b = _make_builder_with_root()
+        s1 = b.create_stage_span("s1")
+        s2 = b.create_stage_span("s2")
+        r1 = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        r2 = b.create_rule_span("r2", "s2", "m1", "n2", {}, [])
+
+        spans = b.get_all_spans()
+        assert len(spans) == 5
+        root = spans[0]
+        assert root.parent_span_id is None
+        # The two stages come before the two rules.
+        stage_ids = {s.span_id for s in spans[1:3]}
+        rule_ids = {s.span_id for s in spans[3:]}
+        assert stage_ids == {s1.span_id, s2.span_id}
+        assert rule_ids == {r1.span_id, r2.span_id}
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle transitions
+# ---------------------------------------------------------------------------
+
+
+class TestRuleLifecycle:
+    def test_started_sets_rule_start_and_propagates_to_stage(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1")
+        rule = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        assert rule.start_time_ns is None
+        assert stage.start_time_ns is None
+
+        b.mark_rule_started("r1")
+        assert rule.start_time_ns is not None
+        assert stage.start_time_ns is not None
+
+    def test_started_does_not_overwrite_stage_start(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1")
+        b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        b.create_rule_span("r2", "s1", "m1", "n2", {}, [])
+
+        b.mark_rule_started("r1")
+        first_start = stage.start_time_ns
+
+        b.mark_rule_started("r2")
+        assert stage.start_time_ns == first_start
+
+    def test_started_on_unknown_rule_returns_none(self):
+        b = _make_builder_with_root()
+        assert b.mark_rule_started("nope") is None
+
+    def test_completed_sets_ok_status_and_end_time(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        b.mark_rule_started("r1")
+
+        b.mark_rule_completed("r1")
+        assert rule.status == SpanStatus.OK
+        assert rule.end_time_ns is not None
+        assert rule.events == []
+
+    def test_completed_records_optional_stdout_and_stderr(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+
+        b.mark_rule_completed("r1", stdout="hi", stderr="warn")
+        event_names = [e.name for e in rule.events]
+        assert event_names == ["stdout", "stderr"]
+        outputs = {e.name: e.attributes[0].value for e in rule.events}
+        assert outputs["stdout"] == "hi"
+        assert outputs["stderr"] == "warn"
+
+    def test_completed_skips_empty_streams(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        b.mark_rule_completed("r1", stdout="", stderr=None)
+        assert rule.events == []
+
+    def test_completed_on_unknown_rule_returns_none(self):
+        b = _make_builder_with_root()
+        assert b.mark_rule_completed("nope") is None
+
+    def test_failed_sets_error_status_and_exception_event(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+
+        b.mark_rule_failed("r1", error="boom")
+        assert rule.status == SpanStatus.ERROR
+        assert rule.status_message == "boom"
+        assert rule.end_time_ns is not None
+        # An exception event must be recorded with the message.
+        exc_events = [e for e in rule.events if e.name == "exception"]
+        assert len(exc_events) == 1
+        attrs = {a.key: a.value for a in exc_events[0].attributes}
+        assert attrs["exception.message"] == "boom"
+
+    def test_failed_attaches_stdout_and_stderr_when_present(self):
+        b = _make_builder_with_root()
+        b.create_stage_span("s1")
+        rule = b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+
+        b.mark_rule_failed("r1", error="boom", stdout="o", stderr="e")
+        names = [e.name for e in rule.events]
+        assert names == ["exception", "stdout", "stderr"]
+
+    def test_failed_on_unknown_rule_returns_none(self):
+        b = _make_builder_with_root()
+        assert b.mark_rule_failed("nope", "err") is None
+
+
+class TestStageLifecycle:
+    def test_stage_ok_when_no_rules_failed(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1")
+        b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        b.mark_rule_completed("r1")
+
+        b.mark_stage_completed("s1")
+        assert stage.status == SpanStatus.OK
+        assert stage.end_time_ns is not None
+
+    def test_stage_error_when_any_rule_failed(self):
+        b = _make_builder_with_root()
+        stage = b.create_stage_span("s1")
+        b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        b.create_rule_span("r2", "s1", "m1", "n2", {}, [])
+        b.mark_rule_completed("r1")
+        b.mark_rule_failed("r2", error="x")
+
+        b.mark_stage_completed("s1")
+        assert stage.status == SpanStatus.ERROR
+
+    def test_stage_failure_does_not_leak_across_stages(self):
+        b = _make_builder_with_root()
+        s1 = b.create_stage_span("s1")
+        s2 = b.create_stage_span("s2")
+        b.create_rule_span("r1", "s1", "m1", "n1", {}, [])
+        b.create_rule_span("r2", "s2", "m1", "n2", {}, [])
+        b.mark_rule_failed("r1", error="x")
+        b.mark_rule_completed("r2")
+
+        b.mark_stage_completed("s1")
+        b.mark_stage_completed("s2")
+        assert s1.status == SpanStatus.ERROR
+        assert s2.status == SpanStatus.OK
+
+    def test_stage_completed_on_unknown_stage_returns_none(self):
+        b = _make_builder_with_root()
+        assert b.mark_stage_completed("nope") is None
+
+
+class TestBenchmarkLifecycle:
+    def test_success_sets_ok(self):
+        b = _make_builder_with_root()
+        root = b.mark_benchmark_completed(success=True)
+        assert root.status == SpanStatus.OK
+        assert root.end_time_ns is not None
+        assert root.status_message == ""
+
+    def test_failure_sets_error_with_message(self):
+        b = _make_builder_with_root()
+        root = b.mark_benchmark_completed(success=False, message="aborted")
+        assert root.status == SpanStatus.ERROR
+        assert root.status_message == "aborted"
+
+    def test_no_root_returns_none(self):
+        b = SpanBuilder()
+        assert b.mark_benchmark_completed(success=True) is None


### PR DESCRIPTION
Ports OpenTelemetry instrumentation from the execution-shell-telemetry branch (squash of 13d2700, dc9daf0, afe2829) onto current main.

Adds:
- omnibenchmark/telemetry/ — pure-Python OTLP-shaped emitter, span builder, and event types (no external opentelemetry-sdk dependency).
- scripts/telemetry-relay.py — relay for forwarding JSONL telemetry.
- --telemetry [json] and --telemetry-output PATH options on 'ob run'. Streaming JSON to stdout disables the Rich progress UI; --telemetry-output writes to a file and keeps Rich active.
- Per-rule log capture wired through the existing log: directive in the generated Snakefile and surfaced via _read_rule_log.

Drops the older snakemake_gen.py touches: the equivalent log/tee infrastructure already lives in backend/snakemake.py on main. Drops the older cache.py changes: superseded by main's refactored ref resolution.

Refs: #293

