### PR TITLE
feat: add performance collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 
 ## [0.5.2](UNRELEASED) ()
 
-- refactor: untangle subpackage import cycles into an acyclic dependency graph; add a generated `ARCHITECTURE.md` and a CI guard that fails on any new cycle (Closes #340)
-- refactor(breaking)!: rename the `omnibenchmark.benchmark` subpackage to `omnibenchmark.core` (`BenchmarkExecution` now at `omnibenchmark.core.execution`; a `Benchmark` alias is kept) (#341)
+- refactor: untangle subpackage import cycles into an acyclic dependency graph (Closes #340)
+- refactor(breaking)!: rename the `omnibenchmark.benchmark` subpackage to `omnibenchmark.core` (#341)
 - docs: expose YAML spec reference in the public docs (#342)
 - bug: prune `exclude` transitively across non-adjacent stages (previously only the immediate predecessor was checked); run-loop and path-level exclusion unified behind a shared predicate (Closes: 337)
 - docs: clarify `exclude` semantics (module-id matched, transitive, symmetric, OR over list) (Closes: #337)
+- feat: add `ob collect performance` to gather scattered `performance.txt` files into a combined `performances.tsv`, enriched with stage, module, parameters and lineage; restores the input expected by `ob dashboard`
 
 ## [0.5.1](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.1) (May 8th 2026)
 

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -438,6 +438,37 @@ stages:
 ```
 
 
+## Collect performance metrics
+
+Every executed node writes a Snakemake benchmark file (`performance.txt`) next to its outputs, recording wall-clock time, memory, I/O and CPU usage. These files are scattered across the output tree, one per `stage/module/parameter` combination.
+
+To gather them into a single table, run:
+
+```bash
+ob collect performance -o out
+```
+
+This walks the output directory, parses every `performance.txt`, and writes a combined `out/performances.tsv`. Each row carries the performance metrics plus metadata reconstructed from the output path:
+
+- `stage`, `module`, `dataset` — where the measurement comes from
+- `param_hash` — the parameter-set identifier (empty for default/unparametrized nodes)
+- `params` — the parameters used, merged across the lineage (read from the `parameters.json` files along the path)
+- `lineage` — the full `stage/module` chain that produced the result
+- `path` — the original performance file, relative to the output directory
+
+Collection is a plain filesystem walk: it does not run Snakemake and can be invoked against any existing output directory, including ones produced by earlier runs.
+
+### Build a dashboard from the metrics
+
+Once `performances.tsv` exists, you can render an interactive [bettr](https://github.com/federicomarini/bettr) dashboard:
+
+```bash
+ob dashboard benchmark.yaml -o out
+```
+
+This reads `out/performances.tsv` and writes `out/bettr_dashboard.json`. If the table is missing, run `ob collect performance` first.
+
+
 ## Use local module repositories
 
 Local Git repositories can be referenced directly in the `url` field of benchmarking YAML manifestos, without the need to push to GitHub, GitLab, Bitbucket, or any other remote. To ensure changes are tracked, remember to stage them with `git add` and commit them with `git commit` in the local repository. It is recommended to specify full paths (beginning with `/`) to the local Git repository (i.e. `/home/user/repos/data` in the example below).

--- a/omnibenchmark/cli/collect.py
+++ b/omnibenchmark/cli/collect.py
@@ -1,0 +1,199 @@
+"""CLI commands for collecting metrics from a benchmark output folder.
+
+The ``collect`` group gathers post-hoc artefacts that are scattered across the
+output tree into a single combined table. Right now it knows how to gather the
+Snakemake ``performance.txt`` benchmark files emitted for every executed node;
+the resulting ``performances.tsv`` is what ``ob dashboard`` consumes.
+
+Collection is a pure filesystem walk -- it does not invoke Snakemake and can be
+run against any existing output directory.
+"""
+
+import csv
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import click
+
+from omnibenchmark.cli.utils.logging import logger
+from .debug import add_debug_option
+
+# Directories that never contain benchmark performance files but are expensive
+# (and noisy) to walk: vendored module checkouts, Snakemake bookkeeping, conda
+# envs, logs, metadata and the archived `old` runs.
+_SKIP_DIRS = {".modules", ".snakemake", ".envs", ".logs", ".metadata", "old"}
+
+# A node's benchmark file is `performance.txt` (>= v0.5.0) or, in older layouts,
+# `{dataset}_performance.txt`. Match both so the collector works across versions.
+_PERF_SUFFIX = "_performance.txt"
+_PERF_NAME = "performance.txt"
+
+# Column emitted by Snakemake that is redundant with `s` and not numeric.
+_DROP_COLS = {"h:m:s"}
+
+
+def _is_performance_file(name: str) -> bool:
+    return name == _PERF_NAME or name.endswith(_PERF_SUFFIX)
+
+
+def _find_performance_files(out_dir: Path) -> List[Path]:
+    """Walk ``out_dir`` and return every performance file, skipping noise dirs."""
+    found: List[Path] = []
+    for root, dirs, files in os.walk(out_dir):
+        # Prune skip dirs in place so os.walk does not descend into them.
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS]
+        for name in files:
+            if _is_performance_file(name):
+                found.append(Path(root) / name)
+    return sorted(found)
+
+
+def _read_performance_row(file_path: Path) -> Optional[Dict[str, Any]]:
+    """Read the single data row of a Snakemake benchmark TSV, coercing numbers."""
+    with open(file_path, newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        for raw in reader:
+            row: Dict[str, Any] = {}
+            for key, value in raw.items():
+                if key in _DROP_COLS:
+                    continue
+                if value is None or value in ("", "NA", "none", "null", "nan"):
+                    row[key] = 0
+                else:
+                    try:
+                        row[key] = float(value)
+                    except (ValueError, TypeError):
+                        row[key] = value
+            return row  # benchmark files hold exactly one data row
+    return None
+
+
+def _triples(rel_parts: List[str]) -> List[tuple]:
+    """Group path components into (stage, module, param_dir) triples.
+
+    The output layout is a chain of ``stage/module/<param-dir>`` directories,
+    where ``<param-dir>`` is ``.default`` (or ``default`` in old layouts) for
+    parameter-free nodes and ``.<hash>`` otherwise.
+    """
+    return list(zip(*(iter(rel_parts),) * 3))
+
+
+def _is_default_param_dir(param_dir: str) -> bool:
+    return param_dir.lstrip(".") == "default"
+
+
+def _collect_params(out_dir: Path, triples: List[tuple]) -> Dict[str, Any]:
+    """Read every ``parameters.json`` along the lineage into ``{stage: params}``."""
+    params: Dict[str, Any] = {}
+    cursor = out_dir
+    for stage, module, param_dir in triples:
+        cursor = cursor / stage / module / param_dir
+        if _is_default_param_dir(param_dir):
+            continue
+        param_file = cursor / "parameters.json"
+        if param_file.exists():
+            try:
+                params[stage] = json.loads(param_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                logger.warning(f"Could not parse parameters at {param_file}")
+    return params
+
+
+def _build_record(out_dir: Path, perf_file: Path) -> Optional[Dict[str, Any]]:
+    """Turn one performance file into an enriched row, or None if unreadable."""
+    row = _read_performance_row(perf_file)
+    if row is None:
+        logger.warning(f"No performance data in {perf_file}; skipping.")
+        return None
+
+    rel_parts = perf_file.relative_to(out_dir).parts[:-1]  # drop filename
+    triples = _triples(list(rel_parts))
+    if not triples:
+        logger.warning(f"Unexpected path layout for {perf_file}; skipping.")
+        return None
+
+    leaf_stage, leaf_module, leaf_param_dir = triples[-1]
+    params = _collect_params(out_dir, triples)
+
+    # Metadata columns; names match what `ob dashboard` excludes from metrics.
+    row["stage"] = leaf_stage
+    row["module"] = leaf_module
+    row["dataset"] = triples[0][1]
+    row["param_hash"] = (
+        "" if _is_default_param_dir(leaf_param_dir) else leaf_param_dir.lstrip(".")
+    )
+    row["params"] = json.dumps(params) if params else ""
+    row["lineage"] = "/".join(f"{s}/{m}" for s, m, _ in triples)
+    row["path"] = str(perf_file.relative_to(out_dir))
+    return row
+
+
+def _write_tsv(output_file: Path, rows: List[Dict[str, Any]]) -> None:
+    # Stable column order: metrics first (from the first row), metadata appended
+    # in a fixed order so the file is diff-friendly across runs.
+    meta_cols = [
+        "stage",
+        "module",
+        "dataset",
+        "param_hash",
+        "params",
+        "lineage",
+        "path",
+    ]
+    metric_cols = [c for c in rows[0].keys() if c not in meta_cols]
+    fieldnames = metric_cols + meta_cols
+    with open(output_file, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+@click.group(name="collect")
+def collect():
+    """Gather scattered benchmark artefacts into combined tables."""
+
+
+@add_debug_option
+@collect.command(name="performance")
+@click.option(
+    "--out-dir",
+    "-o",
+    type=click.Path(),
+    default="out",
+    help="Output directory containing benchmark results (default: out).",
+)
+@click.pass_context
+def performance(ctx, out_dir):
+    """Gather all performance.txt files into a combined performances.tsv.
+
+    Walks the output directory, parses every Snakemake benchmark file, and
+    enriches each row with its stage, module, parameters and lineage. The
+    resulting out/performances.tsv is consumed by `ob dashboard`.
+    """
+    out_path = Path(out_dir)
+    if not out_path.exists():
+        logger.error(f"Output directory does not exist: {out_dir}")
+        sys.exit(1)
+
+    perf_files = _find_performance_files(out_path)
+    if not perf_files:
+        logger.error(f"No performance files found under {out_dir}.")
+        sys.exit(1)
+
+    rows: List[Dict[str, Any]] = []
+    for perf_file in perf_files:
+        record = _build_record(out_path, perf_file)
+        if record is not None:
+            rows.append(record)
+
+    if not rows:
+        logger.error("No readable performance data collected.")
+        sys.exit(1)
+
+    output_file = out_path / "performances.tsv"
+    _write_tsv(output_file, rows)
+    logger.info(f"Collected {len(rows)} performance records to {output_file}.")
+    sys.exit(0)

--- a/omnibenchmark/cli/collect.py
+++ b/omnibenchmark/cli/collect.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional
 
 import click
 
-from omnibenchmark.cli.utils.logging import logger
+from omnibenchmark.logging import logger
 from .debug import add_debug_option
 
 # Directories that never contain benchmark performance files but are expensive

--- a/omnibenchmark/cli/main.py
+++ b/omnibenchmark/cli/main.py
@@ -5,6 +5,7 @@ import click
 from omnibenchmark import __version__
 from omnibenchmark.cli.archive import archive
 from omnibenchmark.cli.cite import cite
+from omnibenchmark.cli.collect import collect
 from omnibenchmark.cli.create import create
 from omnibenchmark.cli.dashboard import dashboard
 from omnibenchmark.cli.describe import describe
@@ -69,6 +70,7 @@ def cli(ctx):
 
 # Add subcommands to the CLI
 cli.add_command(add_debug_option(cite))
+cli.add_command(collect)
 cli.add_command(add_debug_option(create))
 cli.add_command(add_debug_option(describe))
 cli.add_command(add_debug_option(remote))

--- a/pixi.lock
+++ b/pixi.lock
@@ -116,7 +116,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.409-py312h5253ce2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.410-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -321,7 +321,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.409-py312hba6025d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.410-py312hba6025d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -523,7 +523,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.409-py312hb3ab3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.410-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -778,7 +778,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pypandoc-1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.409-py312h5253ce2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.410-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -1013,7 +1013,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pypandoc-1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.409-py312hba6025d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.410-py312hba6025d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -1245,7 +1245,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pypandoc-1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.409-py312hb3ab3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.410-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -5408,6 +5408,43 @@ packages:
   - pytest-timeout==2.3.1 ; extra == 'test'
   - s3fs>=2023.12.0 ; extra == 'test'
   requires_python: '>=3.12.0,<3.14'
+- pypi: ./
+  name: omnibenchmark
+  version: 0.5.1.post19+g17ac31d11
+  sha256: 21e98eba232e17f13627092765fd7e195fdc7220d87df00874967abae799246d
+  requires_dist:
+  - click>=8.1.7
+  - python-dateutil>=2.9.0.post0
+  - filelock>=3.4.0
+  - spdx-license-list>=3.19
+  - pyyaml
+  - humanfriendly
+  - pydantic
+  - python-dotenv>=1.0.0
+  - dulwich>=0.22.0
+  - pathspec>=0.12.0
+  - rich>=13.0.0
+  - snakemake>=9.0
+  - copier>=9.0.0
+  - pydot>=3.0.2
+  - tqdm>=4.66.4
+  - boto3>=1.34.102 ; extra == 's3'
+  - snakemake-storage-plugin-s3>=0.2.12 ; extra == 's3'
+  - snakemake-executor-plugin-slurm>=1.4.0,<2.0.0 ; extra == 'slurm'
+  - pandas ; extra == 'slurm'
+  - ipython ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - isort ; extra == 'dev'
+  - pyright ; extra == 'dev'
+  - pytest-cov>=4.1.0 ; extra == 'test'
+  - pytest-split>=0.9.0 ; extra == 'test'
+  - pytest-xdist>=3.6.1 ; extra == 'test'
+  - testcontainers>=4.5.1 ; extra == 'test'
+  - pytest-timeout==2.3.1 ; extra == 'test'
+  - s3fs>=2023.12.0 ; extra == 'test'
+  requires_python: '>=3.12.0,<3.14'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-hb9d3cd8_0.conda
   sha256: bbff8a60f70d5ebab138b564554f28258472e1e63178614562d4feee29d10da2
   md5: 6ce853cb231f18576d2db5c2d4cb473e
@@ -6048,9 +6085,9 @@ packages:
   version: 1.2.0
   sha256: 9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
   requires_python: '>=3.7'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.409-py312h5253ce2_0.conda
-  sha256: 6b3720b7118f5dbe90645565823a6d238e15d4832cd81a0c78640a20f78cdc36
-  md5: 008f0a166ebe2837d724c29cb96458d4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.410-py312h5253ce2_0.conda
+  sha256: 5122f6e11656d0c32972a5b59b9533d117820d6fd57afd014f9e768818f76ee8
+  md5: 1ecfa7459025353f0727e0d36a2137a9
   depends:
   - nodeenv >=1.6.0
   - nodejs
@@ -6062,12 +6099,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyright?source=hash-mapping
-  size: 4129119
-  timestamp: 1776947291301
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.409-py312hba6025d_0.conda
-  sha256: 9b609d7464186ae297cb5de8bfc24423a1c2bca752e646c263da8160de84fd99
-  md5: 3375e4ff2abd2336b28b6eac20ecd048
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3804681
+  timestamp: 1780370991525
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.410-py312hba6025d_0.conda
+  sha256: 8ddb003b827a1e93d34bab3334fa40048a96e092d75d9e7f05d1560df7c9187d
+  md5: d38d2b108a4ea45a082230eeea7263d9
   depends:
   - nodeenv >=1.6.0
   - nodejs
@@ -6079,25 +6116,25 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyright?source=hash-mapping
-  size: 4129642
-  timestamp: 1776947625732
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.409-py312hb3ab3e3_0.conda
-  sha256: 376608791d5d3f0b2cd58fbbe628e646ef96582496b5dae3984038299b377630
-  md5: 8514d375b178e08ab24e58a96fa071d7
+  size: 3805478
+  timestamp: 1780371178490
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.410-py312hb3ab3e3_0.conda
+  sha256: d7152c285bb157c87d763929b0e044a813ad29f734ef97fef78b58cfd76acb5b
+  md5: f86ea27be8c88712016cee44be4572b6
   depends:
   - nodeenv >=1.6.0
   - nodejs
   - python
   - typing_extensions >=4.1
+  - __osx >=11.0
   - python 3.12.* *_cpython
-  - __osx >=11.0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyright?source=hash-mapping
-  size: 4133160
-  timestamp: 1776947494834
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3809119
+  timestamp: 1780371154762
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,7 +22,7 @@ pytest-cov = ">=4.1.0"
 pytest-timeout = "==2.3.1"
 
 # Type checking and linting
-pyright = ">=1.1.409,<2"
+pyright = ">=1.1.410,<2"
 ruff = "*"
 
 # Core dependencies for the package

--- a/tests/cli/test_collect.py
+++ b/tests/cli/test_collect.py
@@ -1,0 +1,120 @@
+"""Tests for the `collect performance` CLI command and its helpers."""
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from omnibenchmark.cli.collect import (
+    _build_record,
+    _find_performance_files,
+    _read_performance_row,
+    _triples,
+)
+
+_PERF_HEADER = (
+    "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time\n"
+)
+_PERF_ROW = "290.07\t0:04:50\t8031.62\t13551.20\t7742.45\t7812.24\t87.38\t3399.00\t84.93\t247.24\n"
+
+
+def _write_perf(path: Path, name: str = "performance.txt") -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    perf = path / name
+    perf.write_text(_PERF_HEADER + _PERF_ROW)
+    return perf
+
+
+@pytest.mark.short
+def test_read_performance_row_drops_hms_and_coerces():
+    """The h:m:s column is dropped and numbers are coerced to float."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(_PERF_HEADER + _PERF_ROW)
+        tmp = Path(f.name)
+    try:
+        row = _read_performance_row(tmp)
+        assert "h:m:s" not in row
+        assert row["s"] == 290.07
+        assert row["max_rss"] == 8031.62
+    finally:
+        tmp.unlink()
+
+
+@pytest.mark.short
+def test_triples_groups_path_components():
+    parts = ["download", "norman", ".68ee97fd", "split", "simulation", ".a4bbadc1"]
+    assert _triples(parts) == [
+        ("download", "norman", ".68ee97fd"),
+        ("split", "simulation", ".a4bbadc1"),
+    ]
+
+
+@pytest.mark.short
+def test_find_performance_files_matches_both_names_and_skips_noise(tmp_path):
+    """Bare and dataset-prefixed performance files are found; noise dirs pruned."""
+    _write_perf(tmp_path / "download" / "norman" / ".abc", "performance.txt")
+    _write_perf(tmp_path / "download" / "old_ds" / ".def", "old_ds_performance.txt")
+    # Noise that must be skipped.
+    _write_perf(tmp_path / ".modules" / "vendor" / "x", "performance.txt")
+    _write_perf(tmp_path / ".snakemake" / "y" / "z", "performance.txt")
+
+    found = _find_performance_files(tmp_path)
+    rels = {str(p.relative_to(tmp_path)) for p in found}
+    assert rels == {
+        "download/norman/.abc/performance.txt",
+        "download/old_ds/.def/old_ds_performance.txt",
+    }
+
+
+@pytest.mark.short
+def test_build_record_enriches_with_lineage_and_merged_params(tmp_path):
+    """A record carries stage/module/dataset plus params merged along lineage."""
+    download = tmp_path / "download" / "norman" / ".68ee97fd"
+    download.mkdir(parents=True)
+    (download / "parameters.json").write_text(json.dumps({"uri": "http://x"}))
+
+    split = download / "split" / "simulation" / ".a4bbadc1"
+    split.mkdir(parents=True)
+    (split / "parameters.json").write_text(json.dumps({"seed": 1}))
+
+    leaf = split / "methods" / "additive" / ".default"
+    perf = _write_perf(leaf)
+
+    record = _build_record(tmp_path, perf)
+
+    assert record["stage"] == "methods"
+    assert record["module"] == "additive"
+    assert record["dataset"] == "norman"
+    assert record["param_hash"] == ""  # leaf is .default
+    assert record["lineage"] == "download/norman/split/simulation/methods/additive"
+    assert record["path"] == str(perf.relative_to(tmp_path))
+    # Params from every non-default dir along the path are merged, keyed by stage.
+    params = json.loads(record["params"])
+    assert params == {"download": {"uri": "http://x"}, "split": {"seed": 1}}
+    # Metric survived enrichment.
+    assert record["s"] == 290.07
+
+
+@pytest.mark.short
+def test_collect_performance_end_to_end(tmp_path):
+    """The command writes a combined performances.tsv consumable by dashboard."""
+    from click.testing import CliRunner
+
+    from omnibenchmark.cli.collect import collect
+
+    _write_perf(tmp_path / "download" / "norman" / ".abc")
+    _write_perf(tmp_path / "download" / "adamson" / ".def")
+
+    result = CliRunner().invoke(collect, ["performance", "-o", str(tmp_path)])
+    assert result.exit_code == 0
+
+    out = tmp_path / "performances.tsv"
+    assert out.exists()
+    with open(out, newline="") as fh:
+        rows = list(csv.DictReader(fh, delimiter="\t"))
+    assert len(rows) == 2
+    assert {r["module"] for r in rows} == {"norman", "adamson"}
+    assert all(r["stage"] == "download" for r in rows)


### PR DESCRIPTION
After the 0.5 refactor and the move away from scripts, the previous script that collected the performances.tsv file was not used anymore. This effectively invalidated the easy usage of the bettr dashboard.

This commit brings back the collector capability.

## Description

Provide a small description of Pull Request.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.
