### PR TITLE
feat: filtering lineage (provides/requires)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - feat: capability filters by --with-capability (#360)
 - feat: emit threads per rule according if the module requests a number of cores
 - feat: `ob run benchmark --until STAGE` truncates the DAG to that stage and its transitive ancestors (#361)
-- feat: lineage gating — `provides:` labels a lineage, `requires:` runs a module only on matching lineages (api 0.6.0, #354)
+- feat: lineage gating — `provides:` labels a lineage, `requires:` runs a module only on matching lineages (api 0.7.0, #354)
 - feat: reject gates that can never fire at parse time (#354)
 - fix: compare `api_version` by components, not lexicographically (#354)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - feat: `ob run benchmark --until STAGE` truncates the DAG to that stage and its transitive ancestors (#361)
 - feat: lineage gating — `provides:` labels a lineage, `requires:` runs a module only on matching lineages (api 0.6.0, #354)
 - feat: reject gates that can never fire at parse time (#354)
-- fix: empty stage warning names the actual cause: filters or unmatched inputs (#354)
 - fix: compare `api_version` by components, not lexicographically (#354)
 
 ## [0.6.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.6.0) (Jul 21st 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - feat: capability filters by --with-capability (#360)
 - feat: emit threads per rule according if the module requests a number of cores
 - feat: `ob run benchmark --until STAGE` truncates the DAG to that stage and its transitive ancestors (#361)
-- feat: lineage gating — a stage declares labels via `provides:`, its modules bind values to them via `provides: {label: value}`, and a downstream module runs only on lineages matching its `requires: {label: value}`; labels propagate to every descendant node and are usable in path templates. Requires `api_version: "0.6.0"` (#354)
-- feat: gates that could never fire are rejected at parse time instead of silently pruning — a `provides` key its stage does not declare, and a `requires:` on a module in a stage with no `inputs:` (#354)
-- fix: a stage that expands to zero nodes now says whether a filter rejected every combination or none was generated at all, instead of always blaming `requires`/`exclude` (#354)
-- fix: `api_version` values compare by parsed components, so a future `0.10.0` orders after `0.6.0` instead of before it (#354)
+- feat: lineage gating — `provides:` labels a lineage, `requires:` runs a module only on matching lineages (api 0.6.0, #354)
+- feat: reject gates that can never fire at parse time (#354)
+- fix: empty stage warning names the actual cause: filters or unmatched inputs (#354)
+- fix: compare `api_version` by components, not lexicographically (#354)
 
 ## [0.6.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.6.0) (Jul 21st 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - feat: capability filters by --with-capability (#360)
 - feat: emit threads per rule according if the module requests a number of cores
 - feat: `ob run benchmark --until STAGE` truncates the DAG to that stage and its transitive ancestors (#361)
+- feat: lineage gating — a stage declares labels via `provides:`, its modules bind values to them via `provides: {label: value}`, and a downstream module runs only on lineages matching its `requires: {label: value}`; labels propagate to every descendant node and are usable in path templates. Requires `api_version: "0.6.0"` (#354)
+- feat: gates that could never fire are rejected at parse time instead of silently pruning — a `provides` key its stage does not declare, and a `requires:` on a module in a stage with no `inputs:` (#354)
+- fix: a stage that expands to zero nodes now says whether a filter rejected every combination or none was generated at all, instead of always blaming `requires`/`exclude` (#354)
+- fix: `api_version` values compare by parsed components, so a future `0.10.0` orders after `0.6.0` instead of before it (#354)
 
 ## [0.6.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.6.0) (Jul 21st 2026)
 

--- a/docs/design/004-yaml-specification.md
+++ b/docs/design/004-yaml-specification.md
@@ -135,7 +135,13 @@ stages:
     modules: <array>                   # Required: module list (≥1)
     inputs: <array>                    # Optional: input dependencies
     outputs: <array>                   # Optional: output declarations
+    provides: <array>                  # Optional: lineage labels (api 0.6+)
 ```
+
+`provides:` is a list of label names this stage advertises to downstream
+modules; downstream modules gate on these labels via `requires:`. The
+builtin labels `name` and `dataset` are reserved. See
+[008-filtering.md §3.5](./008-filtering.md) for details.
 
 #### Stage Ordering
 
@@ -155,6 +161,8 @@ modules:
     name: <string>                     # Optional: human-readable name
     parameters: <array>                # Optional: module parameters
     exclude: <array>                   # Optional: module ids this module must not share a path with
+    requires: <object>                 # Optional: lineage gate, label → value (api 0.6+)
+    provides: <object>                 # Optional: label → value bindings for this module (api 0.6+)
 ```
 
 #### Required Fields

--- a/docs/design/004-yaml-specification.md
+++ b/docs/design/004-yaml-specification.md
@@ -135,7 +135,7 @@ stages:
     modules: <array>                   # Required: module list (≥1)
     inputs: <array>                    # Optional: input dependencies
     outputs: <array>                   # Optional: output declarations
-    provides: <array>                  # Optional: lineage labels (api 0.6+)
+    provides: <array>                  # Optional: lineage labels (api 0.7+)
 ```
 
 `provides:` is a list of label names this stage advertises to downstream
@@ -161,8 +161,8 @@ modules:
     name: <string>                     # Optional: human-readable name
     parameters: <array>                # Optional: module parameters
     exclude: <array>                   # Optional: module ids this module must not share a path with
-    requires: <object>                 # Optional: lineage gate, label → value (api 0.6+)
-    provides: <object>                 # Optional: label → value bindings for this module (api 0.6+)
+    requires: <object>                 # Optional: lineage gate, label → value (api 0.7+)
+    provides: <object>                 # Optional: label → value bindings for this module (api 0.7+)
 ```
 
 #### Required Fields

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -1,0 +1,551 @@
+# 008: Filtering and gating mechanisms
+
+[![Status: Draft](https://img.shields.io/badge/Status-Draft-yellow.svg)](https://github.com/omnibenchmark/docs/design)
+[![Version: 2](https://img.shields.io/badge/Version-2-blue.svg)](https://github.com/omnibenchmark/docs/design)
+
+| Field           | Value                                                                                                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------|
+| Authors         | btraven00, atchox                                                                                                   |
+| Date            | 2026-05-07                                                                                                          |
+| Status          | Draft                                                                                                               |
+| Version         | 2                                                                                                                   |
+| Supersedes      | N/A                                                                                                                 |
+| Reviewed-by     | TBD                                                                                                                 |
+| Related Issues  | [#331](https://github.com/omnibenchmark/omnibenchmark/issues/331), [#330](https://github.com/omnibenchmark/omnibenchmark/pull/330) (provenance metadata) |
+
+## Changes
+
+| Version | Date       | Description   | Author    |
+|---------|------------|---------------|-----------|
+| 1       | 2026-05-07 | Initial draft | btraven00 |
+| 2       | 2026-06-12 | Two-level label resolution (param-name fallback rejected); reserved builtin labels; diagnostics promoted to phase scope; phases reordered — lineage gating lands before capability gating | btraven00 |
+
+## 1. Problem Statement
+
+A benchmark plan describes the full universe of stages, modules, and parameter
+combinations. In practice users want to run a *subset* of that universe for
+several distinct reasons:
+
+- **Capability gating** — a module needs a GPU, large memory, or a network
+  resource that is not present on the current host (#331).
+- **Partial pipelines** — during development a user wants to run only up to a
+  given stage and inspect intermediates before paying for the rest.
+- **Slicing a large benchmark** — a "child" run that is a stable, addressable
+  subset of a "parent" plan (e.g. one dataset out of ten, two methods out of
+  twenty), produced by tooling such as the `obeditor` web wizard.
+- **Ad-hoc skipping** — a known-broken module that should not block the rest
+  of a run.
+
+Today, the only mechanism that approaches this is `excludes:` (and `requires:`)
+on modules. `excludes:` is *defined by absence*: to exclude a combination, you
+must enumerate it. This is brittle for any non-trivial benchmark and does not
+help with the four cases above.
+
+## 2. Design Goals
+
+- **One selector vocabulary** shared by every gating feature, so that users
+  learn one mental model.
+- **Transparent specs**: filter definitions must be human-readable and
+  diffable. Opaque blobs are acceptable as a *transport* for tooling output but
+  not as the source of truth.
+- **Provenance integration**: every applied filter is recorded in the run's
+  provenance metadata (#330) so that a child run can be reproduced from
+  *parent + filter*.
+- **Additive, not subtractive**: prefer mechanisms that say "include if X"
+  over "exclude when Y".
+- **No silent absence**: every pruned node must be observable — per-prune log
+  lines plus an end-of-expansion summary. In a benchmark, a silently missing
+  result cell is worse than a crash: it corrupts the conclusion without
+  failing the run.
+- **Cheap to start**: this design is rolled out feature-by-feature; no
+  big-bang migration.
+
+### Non-Goals
+
+- A general filter language. We are not building XPath/JMESPath; the selector
+  vocabulary stays small and typed.
+- Free-form `tags:` on modules. Tags ossify into a parallel DSL that the model
+  layer cannot type-check. We prefer typed fields (`requires_capabilities`,
+  parameter predicates) for every use case we can foresee.
+- The `.obfilter` opaque blob as a v1 surface. It remains a possible *output*
+  of `obeditor`, but the underlying spec must be transparent.
+- Replacing the cartesian-expansion engine. `provides`/`requires` already
+  exists and is the seed of an additive model; we grow it, we do not rewrite.
+
+## 3. Proposed Solution
+
+### 3.1 Selector vocabulary
+
+A *selector* identifies a set of nodes in the resolved DAG. The vocabulary in
+v1 is restricted to four predicates, all typed:
+
+| Selector | Matches |
+|---|---|
+| `stage_id: <id>` | every node whose `stage_id` equals `<id>` |
+| `module_id: <id>` | every node whose `module_id` equals `<id>` |
+| `capability: <name>` | every node whose module declares `<name>` in `requires_capabilities` |
+| `param: {key: <k>, value: <v>}` | every node whose `parameters[k] == v` |
+
+A *selector set* is a list of selectors interpreted as a union. There is no
+boolean algebra in v1; if combinations are needed they are expressed as
+multiple selector sets (see §3.6).
+
+### 3.2 `--until <stage>`
+
+Stops the resolved DAG at and including `<stage>`. Exactly one stage may be
+named.
+
+- Validate that `<stage>` exists; error otherwise.
+- Compute `cutoff = stage_order.index(<stage>)` and prune the stage list to
+  `stage_order[:cutoff+1]` *before* module resolution, so modules in pruned
+  stages are never checked out or environment-resolved.
+- Skip metric-collector resolution if any of its declared inputs reference
+  pruned outputs.
+- Rejected up front when combined with `-m/--module`, which already truncates
+  at the target module's stage.
+
+> **TODO (follow-up):** narrow the git prefetch as well.
+> `populate_git_cache` still fetches every repository referenced by the
+> benchmark; only resolution (checkout + environment setup) is currently
+> scoped to the selected stages. Cheap to add once the selected-stages set
+> is threaded into the prefetch step.
+
+### 3.3 `--capability <name>` (repeatable)
+
+Declares a capability available on the current host. Modules may declare
+required capabilities:
+
+```yaml
+modules:
+  - id: gpu_pca
+    requires_capabilities: [gpu]
+```
+
+Resolution rule: a module whose `requires_capabilities` is not a subset of the
+provided set is pruned — its outputs are never registered in
+`output_to_nodes`, so downstream stages naturally lose those branches without
+explicit exclusion logic. One info-level log line per pruned module, and the
+pruned count appears in the end-of-expansion summary (§3.5, Diagnostics).
+
+Interaction with `-m/--module` (dev mode): explicit module selection wins.
+When `-m` names a module, host gates are bypassed for the whole sub-graph,
+with a log line noting the bypass. Silently pruning the very module the user
+asked for is never acceptable; if the host truly cannot run it, the module
+fails loudly at execution time.
+
+> **TODO (follow-up):** support `requires_capabilities` at the *stage* level
+> as well, with **union** semantics — a module's effective set =
+> `stage.requires_capabilities ∪ module.requires_capabilities`. Override-down
+> (a module silently dropping a stage-level requirement) must not be allowed,
+> because it would let a module fake-pass a host gate the stage author
+> declared. Defer until a real benchmark asks: the DRY case is narrower than
+> it looks (if every module in a stage needs the same capability, that often
+> reads cleaner as a separate stage or benchmark). Tracked separately.
+
+> **TODO (follow-up):** make capabilities settable once per host so that
+> operators don't have to retype `--capability` every run. Two layered
+> sources, both strictly additive (host facts only ever accumulate, never
+> revoke):
+>
+> - **`~/.omnibenchmarkrc`** (or equivalent user config) — the right home
+>   for *persistent* host facts: capabilities don't change between shell
+>   sessions, they're a property of the box. A workstation operator
+>   declares `capabilities: [gpu, large_mem]` once.
+> - **`OMNIBENCHMARK_CAPABILITIES=gpu,large_mem`** env var — useful for
+>   *ephemeral / scoped* contexts: CI jobs that want per-job control
+>   without writing files, `direnv`-managed project shells, container
+>   entrypoints.
+>
+> Precedence is union, not override: effective set = rc-file ∪ env ∪ CLI.
+> Each layer can only add; nothing can subtract. (If you reach for
+> subtraction, see §3.6 / the rejected-`!gpu` note.) Cheap to add when
+> someone asks.
+
+#### Considered and rejected: negative capabilities (`--capability !gpu`)
+
+A negation syntax was considered and deliberately not adopted in v1.
+`--capability` is scoped to *host facts*: "what does this machine have?"
+A `!gpu` form would conflate that with *node selection*: "which modules do
+I want to exclude?" Two reasons this is the wrong place:
+
+- **Two semantics on one flag is a UX tax.** Host-fact declaration and
+  module-set filtering are orthogonal axes; mixing them invites the user to
+  reason about which interpretation applies in each case.
+- **Most "I want to skip gpu modules" cases collapse to "don't pass
+  `--capability gpu`."** The remaining real case — "skip gpu modules on a
+  host that does have gpu" — belongs in the v2 filter spec (§3.6) as
+  `exclude: [{capability: gpu}]`, where it sits alongside other exclusions
+  in one shared selector grammar.
+- **Slippery slope.** Once `!gpu` is accepted, the next requests are
+  `gpu|tpu`, `gpu&large_mem`, regex, glob. We do not want to negotiate a
+  mini-language on this flag.
+
+If you find yourself reaching for negation, that is the signal to use the
+filter spec instead.
+
+#### What capabilities are good for
+
+Capabilities are *host facts*: things that are true (or not) about the
+machine running the benchmark. They are static for the duration of a run.
+Useful categories:
+
+| Category | Example labels | Meaning |
+|---|---|---|
+| Hardware accelerator | `gpu`, `tpu`, `cuda_12` | a specific class of accelerator is present |
+| Memory tier | `large_mem` | the host has enough RAM for the heavy method |
+| Compute tier (laptop → cluster) | `compute_xs`, `compute_sm`, `compute_md`, `compute_lg`, `compute_xl` | coarse profile of available compute (cores × RAM × time budget) |
+| Network / data access | `internet`, `s3_egress` | the host can reach remote resources at run time |
+
+The compute-tier vocabulary is a *suggested convention*, not enforced by the
+schema. A module declaring `requires_capabilities: [compute_md]` is asking
+the operator to assert "this is a medium-tier machine"; it does not measure
+RAM. The benchmark author chooses the granularity. Standardizing the names
+in the suggested set lets the wizard surface them as fixed checkboxes
+instead of free-form strings.
+
+### 3.4 Capabilities are *not* tags, and *not* lineage labels
+
+`requires_capabilities` is deliberately scoped to **host facts**, not to:
+
+- **Free-form tags** (`experimental`, `old`, `phase2`). Any value that begs
+  for free-form text is a code smell — it should be modeled as a parameter,
+  a stage split, or a separate benchmark.
+- **Lineage labels** (`dataset_size: lg`, `treatment: ctrl`). Those describe
+  the *data* flowing through an execution path, not the *host*. They are
+  expressed via the existing `provides:` (on stages) / `requires:` (on
+  modules) mechanism — see §3.5 below.
+
+This distinction matters: a host with `--capability lg` should not be
+allowed to fake-run a "large dataset only" method on small data. Host gates
+and lineage gates compose independently and a module may need both.
+
+### 3.5 Lineage-derived gates (`provides` / `requires`)
+
+Independent of capabilities, a module can be gated on properties of its
+upstream lineage. Stages emit labels via `provides:`; modules opt in via
+`requires:`. The values flow with the data, not with the host.
+
+```yaml
+stages:
+  - id: data
+    provides: [dataset_size]
+    modules:
+      - id: small_set
+        provides: {dataset_size: sm}
+      - id: huge_set
+        provides: {dataset_size: lg}
+        requires_capabilities: [large_mem]   # host gate at the source
+
+  - id: methods
+    modules:
+      - id: cheap_method
+        requires: {dataset_size: sm}         # lineage gate
+      - id: scalable_method
+        requires_capabilities: [gpu]         # host gate
+        # no `requires` → runs on every dataset_size
+```
+
+Two axes, composed by AND:
+
+- **Host axis** (`requires_capabilities` ↔ `--capability`): is this box
+  capable?
+- **Lineage axis** (`requires` ↔ `provides`): is this execution path
+  carrying the right kind of data?
+
+A module is included only when both gates pass for the candidate node.
+
+#### Resolution chain (api ≥ 0.6.0)
+
+For each label declared in `Stage.provides`, the per-node value is
+resolved in order, most specific first:
+
+1. **`Module.provides[label]`** — explicit benchmark-local binding. This is
+   the recommended form: it keeps label routing out of the module's CLI
+   parameter contract, so the same module can be reused across benchmarks
+   that use different label vocabularies.
+2. **`module_id`** — silent default. The zero-config pattern for "label =
+   module identity" (e.g. a data stage where each module *is* a dataset
+   and you gate downstream by dataset name).
+
+Downstream modules with `requires: {label: value}` run only on upstream
+nodes whose resolved label matches by exact string equality.
+
+#### Considered and rejected: parameter-name fallback
+
+An intermediate resolution rule was prototyped and cut before shipping:
+when a module had a *parameter literally named* like the label
+(`parameters: [{dataset_size: lg}]`), its value would become the label
+value. Rejected because it silently couples two contracts with different
+owners:
+
+- A module's parameter list is its **CLI surface** — `--dataset_size lg`
+  is passed to the entrypoint; it belongs to the module repository.
+- A label is **routing metadata** — it belongs to the benchmark.
+
+With the fallback in place, a module author renaming a CLI flag (an
+internal refactor, from their perspective) would silently reroute the
+benchmark's DAG: label resolution falls through to the module-id default,
+downstream `requires:` stops matching, and the benchmark loses cells with
+no error at either end. That is action-at-a-distance *across
+repositories* — invisible at the point of cause, silent at the point of
+effect.
+
+The one case the fallback handled that `Module.provides` cannot: a label
+varying *per parameter expansion* of a single module (one module declaring
+`parameters: [{dataset_size: sm}, {dataset_size: lg}]`). The answer for
+that case is to split the module entry in two — which reads better anyway,
+since the label claims to describe the data. If a real benchmark hits this
+and splitting is genuinely painful, the fallback (or a templated
+`Module.provides: {dataset_size: "{params.dataset_size}"}` form) can be
+added back **backward-compatibly**. Removing it after specs depend on it
+cannot. That asymmetry decides it.
+
+#### Reserved labels: `name` and `dataset`
+
+The runtime auto-populates two labels on every node: `dataset` (the root
+dataset identity, inherited down the lineage) and `name` (the current
+module's own id, never inherited — see PR #323). Declaring either in
+`Stage.provides` is a **parse-time error**: the runtime would silently
+clobber the user's value on every node, and a downstream
+`requires: {name: …}` would gate on an accident of propagation rather
+than a declared contract.
+
+#### Diagnostics
+
+Pruning must never be invisible (§2, "No silent absence"). Ships with the
+lineage phase:
+
+- **Empty-stage warning** — when a stage expands to zero nodes after any
+  filter (lineage gate, capability gate, exclusion), emit
+  `logger.warning("stage X pruned to empty by …")` at graph-build time.
+  Without it, a typo in a label value cascades-empty downstream and looks
+  like "nothing happened."
+- **Pruned-combinations summary** — one end-of-expansion line:
+  `N combinations pruned: X by requires, Y by exclude, Z by capability`.
+  This is also the seed of the provenance `filters` block (§3.7): the same
+  record, persisted.
+
+#### Working example
+
+```yaml
+api_version: "0.6.0"
+stages:
+  - id: data
+    provides: [dataset_size]            # stage advertises this label
+    modules:
+      - id: small
+        provides: {dataset_size: sm}    # explicit binding
+        parameters: [{evaluate: "1+1"}]
+      - id: huge
+        provides: {dataset_size: lg}
+        parameters: [{evaluate: "9+9"}]
+    outputs:
+      - {id: data.raw, path: "{dataset}_data.json"}
+
+  - id: methods
+    inputs: [data.raw]
+    modules:
+      - id: M_lg_only
+        requires: {dataset_size: lg}    # lineage gate
+        parameters: [{evaluate: "input+10"}]
+    outputs:
+      - {id: methods.result, path: "{dataset}_method.json"}
+```
+
+Result: `M_lg_only` runs only on the `huge` execution path; the `small`
+branch is pruned at DAG-construction time. No exclusion list, no
+cartesian-product subtraction.
+
+The "label = module identity" case is even shorter — no `Module.provides`
+needed:
+
+```yaml
+stages:
+  - id: data
+    provides: [source]
+    modules:
+      - id: iris
+      - id: penguins
+      - id: atlas_v2
+
+  - id: methods
+    modules:
+      - id: cheap
+        requires: {source: iris}        # match by module id
+```
+
+(The builtin `dataset` label already behaves this way for data stages; a
+custom label is needed only when the identity pattern applies to a
+non-root stage, or when you want a name that survives the eventual
+deprecation of the `dataset` builtin.)
+
+#### Scope and naming
+
+This is the *list-of-labels* form of `Stage.provides:` plus the
+*label → value* form of `Module.provides:`. A separate *map* form
+(`Stage.provides: {label: output_id}`) was proposed for gather contracts
+(see PR #291) but is intentionally out of scope here. If gather lands
+later, its binding will use a different keyword (e.g. `gather_outputs:`,
+`exports:`) to keep the namespaces clean.
+
+> **TODO (deferred — add only if needed):** *stage-level partition syntax*
+> for the case where many modules share a label value. Today, declaring
+> `Module.provides: {dataset_size: lg}` on each of N modules is verbose.
+> A partition form would let the stage author group modules by label
+> value once:
+>
+> ```yaml
+> # Proposed; NOT implemented.
+> provides:
+>   dataset_size:
+>     sm: [iris, penguins, mnist_subset]
+>     lg: [atlas_v2, big_brain]
+> ```
+>
+> Resolution would slot in after `Module.provides` and before the
+> module-id fallback. Defer until a real benchmark hits this volume — for
+> the small-N case, per-module `provides:` is fine and reads more locally.
+
+> **TODO (follow-up):** a `provides` consistency check at parse time. When
+> a stage declares `provides: [X]`, warn if a module in the stage has no
+> `Module.provides` entry for X — i.e. it would silently fall through to
+> module_id. This catches the foot-gun where the author forgot to declare
+> the value and a downstream `requires` silently prunes the module. Cannot
+> warn unconditionally at the producer side (the "label = module_id"
+> pattern is legitimate); needs to look at sibling modules in the stage
+> and the consumer side to be precise.
+
+#### Suggested canonical labels
+
+| Label scope | Example labels | Where declared |
+|---|---|---|
+| Lineage / dataset size | `xs`, `sm`, `md`, `lg`, `xl` (as values of a `dataset_size` provides-label) | `Module.provides` binding + `provides` label on the stage |
+| Lineage / domain | `treatment: ctrl|drug`, `species: human|mouse` | stage `provides:` |
+| Host / compute tier | `compute_xs`, `compute_sm`, `compute_md`, `compute_lg`, `compute_xl` | module `requires_capabilities:` + run-time `--capability` |
+| Host / hardware | `gpu`, `tpu`, `large_mem`, `internet` | module `requires_capabilities:` |
+
+These are conventions, not enforced names. Encouraging consistency lets the
+filter wizard offer fixed checkboxes and a benchmarker can pick a tier
+without reinventing one per benchmark.
+
+### 3.6 Filter spec (deferred to v2)
+
+Sketch only; do not implement in v1.
+
+```yaml
+filter:
+  include:
+    - stage_id: data
+      module_id: D1
+    - stage_id: methods
+      module_id: M1
+  exclude:
+    - capability: gpu
+```
+
+Rules: `include` is a positive selector set; if absent, all nodes are
+included. `exclude` is removed after `include`. The wizard may emit this spec
+verbatim or transport it as base64-JSON (`.obfilter`); both forms must
+round-trip.
+
+### 3.7 Provenance hooks
+
+Every applied filter (including `--until` and `--capability`) is recorded
+under a `provenance.filters` block in the run metadata (#330). A child run
+declares its parent benchmark by canonical URL plus the applied filter spec.
+This is what makes a sliced run reproducible.
+
+Concretely:
+
+```yaml
+provenance:
+  parent: https://example.org/benchmarks/foo@v1.2.3
+  filters:
+    until: methods
+    capabilities: [gpu]
+```
+
+## 4. Alternatives Considered
+
+### Alternative 1: free-form `tags:` on modules
+- **Description**: arbitrary string tags + `--skip <tag>`.
+- **Pros**: maximally flexible.
+- **Cons**: opaque to the model, no type checking, attracts every gating
+  question into one over-loaded field.
+- **Reason for rejection**: see §2 non-goals. Capabilities cover the concrete
+  use case in #331 with stronger semantics.
+
+### Alternative 2: replace cartesian + excludes with provides/wants slots
+- **Description**: full slot-and-signal mechanism, declarative wiring.
+- **Pros**: cleanest model, additive by construction.
+- **Cons**: large engine change; pushback on perceived complexity.
+- **Reason for rejection (for now)**: `requires:`/`provides:` already exist
+  on stages and modules and resolve through `_satisfies_requires`. We extend
+  rather than replace.
+
+### Alternative 3: `.obfilter` opaque blob as primary surface
+- **Description**: wizard emits a signed/encoded blob; tooling consumes it.
+- **Pros**: tamper-evident, easy to embed in URLs.
+- **Cons**: unreviewable in PRs; drifts silently when the parent plan
+  evolves; teaches users a thing they can't read.
+- **Reason for rejection**: kept as a *transport* for the underlying
+  transparent spec, not as the source of truth.
+
+## 5. Implementation Plan
+
+Phases land as separate PRs, in this order. Lineage gating moved ahead of
+capability gating (v2 of this doc): it is the pressing replacement for
+enumerate-everything `excludes:`, while capabilities serve a narrower
+host-heterogeneity case.
+
+### Phase 1 — `--until <stage>` (this PR)
+- CLI flag, single stage, validation against `stage_order`.
+- Stage selection happens *before* module resolution (no checkout/env cost
+  for pruned stages); git prefetch narrowing is a follow-up (§3.2 TODO).
+- Skip metric collectors that reference pruned outputs.
+- Reject combination with `-m/--module`.
+- Tests: until=initial / middle / terminal / unknown / stage with multiple
+  providers.
+
+### Phase 2 — lineage gates (`Stage.provides` / `Module.provides` / `requires`)
+- Model: `Stage.provides: list[str]`, `Module.provides: dict[str, str]`;
+  both gated on api ≥ 0.6.0. **Mints `APIVersion.V0_6_0`.**
+- Two-level resolution chain (§3.5); no parameter-name fallback.
+- Reserved-label parse error for `name` and `dataset`.
+- Diagnostics: empty-stage warning + pruned-combinations summary (§3.5).
+- Tests: unit tests assert on resolved node sets (not generated-Snakefile
+  text); e2e fixture for the lineage gate across a multi-stage DAG.
+
+### Phase 3 — `--capability` + `requires_capabilities`
+- Model: `requires_capabilities: list[str]` on `Module` (extends the 0.6
+  api gate).
+- CLI: repeatable `--capability` flag.
+- Resolution: prune modules whose required set ⊄ available set *before*
+  module resolution; do not register their outputs.
+- `-m` bypasses host gates with a log line (§3.3).
+- Tests: missing capability prunes module; pruning cascades; provided
+  capabilities log line; interaction with `--until` and `-m`.
+
+### Phase 4 — Provenance plumbing
+- After #330 lands, emit applied filters into the provenance block,
+  reusing the pruned-combinations record from Phase 2.
+- Round-trip test: serialize → load → re-run produces the same node set.
+
+### Phase 5 — Filter spec (deferred)
+- Implement §3.6 once the earlier phases have shipped and we understand the
+  ergonomics.
+
+### Testing Strategy
+- Unit: selector predicates, `--until` boundary cases, label resolution
+  precedence, capability pruning cascades — all asserting on resolved node
+  sets.
+- Integration: e2e fixtures exercising lineage-gated and capability-gated
+  modules across a multi-stage DAG.
+- Provenance round-trip in a separate test once #330 lands.
+
+## 6. References
+
+1. [Issue #331 — conditional execution of modules](https://github.com/omnibenchmark/omnibenchmark/issues/331)
+2. [PR #330 — provenance metadata tracking](https://github.com/omnibenchmark/omnibenchmark/pull/330)
+3. [PR #323 — `{name}` resolves to the current module id](https://github.com/omnibenchmark/omnibenchmark/pull/323)
+4. [Snakemake `--until` semantics](https://snakemake.readthedocs.io/en/stable/executing/cli.html)

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -324,6 +324,12 @@ lineage phase:
   `N combinations pruned: X by requires, Y by exclude, Z by capability`.
   This is also the seed of the provenance `filters` block (§3.7): the same
   record, persisted.
+- **Parse-time errors** — a gate that can never fire is rejected before the
+  DAG is built: a `provides` key absent from its stage's list, and a
+  `requires:` on a module in an initial stage (no `inputs:`, hence no
+  upstream lineage to match). The latter is the most natural-looking place
+  to put a gate on a data-stage variant loader, and it would otherwise run
+  unconditionally with no diagnostic at all.
 
 #### Working example
 

--- a/docs/design/008-filtering.md
+++ b/docs/design/008-filtering.md
@@ -254,7 +254,7 @@ Two axes, composed by AND:
 
 A module is included only when both gates pass for the candidate node.
 
-#### Resolution chain (api ≥ 0.6.0)
+#### Resolution chain (api ≥ 0.7.0)
 
 For each label declared in `Stage.provides`, the per-node value is
 resolved in order, most specific first:
@@ -334,7 +334,7 @@ lineage phase:
 #### Working example
 
 ```yaml
-api_version: "0.6.0"
+api_version: "0.7.0"
 stages:
   - id: data
     provides: [dataset_size]            # stage advertises this label
@@ -515,7 +515,7 @@ host-heterogeneity case.
 
 ### Phase 2 — lineage gates (`Stage.provides` / `Module.provides` / `requires`)
 - Model: `Stage.provides: list[str]`, `Module.provides: dict[str, str]`;
-  both gated on api ≥ 0.6.0. **Mints `APIVersion.V0_6_0`.**
+  both gated on api ≥ 0.7.0. **Mints `APIVersion.V0_7_0`.**
 - Two-level resolution chain (§3.5); no parameter-name fallback.
 - Reserved-label parse error for `name` and `dataset`.
 - Diagnostics: empty-stage warning + pruned-combinations summary (§3.5).

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -911,14 +911,37 @@ def _substitute_params_in_path(template: str, params) -> str:
     return re.sub(r"\{params\.([^}]+)\}", _replace, template)
 
 
+def _resolve_label_value(label: str, module_provides, module_id: str) -> str:
+    """Resolve a single `Stage.provides` label's value for one node.
+
+    Two-level chain, most specific first:
+      1. ``module.provides[label]`` — explicit benchmark-local binding.
+      2. ``module_id`` — default for the "label = module identity" pattern.
+
+    The parameter-name fallback prototyped earlier is intentionally absent:
+    sourcing a label from a same-named CLI parameter couples the module's CLI
+    contract to the benchmark's routing across repositories. See
+    docs/design/008-filtering.md §3.5.
+    """
+    if module_provides and label in module_provides:
+        return str(module_provides[label])
+    return module_id
+
+
 def _build_template_context(
     stage,
     module_id: str,
     module_name: Optional[str] = None,
     input_node=None,
     params=None,
+    module_provides=None,
 ) -> TemplateContext:
-    """Build a TemplateContext for a node during expansion."""
+    """Build a TemplateContext for a node during expansion.
+
+    `module_provides` is the optional `Module.provides` dict (label → value);
+    it sources the values for the labels this stage advertises via
+    `Stage.provides`, defaulting to the module id.
+    """
     provides: dict[str, str] = {}
     module_attrs: dict[str, str] = {
         "id": module_id,
@@ -928,27 +951,19 @@ def _build_template_context(
 
     stage_provides = getattr(stage, "provides", None)
 
+    # Inherit the upstream lineage labels first, then layer this stage's own.
+    if input_node is not None and input_node.template_context is not None:
+        provides.update(input_node.template_context.provides)
+
+    if stage_provides:
+        for label in stage_provides:
+            provides[label] = _resolve_label_value(label, module_provides, module_id)
+
     if input_node is not None:
-        if input_node.template_context is not None:
-            provides.update(input_node.template_context.provides)
-
-        if stage_provides:
-            for label in stage_provides:
-                if params is not None and label in params:
-                    provides[label] = str(params[label])
-                else:
-                    provides[label] = module_id
-
         module_attrs["parent.id"] = input_node.module_id
         module_attrs["parent.stage"] = input_node.stage_id
     else:
-        if stage_provides:
-            for label in stage_provides:
-                if params is not None and label in params:
-                    provides[label] = str(params[label])
-                else:
-                    provides[label] = module_id
-
+        # Builtin `dataset` label: root identity, propagated downstream.
         if params is not None and "dataset" in params:
             provides.setdefault("dataset", str(params["dataset"]))
         else:
@@ -1326,6 +1341,9 @@ def _generate_explicit_snakefile(
     output_to_nodes = {}
     previous_stage_nodes = []
     dag_errors: list[tuple[str, str, str]] = []
+    # Count pruned combinations by reason, so a silently absent result cell is
+    # observable (see docs/design/008-filtering.md, "No silent absence").
+    prune_counts = {"requires": 0, "exclude": 0}
 
     # stage_id -> ordered output ids. Precomputed once so per-node output lookup
     # is O(1) instead of scanning every stage and doing an O(outputs) pydantic
@@ -1407,6 +1425,7 @@ def _generate_explicit_snakefile(
                             module_id
                         }
                         if is_lineage_excluded(lineage, path_exclusions):
+                            prune_counts["exclude"] += 1
                             logger.debug(
                                 f"      Excluding combination: lineage {lineage} "
                                 f"violates an exclusion rule"
@@ -1415,6 +1434,7 @@ def _generate_explicit_snakefile(
 
                     if input_node and module.requires:
                         if not satisfies_requires(module.requires, input_node):
+                            prune_counts["requires"] += 1
                             logger.debug(
                                 f"      Skipping combination: requires not satisfied for {module_id} "
                                 f"(upstream context: {input_node.template_context.provides})"
@@ -1486,6 +1506,7 @@ def _generate_explicit_snakefile(
                         module_name=getattr(module, "name", None),
                         input_node=input_node,
                         params=params,
+                        module_provides=module.provides,
                     )
 
                     outputs = []
@@ -1558,7 +1579,26 @@ def _generate_explicit_snakefile(
                 if logger.level <= 10:
                     traceback.print_exc()
 
+        # A stage that had modules to expand but produced no nodes was pruned
+        # to empty by a filter (requires / exclude). Without this the empty set
+        # cascades downstream and looks like "nothing happened" — usually a
+        # typo in a label value or an over-broad exclusion.
+        if modules_to_expand and not current_stage_nodes:
+            logger.warning(
+                f"Stage '{stage.id}' produced no nodes: every module/input "
+                f"combination was pruned by a filter (requires/exclude). "
+                f"Downstream stages depending on it will also be empty."
+            )
+
         previous_stage_nodes = current_stage_nodes
+
+    total_pruned = sum(prune_counts.values())
+    if total_pruned:
+        logger.info(
+            f"Pruned {total_pruned} combination(s): "
+            f"{prune_counts['requires']} by requires, "
+            f"{prune_counts['exclude']} by exclude."
+        )
 
     if not quiet:
         logger.info(f"Created {len(resolved_nodes)} nodes")

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -1356,6 +1356,11 @@ def _generate_explicit_snakefile(
 
     for stage in stages_to_expand:
         current_stage_nodes = []
+        # How many (input, params) combinations this stage actually attempted.
+        # Zero means nothing was generated to prune (an input id resolved to no
+        # upstream node); >0 with an empty stage means a filter rejected them
+        # all. The empty-stage warning below distinguishes the two.
+        combinations_seen = 0
 
         # Module-filter: which modules to expand per stage
         if module_filter:
@@ -1415,6 +1420,8 @@ def _generate_explicit_snakefile(
 
                 if module_filter:
                     node_combinations = node_combinations[:1]
+
+                combinations_seen += len(node_combinations)
 
                 for input_node, params in node_combinations:
                     # Exclusions are transitive over the full lineage, not just
@@ -1579,16 +1586,25 @@ def _generate_explicit_snakefile(
                 if logger.level <= 10:
                     traceback.print_exc()
 
-        # A stage that had modules to expand but produced no nodes was pruned
-        # to empty by a filter (requires / exclude). Without this the empty set
-        # cascades downstream and looks like "nothing happened" — usually a
-        # typo in a label value or an over-broad exclusion.
+        # A stage that had modules to expand but produced no nodes should not
+        # cascade an empty set downstream silently. Two distinct causes, two
+        # distinct messages: a filter rejected every generated combination, vs.
+        # no combination was generated at all (a declared input id matched no
+        # upstream output — usually a misspelled output id).
         if modules_to_expand and not current_stage_nodes:
-            logger.warning(
-                f"Stage '{stage.id}' produced no nodes: every module/input "
-                f"combination was pruned by a filter (requires/exclude). "
-                f"Downstream stages depending on it will also be empty."
-            )
+            if combinations_seen:
+                logger.warning(
+                    f"Stage '{stage.id}' produced no nodes: every module/input "
+                    f"combination was pruned by a filter (requires/exclude). "
+                    f"Downstream stages depending on it will also be empty."
+                )
+            else:
+                logger.warning(
+                    f"Stage '{stage.id}' produced no nodes: no upstream output "
+                    f"matched its declared inputs (check for a misspelled "
+                    f"output id or a skipped upstream stage). Downstream stages "
+                    f"depending on it will also be empty."
+                )
 
         previous_stage_nodes = current_stage_nodes
 
@@ -1621,15 +1637,25 @@ def _generate_explicit_snakefile(
     # Resolve metric collectors (skip in -m module mode)
     if not module_filter:
         collectors_to_resolve = benchmark.model.get_metric_collectors()
-        if until_stage is not None:
-            included_ids = {s.id for s in stages_to_expand}
-            collectors_to_resolve, dropped = _filter_collectors_by_stages(
-                collectors_to_resolve, included_ids, benchmark.model
-            )
-            for cid in dropped:
+        # Drop collectors that reference a stage which produced no nodes —
+        # whether truncated by --until or emptied by requires/exclude filters.
+        # Filtering on stages that actually yielded nodes covers both, where
+        # `stages_to_expand` alone would keep a collector on an organically
+        # emptied stage and hand the resolver zero matches (a confusing error).
+        stages_with_nodes = {n.stage_id for n in resolved_nodes}
+        collectors_to_resolve, dropped = _filter_collectors_by_stages(
+            collectors_to_resolve, stages_with_nodes, benchmark.model
+        )
+        for cid in dropped:
+            if until_stage is not None:
                 logger.info(
                     f"--until {until_stage}: skipping metric collector "
                     f"'{cid}' (references pruned stages)."
+                )
+            else:
+                logger.warning(
+                    f"Skipping metric collector '{cid}': it references a stage "
+                    f"that produced no nodes (pruned by requires/exclude)."
                 )
         try:
             collector_nodes = resolve_metric_collectors(

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -1022,6 +1022,28 @@ def _capability_prune_summary(pruned_modules, available_capabilities) -> str:
     )
 
 
+def _empty_stage_warning(stage_id: str, combinations_seen: int) -> str:
+    """Message for a stage that had modules to expand but produced no nodes.
+
+    `combinations_seen` is how many (input, params) combinations the stage
+    actually attempted. Zero means none was ever generated — a declared input
+    id matched no upstream output, which is a wiring problem, not a filter one.
+    Blaming requires/exclude there sends the user to the wrong config.
+    """
+    cause = (
+        "every module/input combination was pruned by a filter (requires/exclude)"
+        if combinations_seen
+        else (
+            "no upstream output matched its declared inputs (check for a "
+            "misspelled output id or a skipped upstream stage)"
+        )
+    )
+    return (
+        f"Stage '{stage_id}' produced no nodes: {cause}. Downstream stages "
+        f"depending on it will also be empty."
+    )
+
+
 def _apply_until_filter(stages, until_stage, parents):
     """Restrict a stage list to `until_stage` plus its transitive ancestors.
 
@@ -1587,24 +1609,9 @@ def _generate_explicit_snakefile(
                     traceback.print_exc()
 
         # A stage that had modules to expand but produced no nodes should not
-        # cascade an empty set downstream silently. Two distinct causes, two
-        # distinct messages: a filter rejected every generated combination, vs.
-        # no combination was generated at all (a declared input id matched no
-        # upstream output — usually a misspelled output id).
+        # cascade an empty set downstream silently.
         if modules_to_expand and not current_stage_nodes:
-            if combinations_seen:
-                logger.warning(
-                    f"Stage '{stage.id}' produced no nodes: every module/input "
-                    f"combination was pruned by a filter (requires/exclude). "
-                    f"Downstream stages depending on it will also be empty."
-                )
-            else:
-                logger.warning(
-                    f"Stage '{stage.id}' produced no nodes: no upstream output "
-                    f"matched its declared inputs (check for a misspelled "
-                    f"output id or a skipped upstream stage). Downstream stages "
-                    f"depending on it will also be empty."
-                )
+            logger.warning(_empty_stage_warning(stage.id, combinations_seen))
 
         previous_stage_nodes = current_stage_nodes
 

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -1368,6 +1368,39 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
                         f"populated by the runtime; choose another name."
                     )
 
+        # A module can only bind a label its stage advertises. A `provides` key
+        # absent from `stage.provides` is never consulted at resolution time
+        # (`_resolve_label_value` iterates the stage's labels), so it would
+        # silently fall through to the module_id default and break a downstream
+        # `requires:` gate with no diagnostic. See 008 §2 (no silent absence).
+        for stage in self.stages:
+            declared = set(stage.provides or [])
+            for module in stage.modules:
+                for label in module.provides or {}:
+                    if label not in declared:
+                        raise ValueError(
+                            f"Module '{module.id}' binds label '{label}' in "
+                            f"`provides`, but stage '{stage.id}' does not "
+                            f"declare it. Add '{label}' to the stage's "
+                            f"`provides` list or fix the key."
+                        )
+
+        # A `requires:` gate matches against the upstream lineage. An initial
+        # stage has no inputs, so its modules have no upstream context and the
+        # gate can never be satisfied — flag it rather than silently running the
+        # module unconditionally. See 008 §2 (no silent absence).
+        for stage in self.stages:
+            if not self.is_initial(stage):
+                continue
+            for module in stage.modules:
+                if module.requires:
+                    raise ValueError(
+                        f"Module '{module.id}' in initial stage '{stage.id}' "
+                        f"declares `requires`, but an initial stage has no "
+                        f"upstream lineage to match against. Remove the "
+                        f"`requires` gate or move the module to a later stage."
+                    )
+
         # Call the pure model validation from the validator base class
         self.validate_model_structure()
         return self

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -129,11 +129,11 @@ class APIVersion(str, Enum):
     V0_3_0 = "0.3.0"
     V0_4_0 = "0.4.0"
     V0_5_0 = "0.5.0"
-    V0_6_0 = "0.6.0"
+    V0_7_0 = "0.7.0"
 
     @classmethod
     def latest(cls) -> "APIVersion":
-        return cls.V0_6_0
+        return cls.V0_7_0
 
     @classmethod
     def supported_versions(cls) -> set[str]:
@@ -572,7 +572,7 @@ class Module(DescribableEntity, SoftwareEnvironmentReference):
             "value: it keeps routing out of the module's CLI parameter "
             "contract, so the same module stays reusable across benchmarks "
             "with different label vocabularies. When a label has no binding "
-            "here, it defaults to the module id. Requires api_version ≥ 0.6.0."
+            "here, it defaults to the module id. Requires api_version ≥ 0.7.0."
         ),
     )
     resources: Optional[Resources] = Field(
@@ -651,7 +651,7 @@ class Stage(DescribableEntity):
             "id. Downstream modules gate on these labels via `requires:`; "
             "non-matching execution paths prune at DAG-construction time. The "
             "builtin labels `name` and `dataset` are reserved and may not be "
-            "declared here. Requires api_version ≥ 0.6.0."
+            "declared here. Requires api_version ≥ 0.7.0."
         ),
     )
     resources: Optional[Resources] = Field(
@@ -1365,21 +1365,21 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
                         collector.software_environment = sole_env_id
 
         # Gate api_version-introduced fields. `Stage.provides` and
-        # `Module.provides` were introduced in 0.6.0 and must not be used by
+        # `Module.provides` were introduced in 0.7.0 and must not be used by
         # older specs.
-        if self.api_version < APIVersion.V0_6_0:
+        if self.api_version < APIVersion.V0_7_0:
             for stage in self.stages:
                 if stage.provides:
                     raise ValueError(
                         f"Stage '{stage.id}' uses `provides`, which requires "
-                        f"api_version ≥ 0.6.0 (this benchmark declares "
+                        f"api_version ≥ 0.7.0 (this benchmark declares "
                         f"{self.api_version.value})."
                     )
                 for module in stage.modules:
                     if module.provides:
                         raise ValueError(
                             f"Module '{module.id}' uses `provides`, which "
-                            f"requires api_version ≥ 0.6.0 (this benchmark "
+                            f"requires api_version ≥ 0.7.0 (this benchmark "
                             f"declares {self.api_version.value})."
                         )
 

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -142,30 +142,30 @@ class APIVersion(str, Enum):
 
     # Version gates compare with <, <=, >=. Inherited from str those are
     # lexicographic, which would order "0.10.0" before "0.6.0"; delegate to
-    # the semantic Version instead.
-    @property
-    def _semver(self) -> Version:
-        return Version(self.value)
+    # the semantic Version instead. Returning NotImplemented for a plain str
+    # would hand the comparison back to str and reinstate that bug silently,
+    # so an operand that is not an APIVersion raises instead.
+    @staticmethod
+    def _semver(value: object) -> Version:
+        if not isinstance(value, APIVersion):
+            raise TypeError(
+                f"cannot order APIVersion against {type(value).__name__!r}: "
+                f"{value!r} would compare lexicographically. Convert it with "
+                "APIVersion(...) first."
+            )
+        return Version(value.value)
 
     def __lt__(self, other: object) -> bool:
-        if not isinstance(other, APIVersion):
-            return NotImplemented
-        return self._semver < other._semver
+        return self._semver(self) < self._semver(other)
 
     def __le__(self, other: object) -> bool:
-        if not isinstance(other, APIVersion):
-            return NotImplemented
-        return self._semver <= other._semver
+        return self._semver(self) <= self._semver(other)
 
     def __gt__(self, other: object) -> bool:
-        if not isinstance(other, APIVersion):
-            return NotImplemented
-        return self._semver > other._semver
+        return self._semver(self) > self._semver(other)
 
     def __ge__(self, other: object) -> bool:
-        if not isinstance(other, APIVersion):
-            return NotImplemented
-        return self._semver >= other._semver
+        return self._semver(self) >= self._semver(other)
 
 
 # Labels the runtime populates on every node; a stage may not advertise these

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -20,7 +20,6 @@ from pydantic import (
 )
 
 from omnibenchmark.model._merge import merge_dict_list
-from omnibenchmark.versioning.version import Version
 
 from ._parsing import convert_pydantic_error_to_parse_error
 from .params import Params
@@ -141,31 +140,32 @@ class APIVersion(str, Enum):
         return {version.value for version in cls}
 
     # Version gates compare with <, <=, >=. Inherited from str those are
-    # lexicographic, which would order "0.10.0" before "0.6.0"; delegate to
-    # the semantic Version instead. Returning NotImplemented for a plain str
-    # would hand the comparison back to str and reinstate that bug silently,
-    # so an operand that is not an APIVersion raises instead.
+    # lexicographic, which would order "0.10.0" before "0.6.0"; order by parsed
+    # components instead. (versioning.Version would do this too, but `model`
+    # cannot import `versioning` — that package imports `model` back.)
+    # Returning NotImplemented for a plain str would hand the comparison back
+    # to str and reinstate the bug silently, so a non-member operand raises.
     @staticmethod
-    def _semver(value: object) -> Version:
+    def _parts(value: object) -> tuple[int, ...]:
         if not isinstance(value, APIVersion):
             raise TypeError(
                 f"cannot order APIVersion against {type(value).__name__!r}: "
                 f"{value!r} would compare lexicographically. Convert it with "
                 "APIVersion(...) first."
             )
-        return Version(value.value)
+        return tuple(int(part) for part in value.value.split("."))
 
     def __lt__(self, other: object) -> bool:
-        return self._semver(self) < self._semver(other)
+        return self._parts(self) < self._parts(other)
 
     def __le__(self, other: object) -> bool:
-        return self._semver(self) <= self._semver(other)
+        return self._parts(self) <= self._parts(other)
 
     def __gt__(self, other: object) -> bool:
-        return self._semver(self) > self._semver(other)
+        return self._parts(self) > self._parts(other)
 
     def __ge__(self, other: object) -> bool:
-        return self._semver(self) >= self._semver(other)
+        return self._parts(self) >= self._parts(other)
 
 
 # Labels the runtime populates on every node; a stage may not advertise these

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -129,6 +129,7 @@ class APIVersion(str, Enum):
     V0_3_0 = "0.3.0"
     V0_4_0 = "0.4.0"
     V0_5_0 = "0.5.0"
+    V0_6_0 = "0.6.0"
     V0_7_0 = "0.7.0"
 
     @classmethod

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -129,14 +129,21 @@ class APIVersion(str, Enum):
     V0_3_0 = "0.3.0"
     V0_4_0 = "0.4.0"
     V0_5_0 = "0.5.0"
+    V0_6_0 = "0.6.0"
 
     @classmethod
     def latest(cls) -> "APIVersion":
-        return cls.V0_5_0
+        return cls.V0_6_0
 
     @classmethod
     def supported_versions(cls) -> set[str]:
         return {version.value for version in cls}
+
+
+# Labels the runtime populates on every node; a stage may not advertise these
+# via `Stage.provides` (it would silently clobber the builtin value). See
+# docs/design/008-filtering.md §3.5.
+_RESERVED_PROVIDES_LABELS = frozenset({"name", "dataset"})
 
 
 class SoftwareBackendEnum(str, Enum):
@@ -528,6 +535,18 @@ class Module(DescribableEntity, SoftwareEnvironmentReference):
             "named label."
         ),
     )
+    provides: Optional[Dict[str, str]] = Field(
+        None,
+        description=(
+            "Explicit benchmark-local label bindings for this module. Maps "
+            "label name → value, for labels its stage advertises via "
+            "`Stage.provides`. This is the recommended way to source a label "
+            "value: it keeps routing out of the module's CLI parameter "
+            "contract, so the same module stays reusable across benchmarks "
+            "with different label vocabularies. When a label has no binding "
+            "here, it defaults to the module id. Requires api_version ≥ 0.6.0."
+        ),
+    )
     resources: Optional[Resources] = Field(
         None,
         description="Resource requirements (overrides stage-level resources)",
@@ -595,6 +614,18 @@ class Stage(DescribableEntity):
     modules: List[Module] = Field(..., description="Modules in this stage")
     inputs: Optional[List[InputCollection]] = Field(None, description="Stage inputs")
     outputs: List[IOFile] = Field(..., description="Stage outputs")
+    provides: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Lineage labels this stage advertises to downstream modules. For "
+            "each label, every node of this stage carries a value, taken from "
+            "the module's `provides` binding if present, otherwise the module "
+            "id. Downstream modules gate on these labels via `requires:`; "
+            "non-matching execution paths prune at DAG-construction time. The "
+            "builtin labels `name` and `dataset` are reserved and may not be "
+            "declared here. Requires api_version ≥ 0.6.0."
+        ),
+    )
     resources: Optional[Resources] = Field(
         None, description="Resource requirements for rules in this stage"
     )
@@ -1304,6 +1335,38 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
                 for collector in self.metric_collectors:
                     if collector.software_environment is None:
                         collector.software_environment = sole_env_id
+
+        # Gate api_version-introduced fields. `Stage.provides` and
+        # `Module.provides` were introduced in 0.6.0 and must not be used by
+        # older specs.
+        if self.api_version < APIVersion.V0_6_0:
+            for stage in self.stages:
+                if stage.provides:
+                    raise ValueError(
+                        f"Stage '{stage.id}' uses `provides`, which requires "
+                        f"api_version ≥ 0.6.0 (this benchmark declares "
+                        f"{self.api_version.value})."
+                    )
+                for module in stage.modules:
+                    if module.provides:
+                        raise ValueError(
+                            f"Module '{module.id}' uses `provides`, which "
+                            f"requires api_version ≥ 0.6.0 (this benchmark "
+                            f"declares {self.api_version.value})."
+                        )
+
+        # The runtime auto-populates `name` (current module id) and `dataset`
+        # (root dataset identity) on every node; letting a stage advertise
+        # either would silently clobber the user's value and make a downstream
+        # `requires:` gate on an accident of propagation. See 008 §3.5.
+        for stage in self.stages:
+            for label in stage.provides or []:
+                if label in _RESERVED_PROVIDES_LABELS:
+                    raise ValueError(
+                        f"Stage '{stage.id}' declares reserved label "
+                        f"'{label}' in `provides`. '{label}' is a builtin "
+                        f"populated by the runtime; choose another name."
+                    )
 
         # Call the pure model validation from the validator base class
         self.validate_model_structure()

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -20,6 +20,7 @@ from pydantic import (
 )
 
 from omnibenchmark.model._merge import merge_dict_list
+from omnibenchmark.versioning.version import Version
 
 from ._parsing import convert_pydantic_error_to_parse_error
 from .params import Params
@@ -138,6 +139,33 @@ class APIVersion(str, Enum):
     @classmethod
     def supported_versions(cls) -> set[str]:
         return {version.value for version in cls}
+
+    # Version gates compare with <, <=, >=. Inherited from str those are
+    # lexicographic, which would order "0.10.0" before "0.6.0"; delegate to
+    # the semantic Version instead.
+    @property
+    def _semver(self) -> Version:
+        return Version(self.value)
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, APIVersion):
+            return NotImplemented
+        return self._semver < other._semver
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, APIVersion):
+            return NotImplemented
+        return self._semver <= other._semver
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, APIVersion):
+            return NotImplemented
+        return self._semver > other._semver
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, APIVersion):
+            return NotImplemented
+        return self._semver >= other._semver
 
 
 # Labels the runtime populates on every node; a stage may not advertise these

--- a/tests/benchmark/test_mermaid.py
+++ b/tests/benchmark/test_mermaid.py
@@ -65,10 +65,13 @@ def _stage(sid, modules, inputs=None, output_id=None):
     block += [_module(mid, params) for mid, params in modules]
     if inputs is not None:
         block.append("    inputs:")
-        for group in inputs:
-            if len(group) == 1:
-                block.append(f"      - {group[0]}")
-            else:
+        if len(inputs) == 1:
+            # Flat-list form: a single group is just a list of output ids.
+            block += [f"      - {e}" for e in inputs[0]]
+        else:
+            # Several groups have no flat spelling; only `entries:` (deprecated)
+            # can express them.
+            for group in inputs:
                 block.append("      - entries:")
                 block += [f"          - {e}" for e in group]
     block.append("    outputs:")

--- a/tests/cli/test_create_module_with_stage.py
+++ b/tests/cli/test_create_module_with_stage.py
@@ -13,7 +13,7 @@ def sample_benchmark_yaml(tmp_path):
 description: Test benchmark for module creation
 version: "1.0"
 benchmarker: "Test Suite"
-benchmark_yaml_spec: 0.3
+benchmark_yaml_spec: "0.3.0"
 software_backend: host
 
 software_environments:

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -21,6 +21,7 @@ from omnibenchmark.cli.run import (
     _capability_prune_summary,
     _select_capable_modules,
     _resolve_label_value,
+    _empty_stage_warning,
     _apply_until_filter,
     _filter_collectors_by_stages,
     run,
@@ -1379,6 +1380,26 @@ def test_run_benchmark_remote_storage_true_bool_appended(tmp_path):
         _, kwargs = mock_snakemake.call_args
         extra = kwargs["extra_snakemake_args"]
         assert "--use-conda" in extra
+
+
+# ---------------------------------------------------------------------------
+# _empty_stage_warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestEmptyStageWarning:
+    def test_attempted_combinations_blame_the_filters(self):
+        msg = _empty_stage_warning("methods", combinations_seen=4)
+        assert "'methods'" in msg
+        assert "pruned by a filter (requires/exclude)" in msg
+
+    def test_no_combinations_blames_the_input_wiring(self):
+        """Zero combinations means nothing was generated to prune; pointing at
+        requires/exclude would send the user to the wrong part of the YAML."""
+        msg = _empty_stage_warning("methods", combinations_seen=0)
+        assert "no upstream output matched its declared inputs" in msg
+        assert "filter" not in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -20,6 +20,7 @@ from omnibenchmark.cli.run import (
     _module_capabilities_met,
     _capability_prune_summary,
     _select_capable_modules,
+    _resolve_label_value,
     _apply_until_filter,
     _filter_collectors_by_stages,
     run,
@@ -181,6 +182,26 @@ class TestSubstituteParamsInPath:
 
 
 # ---------------------------------------------------------------------------
+# _resolve_label_value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestResolveLabelValue:
+    def test_module_binding_wins(self):
+        assert _resolve_label_value("size", {"size": "lg"}, "M1") == "lg"
+
+    def test_defaults_to_module_id_when_no_binding(self):
+        assert _resolve_label_value("size", None, "M1") == "M1"
+
+    def test_defaults_to_module_id_when_label_absent_from_binding(self):
+        assert _resolve_label_value("size", {"other": "x"}, "M1") == "M1"
+
+    def test_non_string_binding_coerced(self):
+        assert _resolve_label_value("n", {"n": 3}, "M1") == "3"
+
+
+# ---------------------------------------------------------------------------
 # _build_template_context
 # ---------------------------------------------------------------------------
 
@@ -215,11 +236,20 @@ class TestBuildTemplateContext:
         ctx = _build_template_context(stage, "D1", params=p)
         assert ctx.provides["dataset"] == "pbmc3k"
 
-    def test_root_node_provides_label_from_params(self):
+    def test_root_node_provides_label_from_module_binding(self):
+        stage = _make_stage("data", provides=["treatment"])
+        ctx = _build_template_context(
+            stage, "D1", module_provides={"treatment": "ctrl"}
+        )
+        assert ctx.provides["treatment"] == "ctrl"
+
+    def test_root_node_provides_label_ignores_same_named_param(self):
+        # The parameter-name fallback was cut: a same-named param must NOT
+        # become the label value (see 008 §3.5). Falls through to module id.
         stage = _make_stage("data", provides=["treatment"])
         p = Params({"treatment": "ctrl"})
         ctx = _build_template_context(stage, "D1", params=p)
-        assert ctx.provides["treatment"] == "ctrl"
+        assert ctx.provides["treatment"] == "D1"
 
     def test_root_node_provides_label_defaults_to_module_id(self):
         stage = _make_stage("data", provides=["treatment"])
@@ -255,16 +285,19 @@ class TestBuildTemplateContext:
         ctx = _build_template_context(stage, "M1", input_node=input_node)
         assert ctx.provides["method"] == "M1"
 
-    def test_child_node_provides_label_from_params(self):
+    def test_child_node_provides_label_from_module_binding(self):
         parent_ctx = TemplateContext(
             provides={"dataset": "pbmc3k"},
             module_attrs={"id": "D1", "stage": "data"},
         )
         input_node = _make_input_node("D1", "data", template_context=parent_ctx)
         stage = _make_stage("methods", provides=["method"])
-        p = Params({"method": "kmeans"})
-        ctx = _build_template_context(stage, "M1", input_node=input_node, params=p)
+        ctx = _build_template_context(
+            stage, "M1", input_node=input_node, module_provides={"method": "kmeans"}
+        )
         assert ctx.provides["method"] == "kmeans"
+        # parent lineage labels still inherited
+        assert ctx.provides["dataset"] == "pbmc3k"
 
     # --- {name} template variable: always the current module's own ID ---
 

--- a/tests/e2e/configs/11_lineage_provides.yaml
+++ b/tests/e2e/configs/11_lineage_provides.yaml
@@ -1,0 +1,61 @@
+id: LinearArithmeticWithLineageProvides
+description: Lineage gating via Stage.provides + Module.provides + Module.requires
+version: "1.0"
+benchmarker: "E2E Test Suite"
+api_version: "0.6.0"
+software_backend: host
+
+software_environments:
+  host:
+    description: "Host environment for direct execution"
+
+stages:
+  - id: data
+    provides: [dataset_size]
+    modules:
+      - id: small
+        name: "Small dataset"
+        software_environment: "host"
+        # Recommended form: explicit benchmark-local label binding,
+        # no pollution of the module's CLI parameter contract.
+        provides:
+          dataset_size: "sm"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - evaluate: "1+1"
+
+      - id: huge
+        name: "Huge dataset"
+        software_environment: "host"
+        provides:
+          dataset_size: "lg"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - evaluate: "9+9"
+    outputs:
+      - id: data.raw
+        path: "{dataset}_data.json"
+
+  - id: methods
+    inputs:
+      - data.raw
+    modules:
+      - id: M_lg_only
+        name: "Method that only runs on large datasets"
+        software_environment: "host"
+        requires:
+          dataset_size: "lg"
+        repository:
+          url: bundles/dummymodule_4ff8427.bundle
+          commit: 4ff8427
+        parameters:
+          - evaluate: "input+10"
+            input: "data.raw"
+            kind: "method"
+    outputs:
+      - id: methods.result
+        path: "{dataset}_method.json"

--- a/tests/e2e/configs/11_lineage_provides.yaml
+++ b/tests/e2e/configs/11_lineage_provides.yaml
@@ -2,7 +2,7 @@ id: LinearArithmeticWithLineageProvides
 description: Lineage gating via Stage.provides + Module.provides + Module.requires
 version: "1.0"
 benchmarker: "E2E Test Suite"
-api_version: "0.6.0"
+api_version: "0.7.0"
 software_backend: host
 
 software_environments:

--- a/tests/e2e/test_11_lineage_provides.py
+++ b/tests/e2e/test_11_lineage_provides.py
@@ -1,0 +1,64 @@
+"""E2E tests for `Stage.provides` → `Module.requires` lineage gating.
+
+Uses --dry to assert on the generated Snakefile rather than running
+modules; this avoids a quirk where the legacy dummy bundle's filename
+convention (--name = module_id) does not match path templates under
+api_version >= 0.5 for non-data stages. The lineage-gate behavior we
+care about (which rules are created vs pruned) is fully observable in
+the generated Snakefile.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def lineage_provides_config():
+    """Path to the lineage-gating benchmark config."""
+    return Path(__file__).parent / "configs" / "11_lineage_provides.yaml"
+
+
+def _read_snakefile(out_dir: Path) -> str:
+    snakefile = out_dir / "Snakefile"
+    assert snakefile.exists(), f"Snakefile not generated at {snakefile}"
+    return snakefile.read_text()
+
+
+@pytest.mark.e2e
+def test_requires_label_match_keeps_only_matching_lineage(
+    lineage_provides_config, tmp_path, bundled_repos, keep_files
+):
+    """`requires: {dataset_size: lg}` keeps only the `huge` execution path."""
+    from tests.e2e.common import E2ETestRunner
+
+    runner = E2ETestRunner(tmp_path, keep_files)
+    config_in_tmp = runner.setup_test_environment(
+        lineage_provides_config, "11_lineage_provides.yaml"
+    )
+
+    # --dry: generate Snakefile, do not execute.
+    runner.execute_cli_command(config_in_tmp, ["--dry"])
+
+    snakefile = _read_snakefile(runner.out_dir)
+
+    # Both data nodes must be present (the gate is downstream).
+    assert "data/small/" in snakefile, "small data rule missing"
+    assert "data/huge/" in snakefile, "huge data rule missing"
+
+    # The methods rule for the matching lineage must be present.
+    assert "methods/M_lg_only" in snakefile, "M_lg_only rule missing entirely"
+
+    # Critical: the methods rule must run only off the `huge` branch.
+    # Rule output paths nest the lineage; the small branch must not appear
+    # under any methods rule.
+    methods_lines = [
+        line for line in snakefile.splitlines() if "methods/M_lg_only" in line
+    ]
+    assert methods_lines, "expected at least one methods rule line"
+    huge_branch = any("huge" in line for line in methods_lines)
+    small_branch = any("/small/" in line for line in methods_lines)
+    assert huge_branch, f"M_lg_only should run on huge lineage; saw: {methods_lines}"
+    assert (
+        not small_branch
+    ), f"M_lg_only must NOT run on small lineage; saw: {methods_lines}"

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -107,6 +107,15 @@ class TestEnums:
         assert sorted(APIVersion) == list(APIVersion)
         assert APIVersion.latest() == sorted(APIVersion)[-1]
 
+    def test_api_version_ordering_against_str_raises(self):
+        """A bare str operand would silently fall back to str's order."""
+        with pytest.raises(TypeError, match="lexicographically"):
+            APIVersion.V0_6_0 < "0.10.0"
+        with pytest.raises(TypeError, match="lexicographically"):
+            "0.10.0" > APIVersion.V0_6_0
+        # Equality is unaffected; only ordering is.
+        assert APIVersion.V0_6_0 == "0.6.0"
+
     def test_software_backend_enum(self):
         """Test SoftwareBackendEnum."""
         assert SoftwareBackendEnum.host.value == "host"

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -416,13 +416,25 @@ class TestLineageProvides:
                 stages=[make_stage(id="data", provides=[reserved])],
             )
 
-    def test_module_binds_undeclared_label_rejected(self):
-        """A module cannot bind a label its stage does not advertise."""
-        bound = make_module(id="huge", provides={"dataset_size": "lg"})
+    @pytest.mark.parametrize(
+        "stage_provides",
+        [None, ["dataset_size"]],
+        ids=["stage-declares-nothing", "typo-in-module-key"],
+    )
+    def test_module_binds_undeclared_label_rejected(self, stage_provides):
+        """A module cannot bind a label its stage does not advertise.
+
+        The typo case is the dangerous one: `daataset_size` would resolve to
+        the module id instead, and the downstream `requires` gate would prune
+        with no diagnostic.
+        """
+        bound = make_module(id="huge", provides={"daataset_size": "lg"})
         with pytest.raises(ValueError, match="does not"):
             make_benchmark(
                 api_version=APIVersion.V0_6_0,
-                stages=[make_stage(id="data", modules=[bound])],
+                stages=[
+                    make_stage(id="data", provides=stage_provides, modules=[bound])
+                ],
             )
 
     def test_requires_on_initial_stage_rejected(self):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -83,14 +83,17 @@ class TestEnums:
         assert APIVersion.V0_2_0.value == "0.2.0"
         assert APIVersion.V0_3_0.value == "0.3.0"
         assert APIVersion.V0_4_0.value == "0.4.0"
+        assert APIVersion.V0_5_0.value == "0.5.0"
+        assert APIVersion.V0_6_0.value == "0.6.0"
 
-        assert APIVersion.latest() == "0.5.0"
+        assert APIVersion.latest() == "0.6.0"
         assert set(APIVersion.supported_versions()) == {
             "0.1.0",
             "0.2.0",
             "0.3.0",
             "0.4.0",
             "0.5.0",
+            "0.6.0",
         }
 
     def test_software_backend_enum(self):
@@ -331,6 +334,67 @@ class TestCoreEntities:
         collector = make_metric_collector(software_environment="env1")
         assert collector.has_environment_reference("env1") is True
         assert collector.has_environment_reference("env2") is False
+
+
+# Test lineage provides/requires (api 0.6)
+@pytest.mark.short
+class TestLineageProvides:
+    def test_stage_provides_default_none(self):
+        """A stage without `provides` parses with the field unset."""
+        stage = make_stage(id="data")
+        assert stage.provides is None
+
+    def test_module_provides_default_none(self):
+        """A module without `provides` parses with the field unset."""
+        module = make_module(id="no_labels")
+        assert module.provides is None
+
+    def test_stage_provides_list(self):
+        """`Stage.provides` is parsed as a list of label names."""
+        stage = make_stage(id="data", provides=["dataset_size"])
+        assert stage.provides == ["dataset_size"]
+
+    def test_module_provides_dict(self):
+        """`Module.provides` is parsed as a label→value dict."""
+        module = make_module(id="huge", provides={"dataset_size": "lg"})
+        assert module.provides == {"dataset_size": "lg"}
+
+    def test_stage_provides_rejected_below_v0_6(self):
+        """`Stage.provides` is gated on api_version ≥ 0.6.0."""
+        with pytest.raises(ValueError, match="provides"):
+            make_benchmark(
+                api_version=APIVersion.V0_5_0,
+                stages=[make_stage(id="data", provides=["dataset_size"])],
+            )
+
+    def test_module_provides_rejected_below_v0_6(self):
+        """`Module.provides` is gated on api_version ≥ 0.6.0."""
+        bound = make_module(id="huge", provides={"dataset_size": "lg"})
+        with pytest.raises(ValueError, match="provides"):
+            make_benchmark(
+                api_version=APIVersion.V0_5_0,
+                stages=[make_stage(id="data", modules=[bound])],
+            )
+
+    def test_provides_accepted_at_v0_6(self):
+        """At api_version 0.6.0 both producer and binding are accepted."""
+        bound = make_module(id="huge", provides={"dataset_size": "lg"})
+        bench = make_benchmark(
+            api_version=APIVersion.V0_6_0,
+            stages=[make_stage(id="data", provides=["dataset_size"], modules=[bound])],
+        )
+        data_stage = bench.stages[0]
+        assert data_stage.provides == ["dataset_size"]
+        assert data_stage.modules[0].provides == {"dataset_size": "lg"}
+
+    @pytest.mark.parametrize("reserved", ["name", "dataset"])
+    def test_reserved_label_rejected(self, reserved):
+        """A stage may not advertise the builtin `name`/`dataset` labels."""
+        with pytest.raises(ValueError, match="reserved"):
+            make_benchmark(
+                api_version=APIVersion.V0_6_0,
+                stages=[make_stage(id="data", provides=[reserved])],
+            )
 
 
 # Test Benchmark

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -84,6 +84,7 @@ class TestEnums:
         assert APIVersion.V0_3_0.value == "0.3.0"
         assert APIVersion.V0_4_0.value == "0.4.0"
         assert APIVersion.V0_5_0.value == "0.5.0"
+        assert APIVersion.V0_6_0.value == "0.6.0"
         assert APIVersion.V0_7_0.value == "0.7.0"
 
         assert APIVersion.latest() == "0.7.0"
@@ -93,6 +94,7 @@ class TestEnums:
             "0.3.0",
             "0.4.0",
             "0.5.0",
+            "0.6.0",
             "0.7.0",
         }
 
@@ -379,20 +381,22 @@ class TestLineageProvides:
         module = make_module(id="huge", provides={"dataset_size": "lg"})
         assert module.provides == {"dataset_size": "lg"}
 
-    def test_stage_provides_rejected_below_v0_7(self):
+    @pytest.mark.parametrize("older", [APIVersion.V0_5_0, APIVersion.V0_6_0])
+    def test_stage_provides_rejected_below_v0_7(self, older):
         """`Stage.provides` is gated on api_version ≥ 0.7.0."""
         with pytest.raises(ValueError, match="provides"):
             make_benchmark(
-                api_version=APIVersion.V0_5_0,
+                api_version=older,
                 stages=[make_stage(id="data", provides=["dataset_size"])],
             )
 
-    def test_module_provides_rejected_below_v0_7(self):
+    @pytest.mark.parametrize("older", [APIVersion.V0_5_0, APIVersion.V0_6_0])
+    def test_module_provides_rejected_below_v0_7(self, older):
         """`Module.provides` is gated on api_version ≥ 0.7.0."""
         bound = make_module(id="huge", provides={"dataset_size": "lg"})
         with pytest.raises(ValueError, match="provides"):
             make_benchmark(
-                api_version=APIVersion.V0_5_0,
+                api_version=older,
                 stages=[make_stage(id="data", modules=[bound])],
             )
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -96,6 +96,17 @@ class TestEnums:
             "0.6.0",
         }
 
+    def test_api_version_ordering_is_semantic(self):
+        """Version gates order by components, not lexicographically."""
+        assert APIVersion.V0_5_0 < APIVersion.V0_6_0
+        assert APIVersion.V0_6_0 >= APIVersion.V0_5_0
+        assert not APIVersion.V0_6_0 <= APIVersion.V0_5_0
+        # Members are declared ascending. Once a two-digit minor exists
+        # ("0.10.0"), str's lexicographic order sorts it before "0.6.0" and
+        # this breaks; semantic ordering keeps it last.
+        assert sorted(APIVersion) == list(APIVersion)
+        assert APIVersion.latest() == sorted(APIVersion)[-1]
+
     def test_software_backend_enum(self):
         """Test SoftwareBackendEnum."""
         assert SoftwareBackendEnum.host.value == "host"

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -84,25 +84,25 @@ class TestEnums:
         assert APIVersion.V0_3_0.value == "0.3.0"
         assert APIVersion.V0_4_0.value == "0.4.0"
         assert APIVersion.V0_5_0.value == "0.5.0"
-        assert APIVersion.V0_6_0.value == "0.6.0"
+        assert APIVersion.V0_7_0.value == "0.7.0"
 
-        assert APIVersion.latest() == "0.6.0"
+        assert APIVersion.latest() == "0.7.0"
         assert set(APIVersion.supported_versions()) == {
             "0.1.0",
             "0.2.0",
             "0.3.0",
             "0.4.0",
             "0.5.0",
-            "0.6.0",
+            "0.7.0",
         }
 
     def test_api_version_ordering_is_semantic(self):
         """Version gates order by components, not lexicographically."""
-        assert APIVersion.V0_5_0 < APIVersion.V0_6_0
-        assert APIVersion.V0_6_0 >= APIVersion.V0_5_0
-        assert not APIVersion.V0_6_0 <= APIVersion.V0_5_0
+        assert APIVersion.V0_5_0 < APIVersion.V0_7_0
+        assert APIVersion.V0_7_0 >= APIVersion.V0_5_0
+        assert not APIVersion.V0_7_0 <= APIVersion.V0_5_0
         # Members are declared ascending. Once a two-digit minor exists
-        # ("0.10.0"), str's lexicographic order sorts it before "0.6.0" and
+        # ("0.10.0"), str's lexicographic order sorts it before "0.7.0" and
         # this breaks; semantic ordering keeps it last.
         assert sorted(APIVersion) == list(APIVersion)
         assert APIVersion.latest() == sorted(APIVersion)[-1]
@@ -110,11 +110,11 @@ class TestEnums:
     def test_api_version_ordering_against_str_raises(self):
         """A bare str operand would silently fall back to str's order."""
         with pytest.raises(TypeError, match="lexicographically"):
-            APIVersion.V0_6_0 < "0.10.0"
+            APIVersion.V0_7_0 < "0.10.0"
         with pytest.raises(TypeError, match="lexicographically"):
-            "0.10.0" > APIVersion.V0_6_0
+            "0.10.0" > APIVersion.V0_7_0
         # Equality is unaffected; only ordering is.
-        assert APIVersion.V0_6_0 == "0.6.0"
+        assert APIVersion.V0_7_0 == "0.7.0"
 
     def test_software_backend_enum(self):
         """Test SoftwareBackendEnum."""
@@ -356,7 +356,7 @@ class TestCoreEntities:
         assert collector.has_environment_reference("env2") is False
 
 
-# Test lineage provides/requires (api 0.6)
+# Test lineage provides/requires (api 0.7)
 @pytest.mark.short
 class TestLineageProvides:
     def test_stage_provides_default_none(self):
@@ -379,16 +379,16 @@ class TestLineageProvides:
         module = make_module(id="huge", provides={"dataset_size": "lg"})
         assert module.provides == {"dataset_size": "lg"}
 
-    def test_stage_provides_rejected_below_v0_6(self):
-        """`Stage.provides` is gated on api_version ≥ 0.6.0."""
+    def test_stage_provides_rejected_below_v0_7(self):
+        """`Stage.provides` is gated on api_version ≥ 0.7.0."""
         with pytest.raises(ValueError, match="provides"):
             make_benchmark(
                 api_version=APIVersion.V0_5_0,
                 stages=[make_stage(id="data", provides=["dataset_size"])],
             )
 
-    def test_module_provides_rejected_below_v0_6(self):
-        """`Module.provides` is gated on api_version ≥ 0.6.0."""
+    def test_module_provides_rejected_below_v0_7(self):
+        """`Module.provides` is gated on api_version ≥ 0.7.0."""
         bound = make_module(id="huge", provides={"dataset_size": "lg"})
         with pytest.raises(ValueError, match="provides"):
             make_benchmark(
@@ -396,11 +396,11 @@ class TestLineageProvides:
                 stages=[make_stage(id="data", modules=[bound])],
             )
 
-    def test_provides_accepted_at_v0_6(self):
-        """At api_version 0.6.0 both producer and binding are accepted."""
+    def test_provides_accepted_at_v0_7(self):
+        """At api_version 0.7.0 both producer and binding are accepted."""
         bound = make_module(id="huge", provides={"dataset_size": "lg"})
         bench = make_benchmark(
-            api_version=APIVersion.V0_6_0,
+            api_version=APIVersion.V0_7_0,
             stages=[make_stage(id="data", provides=["dataset_size"], modules=[bound])],
         )
         data_stage = bench.stages[0]
@@ -412,7 +412,7 @@ class TestLineageProvides:
         """A stage may not advertise the builtin `name`/`dataset` labels."""
         with pytest.raises(ValueError, match="reserved"):
             make_benchmark(
-                api_version=APIVersion.V0_6_0,
+                api_version=APIVersion.V0_7_0,
                 stages=[make_stage(id="data", provides=[reserved])],
             )
 
@@ -431,7 +431,7 @@ class TestLineageProvides:
         bound = make_module(id="huge", provides={"daataset_size": "lg"})
         with pytest.raises(ValueError, match="does not"):
             make_benchmark(
-                api_version=APIVersion.V0_6_0,
+                api_version=APIVersion.V0_7_0,
                 stages=[
                     make_stage(id="data", provides=stage_provides, modules=[bound])
                 ],
@@ -442,7 +442,7 @@ class TestLineageProvides:
         gated = make_module(id="pca", requires={"dataset_size": "lg"})
         with pytest.raises(ValueError, match="initial stage"):
             make_benchmark(
-                api_version=APIVersion.V0_6_0,
+                api_version=APIVersion.V0_7_0,
                 stages=[make_stage(id="data", modules=[gated])],
             )
 
@@ -450,7 +450,7 @@ class TestLineageProvides:
         """The same gate one stage later, where lineage exists, is fine."""
         gated = make_module(id="pca", requires={"dataset_size": "lg"})
         bench = make_benchmark(
-            api_version=APIVersion.V0_6_0,
+            api_version=APIVersion.V0_7_0,
             stages=[
                 make_stage(
                     id="data",

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -396,6 +396,46 @@ class TestLineageProvides:
                 stages=[make_stage(id="data", provides=[reserved])],
             )
 
+    def test_module_binds_undeclared_label_rejected(self):
+        """A module cannot bind a label its stage does not advertise."""
+        bound = make_module(id="huge", provides={"dataset_size": "lg"})
+        with pytest.raises(ValueError, match="does not"):
+            make_benchmark(
+                api_version=APIVersion.V0_6_0,
+                stages=[make_stage(id="data", modules=[bound])],
+            )
+
+    def test_requires_on_initial_stage_rejected(self):
+        """`requires` in a stage with no inputs has no lineage to match."""
+        gated = make_module(id="pca", requires={"dataset_size": "lg"})
+        with pytest.raises(ValueError, match="initial stage"):
+            make_benchmark(
+                api_version=APIVersion.V0_6_0,
+                stages=[make_stage(id="data", modules=[gated])],
+            )
+
+    def test_requires_on_downstream_stage_accepted(self):
+        """The same gate one stage later, where lineage exists, is fine."""
+        gated = make_module(id="pca", requires={"dataset_size": "lg"})
+        bench = make_benchmark(
+            api_version=APIVersion.V0_6_0,
+            stages=[
+                make_stage(
+                    id="data",
+                    provides=["dataset_size"],
+                    modules=[make_module(id="huge", provides={"dataset_size": "lg"})],
+                    outputs=[make_iofile(id="data.counts", path="counts.txt")],
+                ),
+                make_stage(
+                    id="process",
+                    inputs=[["data.counts"]],
+                    modules=[gated],
+                    outputs=[make_iofile(id="process.out", path="out.txt")],
+                ),
+            ],
+        )
+        assert bench.stages[1].modules[0].requires == {"dataset_size": "lg"}
+
 
 # Test Benchmark
 @pytest.mark.short

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -682,10 +682,10 @@ stages:
           commit: "abc123"
         outputs:
           - id: "cleaned_data"
-            path: "output/cleaned.csv"
+            path: "cleaned.csv"
     outputs:
       - id: "cleaned_data"
-        path: "output/cleaned.csv"
+        path: "cleaned.csv"
 metric_collectors:
   - id: performance_metrics
     name: "Performance Metrics"
@@ -695,7 +695,7 @@ metric_collectors:
       commit: "ghi789"
     inputs:
       - id: "cleaned_data"
-        path: "output/cleaned.csv"
+        path: "cleaned.csv"
     outputs:
       - id: "metrics_report"
         path: "metrics/report.html"

--- a/tests/model/test_validation_consistency.py
+++ b/tests/model/test_validation_consistency.py
@@ -53,6 +53,9 @@ class TestValidationConsistency:
         error_msg = str(exc_info.value)
         assert "not valid" in error_msg.lower()
 
+    # An absolute path also contains '/', so it trips the full-path
+    # deprecation on its way to the rejection under test.
+    @pytest.mark.filterwarnings("ignore:Output path")
     def test_validate_absolute_paths(self):
         """Test that absolute paths are rejected."""
         invalid_data = make_invalid_benchmark_for_testing("absolute_path")
@@ -204,6 +207,7 @@ class TestValidationConsistency:
         )
         assert host_benchmark.software_backend.value == "host"
 
+    @pytest.mark.filterwarnings("ignore:Output path")
     def test_file_path_validation(self):
         """Test file path validation rules."""
         # Valid relative paths

--- a/tests/model/test_version_validation.py
+++ b/tests/model/test_version_validation.py
@@ -141,8 +141,9 @@ class TestVersionValidation:
             1  # Integer should be converted to "1" and then rejected
         )
 
-        with pytest.raises(ValidationError) as exc_info:
-            Benchmark(**benchmark_data)
+        with pytest.warns(FutureWarning, match="Field 'version' should be a string"):
+            with pytest.raises(ValidationError) as exc_info:
+                Benchmark(**benchmark_data)
         # After conversion to "1", it should fail semantic versioning validation
         assert "does not follow strict semantic versioning" in str(exc_info.value)
 


### PR DESCRIPTION
## Ticket

#360

Follow-up on #361 (should be rebased on top of that one when it lands in main; getting 361 as base to avoid reviewing the same code).

## Description


Declares the producer side of the provides/requires lineage gate: 

- stage.provides: list[str] — labels this stage advertises downstream.
- Module.provides: dict[str, str] — explicit per-module label bindings

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

## Remarks for the reviewer:

Leave here some remarks for the reviewer.