### PR TITLE
bug: clarify exclude behavior as transitive and symmetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 
 ## [0.5.2](UNRELEASED) ()
 
-- refactor: untangle subpackage import cycles into an acyclic dependency graph; add a generated `ARCHITECTURE.md` and a CI guard that fails on any new cycle
-- refactor(breaking)!: rename the `omnibenchmark.benchmark` subpackage to `omnibenchmark.core` (`BenchmarkExecution` now at `omnibenchmark.core.execution`; a `Benchmark` alias is kept)
-- docs: expose YAML spec reference in the public docs
+- refactor: untangle subpackage import cycles into an acyclic dependency graph; add a generated `ARCHITECTURE.md` and a CI guard that fails on any new cycle (Closes #340)
+- refactor(breaking)!: rename the `omnibenchmark.benchmark` subpackage to `omnibenchmark.core` (`BenchmarkExecution` now at `omnibenchmark.core.execution`; a `Benchmark` alias is kept) (#341)
+- docs: expose YAML spec reference in the public docs (#342)
+- bug: prune `exclude` transitively across non-adjacent stages (previously only the immediate predecessor was checked); run-loop and path-level exclusion unified behind a shared predicate (Closes: 337)
+- docs: clarify `exclude` semantics (module-id matched, transitive, symmetric, OR over list) (Closes: #337)
 
 ## [0.5.1](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.1) (May 8th 2026)
 
 - fix: raise warning for disjoint keys (Closes: #313)
 - fix: clearer error on missing entrypoint (Closes: #321)
-- fix: truncate filename to avoid hitting filesystem limits (Closes: #...)
+- fix: truncate filename to avoid hitting filesystem limits (#334)
 - chore(pkg): unpink snakemake dependency (#269)
 
 ## [0.5.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.0) (Apr 23th 2026)

--- a/docs/design/004-yaml-specification.md
+++ b/docs/design/004-yaml-specification.md
@@ -154,7 +154,7 @@ modules:
     repository: <object>               # Required: source location
     name: <string>                     # Optional: human-readable name
     parameters: <array>                # Optional: module parameters
-    exclude: <array>                   # Optional: exclusion list
+    exclude: <array>                   # Optional: module ids this module must not share a path with
 ```
 
 #### Required Fields
@@ -332,13 +332,28 @@ Downstream stages inherit wildcards from upstream dependencies.
 
 #### Cartesian Exclusions
 
-Modules can exclude specific combinations:
+Modules can exclude specific combinations. Each entry is a **module id**; any
+execution path containing both this module and a listed one is pruned:
 
 ```yaml
 modules:
   - id: D2
-    exclude: [M2]  # Exclude combination dataset=D2 AND method=M2
+    exclude: [M2]  # drop every path containing both D2 and M2
 ```
+
+Semantics:
+
+- **Matched by module id.** Entries are module ids, not stage ids or paths.
+  A non-matching entry (wrong level, or a typo) is silently ignored, not an error.
+- **Transitive.** The two modules need not be in adjacent stages — any path
+  carrying both is pruned, however many stages separate them.
+- **Symmetric.** `D2: exclude [M2]` and `M2: exclude [D2]` prune the same paths;
+  declare it wherever it reads most naturally.
+- **OR over the list.** `exclude: [M2, M3]` is two independent rules (drop D2+M2,
+  drop D2+M3). There is no "exclude only when both present" (AND) form. (A future
+  additive lineage gate — `provides`/`requires`, not yet implemented — is the
+  intended home for richer conditions; see
+  [PR #332](https://github.com/omnibenchmark/omnibenchmark/pull/332).)
 
 ## 4. Complete Example
 

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -383,6 +383,20 @@ stages:
    [snip]
 ```
 
+Semantics worth knowing:
+
+- **Matched by module id.** Each entry is a *module id*. Anything else (a stage
+  id, or a typo) simply never matches — it is silently ignored, not an error.
+- **Transitive.** The two modules do not need to be in adjacent stages. Any
+  execution path that contains *both* modules is pruned, however many stages
+  separate them.
+- **Symmetric.** Declaring `M1: exclude [D2]` is exactly equivalent to declaring
+  `D2: exclude [M1]` — both prune the same paths. Put it wherever it reads most
+  naturally.
+- **OR over the list.** `exclude: [D2, D3]` means "not with D2, *and* not with
+  D3" as two independent rules: a path is pruned if it contains M1 together with
+  D2 **or** with D3. There is no "exclude only when both are present" (AND) form.
+
 ## Use a custom apptainer container to run methods
 
 We recommend building apptainer containers using apptainer. Still, it is possible to use any apptainer container from an ORAS-compatible registry (could be a GitLab registry), or available locally as a SIF file.

--- a/docs/templates/benchmark_template.yaml
+++ b/docs/templates/benchmark_template.yaml
@@ -110,7 +110,8 @@ stages:
         # optional (array), Module parameters
         parameters: ...
 
-        # optional (array), Paths to exclude
+        # optional (array), module ids this module must not share a path with
+        # (symmetric, transitive, OR over the list)
         exclude: ...
 
         # optional (array), Module outputs

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -17,7 +17,11 @@ from omnibenchmark.backend._manifest import write_run_manifest
 from omnibenchmark.backend._metadata import save_metadata
 from omnibenchmark.backend.snakemake import SnakemakeGenerator
 from omnibenchmark.core import BenchmarkExecution
-from omnibenchmark.core._paths import truncate_path_filename
+from omnibenchmark.core._paths import (
+    truncate_path_filename,
+    collect_path_exclusions,
+    is_lineage_excluded,
+)
 from omnibenchmark.model.params import Params
 from omnibenchmark.cli.formatting import pretty_print_parse_error
 from omnibenchmark.logging import logger
@@ -613,6 +617,21 @@ def _satisfies_requires(requires: dict, input_node) -> bool:
     return True
 
 
+def _lineage_module_ids(input_node, nodes_by_id) -> set:
+    """Return the module_ids along input_node's full lineage, inclusive.
+
+    Walks the explicit ``parent_id`` chain rather than matching node-ID string
+    prefixes, so it is unaffected by module/stage ids that contain the id
+    separator. ``nodes_by_id`` maps node id → node.
+    """
+    lineage = set()
+    node = input_node
+    while node is not None:
+        lineage.add(node.module_id)
+        node = nodes_by_id.get(node.parent_id) if node.parent_id else None
+    return lineage
+
+
 def _generate_explicit_snakefile(
     benchmark: BenchmarkExecution,
     benchmark_yaml_path: Path,
@@ -809,9 +828,14 @@ def _generate_explicit_snakefile(
         stages_to_expand = benchmark.model.stages
 
     resolved_nodes = []
+    nodes_by_id = {}
     output_to_nodes = {}
     previous_stage_nodes = []
     dag_errors: list[tuple[str, str, str]] = []
+
+    # Lineage-wide exclusion rules, shared with execution-path pruning so the
+    # two code paths agree (see core._paths.is_lineage_excluded).
+    path_exclusions = collect_path_exclusions(benchmark.model)
 
     for stage in stages_to_expand:
         current_stage_nodes = []
@@ -873,21 +897,17 @@ def _generate_explicit_snakefile(
                     node_combinations = node_combinations[:1]
 
                 for input_node, params in node_combinations:
-                    if input_node and module.exclude:
-                        if input_node.module_id in module.exclude:
-                            logger.debug(
-                                f"      Excluding combination: {input_node.module_id} → {module_id}"
-                            )
-                            continue
-
-                    # Also check: input module may declare that it excludes this method
+                    # Exclusions are transitive over the full lineage, not just
+                    # the immediate predecessor: prune if any exclusion rule has
+                    # both endpoints present along this node's lineage.
                     if input_node:
-                        input_excludes = benchmark.model.get_module_excludes(
-                            input_node.module_id
-                        )
-                        if input_excludes and module_id in input_excludes:
+                        lineage = _lineage_module_ids(input_node, nodes_by_id) | {
+                            module_id
+                        }
+                        if is_lineage_excluded(lineage, path_exclusions):
                             logger.debug(
-                                f"      Excluding combination: {input_node.module_id} excludes {module_id}"
+                                f"      Excluding combination: lineage {lineage} "
+                                f"violates an exclusion rule"
                             )
                             continue
 
@@ -1007,6 +1027,7 @@ def _generate_explicit_snakefile(
                         param_id=param_id,
                         module=resolved_module,
                         parameters=params,
+                        parent_id=input_node.id if input_node else None,
                         inputs=inputs,
                         outputs=outputs,
                         input_name_mapping=input_name_mapping,
@@ -1018,6 +1039,7 @@ def _generate_explicit_snakefile(
                     )
 
                     resolved_nodes.append(node)
+                    nodes_by_id[node.id] = node
                     current_stage_nodes.append(node)
 
                 if not quiet:

--- a/omnibenchmark/core/_graph.py
+++ b/omnibenchmark/core/_graph.py
@@ -10,6 +10,7 @@ from omnibenchmark.dag import (
 from omnibenchmark.model import Benchmark, Stage, ValidationError
 
 from ._node import BenchmarkNode
+from ._paths import is_lineage_excluded
 
 
 def expand_stage_nodes(
@@ -126,24 +127,12 @@ def list_all_paths(graph: DiGraph, source: BenchmarkNode, target: BenchmarkNode)
     return all_paths
 
 
-def contains_all(path, modules):
-    path_modules = [node.module_id for node in path]
-    return all(module in path_modules for module in modules)
-
-
 def exclude_paths(paths, path_exclusions):
-    updated_paths = []
-    for path in paths:
-        should_exclude = False
-        for module, excluded_modules in path_exclusions.items():
-            for excluded_module in excluded_modules:
-                if contains_all(path, [module, excluded_module]):
-                    should_exclude = True
-
-        if not should_exclude:
-            updated_paths.append(path)
-
-    return updated_paths
+    return [
+        path
+        for path in paths
+        if not is_lineage_excluded({node.module_id for node in path}, path_exclusions)
+    ]
 
 
 def compute_stage_order(stage_dag: DiGraph) -> List:

--- a/omnibenchmark/core/_paths.py
+++ b/omnibenchmark/core/_paths.py
@@ -225,3 +225,23 @@ def collect_path_exclusions(model) -> Dict[str, List[str]]:
                 path_exclusions[module_id] = module_excludes
 
     return path_exclusions
+
+
+def is_lineage_excluded(
+    module_ids: Set[str], path_exclusions: Dict[str, List[str]]
+) -> bool:
+    """Whether a lineage of module IDs violates any declared exclusion.
+
+    ``module_ids`` is the full set of module IDs along a path (e.g. an execution
+    path or a candidate node's lineage). A lineage is excluded when, for any
+    module that declares exclusions, both the declaring module and one of its
+    excluded modules are present — i.e. the degenerate combination co-occurs on
+    the same path, regardless of how many stages separate them.
+
+    This is the single source of truth shared by execution-path pruning
+    (``exclude_paths``) and Snakefile generation (``cli/run.py``).
+    """
+    for module_id, excluded in path_exclusions.items():
+        if module_id in module_ids and any(e in module_ids for e in excluded):
+            return True
+    return False

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -509,7 +509,16 @@ class Module(DescribableEntity, SoftwareEnvironmentReference):
         None, description="Software environment ID"
     )
     parameters: Optional[List[Parameter]] = Field(None, description="Module parameters")
-    exclude: Optional[List[str]] = Field(None, description="Paths to exclude")
+    exclude: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Module IDs this module must not share an execution path with. "
+            "Symmetric (declaring it on either module is equivalent), transitive "
+            "(applies across non-adjacent stages), and OR over the list (a path "
+            "is pruned if it contains this module together with any listed one). "
+            "Non-module-id entries are silently ignored."
+        ),
+    )
     outputs: Optional[List[IOFile]] = Field(None, description="Module outputs")
     requires: Optional[Dict[str, str]] = Field(
         None,

--- a/tests/benchmark/test_path_exclusions.py
+++ b/tests/benchmark/test_path_exclusions.py
@@ -1,0 +1,112 @@
+"""Short unit tests for the shared lineage-exclusion predicate.
+
+``is_lineage_excluded`` is the single source of truth used by both
+execution-path pruning (``_graph.exclude_paths``) and Snakefile generation
+(``cli/run.py``); these tests pin its semantics directly.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from omnibenchmark.core._paths import is_lineage_excluded
+from omnibenchmark.core._graph import exclude_paths
+
+
+@pytest.mark.short
+class TestIsLineageExcluded:
+    def test_no_exclusions_keeps_everything(self):
+        assert is_lineage_excluded({"adamson", "prep", "additive"}, {}) is False
+
+    def test_excludes_adjacent_pair(self):
+        # Minimal case: declaring and excluded module on the same path.
+        assert (
+            is_lineage_excluded({"adamson", "additive"}, {"adamson": ["additive"]})
+            is True
+        )
+
+    def test_non_adjacent_endpoints_still_excluded(self):
+        # Declaring and excluded modules are several stages apart, with
+        # intervening modules — the exact case the immediate-predecessor
+        # check missed.
+        assert (
+            is_lineage_excluded(
+                {"adamson", "prep", "sim", "additive"}, {"adamson": ["additive"]}
+            )
+            is True
+        )
+
+    def test_excluded_module_absent_keeps_lineage(self):
+        assert (
+            is_lineage_excluded(
+                {"adamson", "prep", "double"}, {"adamson": ["additive"]}
+            )
+            is False
+        )
+
+    def test_declaring_module_absent_keeps_lineage(self):
+        # additive only appears with a different dataset that has no exclusions.
+        assert (
+            is_lineage_excluded(
+                {"norman", "prep", "additive"}, {"adamson": ["additive"]}
+            )
+            is False
+        )
+
+    def test_symmetric_declaration(self):
+        # Declaring the rule on either endpoint prunes the identical lineage:
+        # the predicate is pure set co-occurrence, direction-agnostic.
+        lineage = {"adamson", "prep", "additive"}
+        forward = is_lineage_excluded(lineage, {"adamson": ["additive"]})
+        reverse = is_lineage_excluded(lineage, {"additive": ["adamson"]})
+        assert forward is reverse is True
+
+    def test_unknown_id_in_list_is_a_noop(self):
+        # A stage id or a typo is just a module id that never matches.
+        assert (
+            is_lineage_excluded(
+                {"adamson", "prep", "additive"}, {"adamson": ["methods"]}
+            )
+            is False
+        )
+
+    def test_multi_exclude_is_or_not_and(self):
+        # `adamson: [additive, multiplicative]` is two independent rules:
+        # co-occurrence with *either* prunes; neither must be present together.
+        rule = {"adamson": ["additive", "multiplicative"]}
+        assert is_lineage_excluded({"adamson", "additive"}, rule) is True
+        assert is_lineage_excluded({"adamson", "multiplicative"}, rule) is True
+        assert (
+            is_lineage_excluded({"adamson", "additive", "multiplicative"}, rule) is True
+        )
+        # Neither excluded module present → kept.
+        assert is_lineage_excluded({"adamson", "double"}, rule) is False
+
+    def test_multiple_rules_any_match_excludes(self):
+        # Rules from different declaring modules are independent (OR across rules).
+        rules = {"adamson": ["additive"], "norman": ["double"]}
+        assert is_lineage_excluded({"norman", "double"}, rules) is True
+        assert is_lineage_excluded({"adamson", "double"}, rules) is False
+
+
+def _path(*module_ids):
+    return [MagicMock(module_id=m) for m in module_ids]
+
+
+@pytest.mark.short
+class TestExcludePaths:
+    def test_prunes_violating_path_across_stages(self):
+        keep = _path("norman", "prep", "additive")
+        drop = _path("adamson", "prep", "sim", "additive")
+        result = exclude_paths([keep, drop], {"adamson": ["additive"]})
+        assert result == [keep]
+
+    def test_no_exclusions_returns_all(self):
+        paths = [_path("adamson", "additive"), _path("norman", "double")]
+        assert exclude_paths(paths, {}) == paths
+
+    def test_symmetric_declaration_prunes_same_paths(self):
+        keep = _path("norman", "prep", "additive")
+        drop = _path("adamson", "prep", "sim", "additive")
+        forward = exclude_paths([keep, drop], {"adamson": ["additive"]})
+        reverse = exclude_paths([keep, drop], {"additive": ["adamson"]})
+        assert forward == reverse == [keep]

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -15,6 +15,7 @@ from omnibenchmark.cli.run import (
     _build_template_context,
     _select_input_nodes,
     _satisfies_requires,
+    _lineage_module_ids,
     run,
 )
 from omnibenchmark.core.prefetch import populate_git_cache
@@ -305,6 +306,74 @@ class TestSatisfiesRequires:
             _satisfies_requires({"dataset": "pbmc3k", "treatment": "stim"}, node)
             is False
         )
+
+
+# ---------------------------------------------------------------------------
+# _lineage_module_ids
+# ---------------------------------------------------------------------------
+
+
+def _make_lineage_node(module_id, parent_id=None, node_id=None):
+    n = MagicMock()
+    n.id = node_id if node_id is not None else module_id
+    n.module_id = module_id
+    n.parent_id = parent_id
+    return n
+
+
+def _by_id(*nodes):
+    return {n.id: n for n in nodes}
+
+
+@pytest.mark.short
+class TestLineageModuleIds:
+    def test_root_node_lineage_is_self(self):
+        root = _make_lineage_node("adamson")
+        assert _lineage_module_ids(root, _by_id(root)) == {"adamson"}
+
+    def test_immediate_predecessor_in_lineage(self):
+        root = _make_lineage_node("adamson")
+        child = _make_lineage_node("prep", parent_id=root.id)
+        assert _lineage_module_ids(child, _by_id(root, child)) == {"adamson", "prep"}
+
+    def test_transitive_lineage_across_non_adjacent_stages(self):
+        """Regression: a download module several stages upstream must appear in
+        the lineage of a leaf node, not just the immediate predecessor."""
+        download = _make_lineage_node("adamson")
+        preprocess = _make_lineage_node("prep", parent_id=download.id)
+        split = _make_lineage_node("sim", parent_id=preprocess.id)
+        # split is the immediate predecessor of a `methods` node; its lineage
+        # must still include the non-adjacent `adamson` download module.
+        assert _lineage_module_ids(split, _by_id(download, preprocess, split)) == {
+            "adamson",
+            "prep",
+            "sim",
+        }
+
+    def test_unrelated_branch_excluded_from_lineage(self):
+        download = _make_lineage_node("adamson")
+        other = _make_lineage_node("norman")  # sibling root, not an ancestor
+        child = _make_lineage_node("prep", parent_id=download.id)
+        assert _lineage_module_ids(child, _by_id(download, other, child)) == {
+            "adamson",
+            "prep",
+        }
+
+    def test_dashed_module_ids_resolve_via_parent_links(self):
+        """Lineage follows explicit parent_id links, so module ids containing the
+        id separator ('-') cannot confuse ancestry (the old prefix-match risk)."""
+        download = _make_lineage_node(
+            "adamson-v2", node_id="download-adamson-v2.default"
+        )
+        method = _make_lineage_node(
+            "my-method",
+            parent_id=download.id,
+            node_id="download-adamson-v2.default-methods-my-method.default",
+        )
+        assert _lineage_module_ids(method, _by_id(download, method)) == {
+            "adamson-v2",
+            "my-method",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/configs/09_transitive_exclude.yaml
+++ b/tests/e2e/configs/09_transitive_exclude.yaml
@@ -1,0 +1,109 @@
+id: TransitiveExcludeBenchmark
+description: >-
+  A dataset module excludes a method module across an intervening
+  preprocessing stage. The exclusion must prune the degenerate
+  combination transitively, not only when the two modules are adjacent.
+version: "1.0"
+benchmarker: "E2E Test Suite"
+api_version: "0.5.0"
+software_backend: host
+
+software_environments:
+  host:
+    description: "Host environment for direct execution"
+
+stages:
+  - id: data
+    modules:
+      - id: D1
+        name: "Dataset 1"
+        software_environment: "host"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - values: ["--evaluate", "1+1"]
+
+      - id: D2
+        name: "Dataset 2 - excludes method M2 (degenerate combination)"
+        software_environment: "host"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - values: ["--evaluate", "2+2"]
+        exclude: ["M2"]
+    outputs:
+      - id: data.raw
+        path: "{dataset}_data.json"
+
+  - id: preprocessing
+    modules:
+      - id: P1
+        name: "Preprocessing - Add 1"
+        software_environment: "host"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - values:
+              ["--evaluate", "input+1", "--input", "data.raw", "--kind", "preprocessed"]
+    inputs:
+      - data.raw
+    outputs:
+      - id: preprocessing.processed
+        path: "{dataset}_preprocessed.json"
+
+  - id: methods
+    modules:
+      - id: M1
+        name: "Method 1 - Add 10"
+        software_environment: "host"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - values:
+              [
+                "--evaluate",
+                "input+10",
+                "--input",
+                "preprocessing.processed",
+                "--kind",
+                "method",
+              ]
+
+      - id: M2
+        name: "Method 2 - Multiply by 5 (excluded by D2)"
+        software_environment: "host"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - values:
+              [
+                "--evaluate",
+                "input*5",
+                "--input",
+                "preprocessing.processed",
+                "--kind",
+                "method",
+              ]
+    inputs:
+      - preprocessing.processed
+    outputs:
+      - id: methods.result
+        path: "{dataset}_method.json"
+
+metric_collectors:
+  - id: MC1
+    name: "Gather and calculate metrics from method results"
+    software_environment: "host"
+    repository:
+      url: bundles/dummycollector_9e3a99a.bundle
+      commit: 9e3a99a
+    inputs:
+      - methods.result
+    outputs:
+      - id: metrics.summary
+        path: "metrics/metrics.json"

--- a/tests/e2e/test_09_transitive_exclude.py
+++ b/tests/e2e/test_09_transitive_exclude.py
@@ -1,0 +1,48 @@
+import re
+import pytest
+from pathlib import Path
+
+from tests.e2e.common import E2ETestRunner
+
+
+@pytest.fixture
+def transitive_exclude_config():
+    """Path to the transitive (cross-stage) exclude config."""
+    return Path(__file__).parent / "configs" / "09_transitive_exclude.yaml"
+
+
+@pytest.mark.e2e
+def test_transitive_exclude_prunes_across_stages(
+    transitive_exclude_config, tmp_path, bundled_repos, keep_files
+):
+    """A dataset excluding a method must prune the combination even when the
+    two modules are separated by an intervening stage.
+
+    Topology: data -> preprocessing -> methods. ``D2`` declares ``exclude: [M2]``.
+    Because M2 is not D2's immediate downstream neighbour, the pre-fix run loop
+    (which only compared the direct predecessor) failed to prune it and emitted
+    the degenerate D2 -> preprocessing -> M2 rule into the Snakefile.
+
+    We assert on the generated Snakefile (``--dry``), mirroring the original
+    bug repro, so the check is independent of module execution.
+    """
+    runner = E2ETestRunner(tmp_path, keep_files)
+    config_file = runner.setup_test_environment(
+        transitive_exclude_config, "09_transitive_exclude.yaml"
+    )
+
+    runner.execute_cli_command(config_file, ["--dry"])
+
+    snakefile = (runner.out_dir / "Snakefile").read_text()
+
+    # Every D2 path that reaches a method must route through M1, never M2.
+    d2_method_paths = re.findall(r"\bdata/D2\S*methods/M\d", snakefile)
+    assert d2_method_paths, "expected at least one D2->methods path in the Snakefile"
+    assert all(
+        p.endswith("methods/M1") for p in d2_method_paths
+    ), f"D2->M2 should be excluded across the preprocessing stage, got: {d2_method_paths}"
+
+    # Sanity: the legitimate D1->M2 combination is still generated.
+    assert re.search(
+        r"\bdata/D1\S*methods/M2", snakefile
+    ), "D1->M2 should still be present"


### PR DESCRIPTION
## Ticket

#337

## Description

excludes were ignored (as of 0.5.1) in non-adjacent stages.
This PR clarifies documentation, adds new regression tests, and applies a fix 
making the run-loop check transitive over the full lineage, unified with exclude_paths behind a shared `is_lineage_excluded` predicate.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

