### PR TITLE
bug: truncate filename to avoid hitting filesystem limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 
 - fix: raise warning for disjoint keys (Closes: #313)
 - fix: clearer error on missing entrypoint (Closes: #321)
+- fix: truncate filename to avoid hitting filesystem limits (Closes: #...)
 
 ## [0.5.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.0) (Apr 23th 2026)
 

--- a/omnibenchmark/backend/snakemake.py
+++ b/omnibenchmark/backend/snakemake.py
@@ -23,10 +23,15 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, TextIO
 
+from omnibenchmark.benchmark._paths import (
+    _UNSAFE_CHARS,
+    make_human_name as _make_human_name,
+    truncate_filename,
+)
 from omnibenchmark.model.benchmark import APIVersion
 from omnibenchmark.model.resolved import ResolvedModule, ResolvedNode
 
-_UNSAFE_CHARS = ["/", "\\", ":", "*", "?", '"', "<", ">", "|", " "]
+__all__ = ["SnakemakeGenerator", "_make_human_name", "_UNSAFE_CHARS"]
 
 # Indentation constants for generated Snakemake syntax.
 # Shell block content lives at 8 spaces (2 levels × 4 spaces).
@@ -41,22 +46,6 @@ def _bash_var(name: str) -> str:
     '_data_raw'
     """
     return "_" + name.replace(".", "_").replace("-", "_")
-
-
-def _make_human_name(params) -> str:
-    """Create a human-readable symlink name from a Params object.
-
-    Joins key-value pairs with underscores and strips filesystem-unsafe
-    characters.  Falls back to appending a short hash if the result exceeds
-    255 characters (the typical filesystem limit).
-    """
-    parts = [f"{k}-{v}" for k, v in params.items()]
-    name = "_".join(parts)
-    for char in _UNSAFE_CHARS:
-        name = name.replace(char, "_")
-    if len(name) > 255:
-        name = name[:246] + "_" + params.hash_short()
-    return name
 
 
 class SnakemakeGenerator:
@@ -158,8 +147,9 @@ class SnakemakeGenerator:
             f.write(f'        "{benchmark_file}"\n')
 
         rule_name = self._sanitize_rule_name(node.id)
+        log_filename = truncate_filename(f"{rule_name}.log")
         f.write("    log:\n")
-        f.write(f'        ".logs/{rule_name}.log"\n')
+        f.write(f'        ".logs/{log_filename}"\n')
 
         self._write_environment_directive(f, node.module)
         self._write_resources_directive(f, node)

--- a/omnibenchmark/benchmark/_paths.py
+++ b/omnibenchmark/benchmark/_paths.py
@@ -1,8 +1,96 @@
 """Path construction utilities for omnibenchmark workflows."""
 
+import hashlib
 import re
-from pathlib import Path
+from pathlib import PurePosixPath, Path
 from typing import List, Dict, Set, Optional
+
+# Per-component limit on most modern filesystems (ext4, xfs, apfs, ntfs).
+MAX_FILENAME_LEN = 255
+
+# Cap on what we treat as a "compound extension" before falling back to the
+# last suffix only. Covers .tar.gz, .tar.bz2, .tar.zst, .nii.gz, etc.
+_MAX_COMPOUND_SUFFIX_LEN = 16
+_EXT_RE = re.compile(r"\.[A-Za-z0-9]+")
+
+
+def _split_extension(name: str) -> tuple[str, str]:
+    """Split *name* into (stem, suffix), preserving compound extensions.
+
+    Only treats trailing dot-segments matching ``.[A-Za-z0-9]+`` as extension,
+    and only when the joined suffix is at most ``_MAX_COMPOUND_SUFFIX_LEN``
+    characters — so ``foo.tar.gz`` -> ("foo", ".tar.gz") but a pathological
+    ``my.dotted.name.txt`` -> ("my.dotted.name", ".txt") rather than eating
+    the whole stem.
+    """
+    suffixes = PurePosixPath(name).suffixes
+    if not suffixes:
+        return name, ""
+
+    compound = "".join(suffixes)
+    if len(compound) <= _MAX_COMPOUND_SUFFIX_LEN and all(
+        _EXT_RE.fullmatch(s) for s in suffixes
+    ):
+        return name[: -len(compound)], compound
+
+    last = suffixes[-1]
+    if _EXT_RE.fullmatch(last) and len(last) <= _MAX_COMPOUND_SUFFIX_LEN:
+        return name[: -len(last)], last
+
+    return name, ""
+
+
+def truncate_filename(name: str, limit: int = MAX_FILENAME_LEN) -> str:
+    """Truncate a single filename component to fit *limit* bytes.
+
+    Preserves the file extension (including compound forms like ``.tar.gz``)
+    and appends an 8-char hash of the original stem for uniqueness, so two
+    long names that share a prefix still produce distinct truncated names.
+
+    Operates on a single path component — callers must split parent dirs off
+    before calling.
+    """
+    if len(name) <= limit:
+        return name
+
+    stem, suffix = _split_extension(name)
+    digest = hashlib.sha256(stem.encode("utf-8")).hexdigest()[:8]
+    sep = "_"
+    keep = limit - len(suffix) - len(sep) - len(digest)
+    if keep < 1:
+        # Limit too small to fit hash + suffix; degrade gracefully.
+        return (digest + suffix)[:limit]
+    return stem[:keep] + sep + digest + suffix
+
+
+_UNSAFE_CHARS = ["/", "\\", ":", "*", "?", '"', "<", ">", "|", " "]
+
+
+def make_human_name(params, limit: int = MAX_FILENAME_LEN) -> str:
+    """Create a human-readable symlink name from a Params object.
+
+    Joins key-value pairs with underscores and strips filesystem-unsafe
+    characters.  Falls back to appending the params' short hash if the result
+    exceeds *limit* (the typical filesystem per-component limit).
+    """
+    parts = [f"{k}-{v}" for k, v in params.items()]
+    name = "_".join(parts)
+    for char in _UNSAFE_CHARS:
+        name = name.replace(char, "_")
+    if len(name) > limit:
+        digest = params.hash_short()
+        keep = limit - len(digest) - 1
+        name = name[:keep] + "_" + digest
+    return name
+
+
+def truncate_path_filename(path: str, limit: int = MAX_FILENAME_LEN) -> str:
+    """Apply :func:`truncate_filename` to the leaf component of *path* only."""
+    parent, sep, basename = path.rpartition("/")
+    truncated = truncate_filename(basename, limit=limit)
+    if truncated == basename:
+        return path
+    return f"{parent}{sep}{truncated}" if sep else truncated
 
 
 def normalize_dataset_path(path: str, prefix: Path) -> str:

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -17,6 +17,7 @@ from omnibenchmark.backend._manifest import write_run_manifest
 from omnibenchmark.backend._metadata import save_metadata
 from omnibenchmark.backend.snakemake import SnakemakeGenerator
 from omnibenchmark.benchmark import BenchmarkExecution
+from omnibenchmark.benchmark._paths import truncate_path_filename
 from omnibenchmark.model.params import Params
 from omnibenchmark.cli.error_formatting import pretty_print_parse_error
 from omnibenchmark.cli.utils.logging import logger
@@ -985,6 +986,8 @@ def _generate_explicit_snakefile(
                             raise ValueError(
                                 f"Unknown nesting strategy: {nesting_strategy}"
                             )
+
+                        output_path = truncate_path_filename(output_path)
 
                         outputs.append(output_path)
                         if output_spec.id not in output_to_nodes:

--- a/tests/benchmark/test_paths_truncate.py
+++ b/tests/benchmark/test_paths_truncate.py
@@ -1,0 +1,79 @@
+"""Unit tests for filename truncation in benchmark._paths."""
+
+from omnibenchmark.benchmark._paths import (
+    MAX_FILENAME_LEN,
+    truncate_filename,
+    truncate_path_filename,
+)
+
+
+def test_short_name_unchanged():
+    assert truncate_filename("foo.txt") == "foo.txt"
+
+
+def test_truncates_long_name_preserving_simple_extension():
+    stem = "x" * 400
+    name = stem + ".txt"
+    out = truncate_filename(name)
+    assert len(out) == MAX_FILENAME_LEN
+    assert out.endswith(".txt")
+
+
+def test_preserves_compound_tar_gz():
+    stem = "dataset_" + "y" * 400
+    name = stem + ".tar.gz"
+    out = truncate_filename(name)
+    assert len(out) == MAX_FILENAME_LEN
+    assert out.endswith(".tar.gz")
+
+
+def test_preserves_nii_gz():
+    name = "scan_" + "z" * 300 + ".nii.gz"
+    out = truncate_filename(name)
+    assert len(out) == MAX_FILENAME_LEN
+    assert out.endswith(".nii.gz")
+
+
+def test_distinguishes_long_names_sharing_prefix():
+    a = "shared_prefix_" + "a" * 300 + ".txt"
+    b = "shared_prefix_" + "b" * 300 + ".txt"
+    assert truncate_filename(a) != truncate_filename(b)
+
+
+def test_dotted_stem_does_not_eat_filename():
+    # All-suffix join would be ".v1.beta.release.candidate.txt" (>16 chars), so
+    # the helper should fall back to just the trailing ".txt" extension.
+    name = "my.v1.beta.release.candidate." + "x" * 300 + ".txt"
+    out = truncate_filename(name)
+    assert out.endswith(".txt")
+    assert len(out) == MAX_FILENAME_LEN
+    # The earlier dotted segments live in the stem, not the extension.
+    assert "v1.beta" in out
+
+
+def test_no_extension_still_truncates():
+    name = "x" * 400
+    out = truncate_filename(name)
+    assert len(out) == MAX_FILENAME_LEN
+    assert "." not in out  # no extension introduced
+
+
+def test_truncate_path_filename_only_touches_basename():
+    parent = "results/stage1/module/abcd1234"
+    name = "x" * 400 + ".tar.gz"
+    out = truncate_path_filename(f"{parent}/{name}")
+    out_parent, _, out_name = out.rpartition("/")
+    assert out_parent == parent
+    assert out_name.endswith(".tar.gz")
+    assert len(out_name) == MAX_FILENAME_LEN
+
+
+def test_truncate_path_filename_short_path_unchanged():
+    p = "results/stage1/module/abcd1234/foo.txt"
+    assert truncate_path_filename(p) == p
+
+
+def test_custom_limit():
+    out = truncate_filename("a" * 50 + ".txt", limit=20)
+    assert len(out) == 20
+    assert out.endswith(".txt")


### PR DESCRIPTION
eCryptfs might impose similar limits, going with 255 chars now by default but this might be need to be configurable in the future.

