### PR TITLE
fix: ob status --logs now shows logs for failed rules (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - fix: expand stages in topological order so a stage declared before an upstream-only producer resolves instead of failing with an opaque `Could not resolve input <id>` at run time (#289)
 - feat: `ob validate plan` rejects "diamond" input joins — a stage collecting inputs from two divergent branches (neither upstream of the other) — with an actionable error that names both branch stages, instead of surfacing only as a runtime warning (#289)
 - fix(pkg): give all authors emails so PyPI lists them correctly instead of partitioning name-only entries into the Author field
+- bug: make status --logs display logs for failed rules (#318)
 
 ## [0.5.3](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.3) (Jun 15th 2026)
 

--- a/omnibenchmark/backend/snakemake.py
+++ b/omnibenchmark/backend/snakemake.py
@@ -26,6 +26,7 @@ from typing import List, TextIO
 from omnibenchmark.core._paths import (
     _UNSAFE_CHARS,
     make_human_name as _make_human_name,
+    sanitize_rule_name,
     truncate_filename,
 )
 from omnibenchmark.model.benchmark import APIVersion
@@ -216,10 +217,7 @@ class SnakemakeGenerator:
 
     def _sanitize_rule_name(self, node_id: str) -> str:
         """Sanitize node ID to a valid Snakemake rule name (Python identifier)."""
-        name = node_id.replace("-", "_").replace(".", "_")
-        if name and not name[0].isalpha():
-            name = "rule_" + name
-        return name
+        return sanitize_rule_name(node_id)
 
     # ------------------------------------------------------------------
     # Shell writers — override in subclasses to change generated commands

--- a/omnibenchmark/cli/describe.py
+++ b/omnibenchmark/cli/describe.py
@@ -233,7 +233,7 @@ def status(
             ),
             result_file_str=result_file_str,
             show_incomplete_reason=show_incomplete_reason and not is_complete,
-            show_missing_files=show_missing_files and not is_complete,
+            show_missing_files=(show_missing_files or show_logs) and not is_complete,
         )
         logger.info(result_str)
         sys.exit(0)
@@ -256,10 +256,8 @@ def status(
                 node_key = (st, eps.node.get_id())
                 if node_key not in logs_by_node:
                     logs = []
-                    if eps.stdout_log is not None:
-                        logs.append(str(Path(eps.stdout_log).absolute()))
-                    if eps.stderr_log is not None:
-                        logs.append(str(Path(eps.stderr_log).absolute()))
+                    if eps.log is not None:
+                        logs.append(str(Path(eps.log).absolute()))
                     logs_by_node[node_key] = logs
 
         # Collect file status for each node

--- a/omnibenchmark/core/_paths.py
+++ b/omnibenchmark/core/_paths.py
@@ -63,6 +63,19 @@ def truncate_filename(name: str, limit: int = MAX_FILENAME_LEN) -> str:
     return stem[:keep] + sep + digest + suffix
 
 
+def sanitize_rule_name(node_id: str) -> str:
+    """Sanitize a node ID into a valid Snakemake rule name (Python identifier).
+
+    Shared by the Snakefile generator (which names each rule's ``log:`` file)
+    and the status reporter (which locates those log files), so the two stay in
+    lockstep.
+    """
+    name = node_id.replace("-", "_").replace(".", "_")
+    if name and not name[0].isalpha():
+        name = "rule_" + name
+    return name
+
+
 _UNSAFE_CHARS = ["/", "\\", ":", "*", "?", '"', "<", ">", "|", " "]
 
 

--- a/omnibenchmark/core/execution_path.py
+++ b/omnibenchmark/core/execution_path.py
@@ -372,11 +372,11 @@ class ExecutionPathStage:
             )
         )
 
-        # TODO: check if log file is newer than input files, can be both newer or older than output files
-        stdout_log = Path(self.output_dir) / "stdout.log"
-        self.stdout_log = stdout_log if stdout_log.is_file() else None
-        stderr_log = Path(self.output_dir) / "stderr.log"
-        self.stderr_log = stderr_log if stderr_log.is_file() else None
+        # Path to this node's combined stdout/stderr log, as written by the
+        # Snakemake backend at "{out_dir}/.logs/{rule_name}.log".  Populated by
+        # the owning ExecutionPath once the full ancestor chain (hence the rule
+        # name) is known; None when the log file does not exist on disk.
+        self.log: Union[Path, None] = None
 
     def update(self):
         for f in self.output_stage_files:
@@ -666,19 +666,11 @@ class ExecutionPath:
 
     def remove_logs(self):
         """
-        Remove stdout and stderr log files for all stages.
+        Remove the log file for all stages.
         """
         for st in self.stages:
-            if (
-                self.exec_path[st].stdout_log
-                and self.exec_path[st].stdout_log.is_file()
-            ):
-                self.exec_path[st].stdout_log.unlink()
-            if (
-                self.exec_path[st].stderr_log
-                and self.exec_path[st].stderr_log.is_file()
-            ):
-                self.exec_path[st].stderr_log.unlink()
+            if self.exec_path[st].log and self.exec_path[st].log.is_file():
+                self.exec_path[st].log.unlink()
 
 
 # repo_timestamps_all = get_module_timestamps(b)

--- a/omnibenchmark/core/status/status.py
+++ b/omnibenchmark/core/status/status.py
@@ -1,9 +1,34 @@
 from pathlib import Path
 from typing import Union
+from omnibenchmark.core._paths import sanitize_rule_name, truncate_filename
 from omnibenchmark.core.execution_path import (
     ExecutionPathSet,
 )
 from omnibenchmark.core import BenchmarkExecution
+
+
+def _attach_log_paths(exec_path_dict: dict, out_dir: Union[str, Path]) -> None:
+    """Populate ``ExecPathStage.log`` for every stage in every execution path.
+
+    The Snakemake backend writes each node's combined log to
+    ``{out_dir}/.logs/{rule_name}.log``, where ``rule_name`` is the sanitized,
+    fully-nested node id (ancestor chain joined by '-').  We rebuild that same id
+    here so status can point at the real files; the attribute is left as the
+    resolved Path only when the file exists, else None.
+    """
+    logs_dir = Path(out_dir) / ".logs"
+    for ep in exec_path_dict.values():
+        nested_id = ""
+        for st in ep.stages:
+            node = ep.exec_path[st].node
+            param_id = node.param_id
+            suffix = param_id if param_id.startswith(".") else f".{param_id}"
+            segment = f"{node.stage_id}-{node.module_id}{suffix}"
+            nested_id = f"{nested_id}-{segment}" if nested_id else segment
+            log_file = logs_dir / truncate_filename(
+                f"{sanitize_rule_name(nested_id)}.log"
+            )
+            ep.exec_path[st].log = log_file if log_file.is_file() else None
 
 
 def print_exec_path_dict(
@@ -30,7 +55,7 @@ def print_exec_path_dict(
     nmissls = []
     for i in range(len(exec_path_dict)):
         outls2 = []
-        tmps1, nmiss, is_failed_stage = exec_path_dict[i].dict_encode(
+        tmps1, nmiss, _ = exec_path_dict[i].dict_encode(
             full=full, cumulative=True, stages=stages
         )
         outls2.append(tmps1)
@@ -50,11 +75,12 @@ def print_exec_path_dict(
 
         if logs:
             tmps2 = ""
-            if is_failed_stage is not None:
-                if exec_path_dict[i].exec_path[st].stdout_log is not None:
-                    tmps2 += f"\n        STDOUT: {exec_path_dict[i].exec_path[st].stdout_log.as_posix()}"
-                if exec_path_dict[i].exec_path[st].stderr_log is not None:
-                    tmps2 += f"\n        STDERR: {exec_path_dict[i].exec_path[st].stderr_log.as_posix()}"
+            # Show the log for every stage with a missing/invalid output (a
+            # non-"." per-stage code), not just the first failed one.
+            for st_id in exec_path_dict[i].stages:
+                stage = exec_path_dict[i].exec_path[st_id]
+                if stage.dict_encode(full=full) != "." and stage.log is not None:
+                    tmps2 += f"\n        LOG ({st_id}): {stage.log.as_posix()}"
             logls.append(tmps2)
         outls.append(outls2)
 
@@ -111,6 +137,7 @@ def prepare_status(
 
     stages = eps.stages
     exec_path_dict = eps.exec_path_dict
+    _attach_log_paths(exec_path_dict, out_dir)
     filedict2 = eps.get_filedict(cumulative=True)
 
     status_dict = {}

--- a/tests/status/test_status_logs.py
+++ b/tests/status/test_status_logs.py
@@ -1,0 +1,139 @@
+"""Regression tests for `ob describe status ... --logs` (issue #318).
+
+The status reporter used to look for ``stdout.log``/``stderr.log`` inside each
+node's *output* directory, but the Snakemake backend actually writes a single
+combined log to ``{out_dir}/.logs/{rule_name}.log`` where ``rule_name`` is the
+sanitized, fully-nested node id.  As a result ``--logs`` never showed anything.
+
+These tests pin the status side to the backend's naming and exercise the
+log-selection logic in ``print_exec_path_dict``.
+"""
+
+from types import SimpleNamespace
+
+from omnibenchmark.backend.snakemake import SnakemakeGenerator
+from omnibenchmark.core._paths import sanitize_rule_name
+from omnibenchmark.core.status.status import (
+    _attach_log_paths,
+    print_exec_path_dict,
+)
+
+
+def _node(stage_id, module_id, param_id):
+    return SimpleNamespace(
+        stage_id=stage_id,
+        module_id=module_id,
+        param_id=param_id,
+        parameters=None,
+    )
+
+
+class _FakeStage:
+    """Minimal stand-in for ExecutionPathStage."""
+
+    def __init__(self, node, code, output_file="out/x"):
+        self.node = node
+        self._code = code
+        self.log = None
+        self._output_file = output_file
+
+    def dict_encode(self, full=False, cumulative=False):
+        return self._code
+
+    def get_output_files(self, *a, **k):
+        return [self._output_file]
+
+
+class _FakeExecPath:
+    """Minimal stand-in for ExecutionPath."""
+
+    def __init__(self, stage_nodes):
+        # stage_nodes: list of (stage_id, _FakeStage)
+        self.stages = [s for s, _ in stage_nodes]
+        self.exec_path = {s: st for s, st in stage_nodes}
+
+    def dict_encode(self, full=False, cumulative=False, stages=None):
+        codes = "".join(self.exec_path[s].dict_encode() for s in self.stages)
+        nmiss = sum(1 for c in codes if c != ".")
+        first_failed = next(
+            (s for s in self.stages if self.exec_path[s].dict_encode() != "."),
+            None,
+        )
+        return codes, nmiss, first_failed
+
+
+def _build_path(specs):
+    """specs: list of (stage, module, param_id, code) -> _FakeExecPath."""
+    return _FakeExecPath(
+        [(st, _FakeStage(_node(st, mod, pid), code)) for st, mod, pid, code in specs]
+    )
+
+
+def test_attach_log_paths_matches_backend_naming(tmp_path):
+    """The reconstructed log file equals the backend's sanitized nested id."""
+    logs_dir = tmp_path / ".logs"
+    logs_dir.mkdir()
+
+    # Two-stage path: a default-param dataset feeding a hashed-param method.
+    nested_id = "data-D1.default-methods-M1.17e49005"
+    rule_name = sanitize_rule_name(nested_id)
+    # Sanity: a hashed param must collapse to a single underscore, not two.
+    assert rule_name == "data_D1_default_methods_M1_17e49005"
+    # Pin to the backend's own sanitizer (the source of the on-disk filename).
+    assert rule_name == SnakemakeGenerator._sanitize_rule_name(
+        SnakemakeGenerator.__new__(SnakemakeGenerator), nested_id
+    )
+
+    (logs_dir / "data_D1_default.log").write_text("data log")
+    (logs_dir / f"{rule_name}.log").write_text("methods log")
+
+    ep = _build_path(
+        [("data", "D1", "default", "M"), ("methods", "M1", ".17e49005", "M")]
+    )
+    _attach_log_paths({0: ep}, tmp_path)
+
+    # The intermediate stage uses its own (un-nested) id.
+    assert ep.exec_path["data"].log == logs_dir / "data_D1_default.log"
+    # The downstream stage uses the full nested id (single-underscore hash).
+    assert ep.exec_path["methods"].log == logs_dir / f"{rule_name}.log"
+
+
+def test_attach_log_paths_missing_file_is_none(tmp_path):
+    (tmp_path / ".logs").mkdir()
+    ep = _build_path([("data", "D1", "default", "M")])
+    _attach_log_paths({0: ep}, tmp_path)
+    # No log file written -> attribute stays None.
+    assert ep.exec_path["data"].log is None
+
+
+def test_print_logs_shows_every_missing_stage(tmp_path):
+    """--logs lists a LOG line for *each* missing-output stage, not just one."""
+    stages = ["data", "methods", "metrics"]
+    ep = _build_path(
+        [
+            ("data", "D1", "default", "."),  # complete, no log expected
+            ("methods", "M1", "default", "M"),  # missing
+            ("metrics", "m1", "default", "M"),  # missing
+        ]
+    )
+    # Give the two failing stages real log paths.
+    ep.exec_path["methods"].log = tmp_path / "methods.log"
+    ep.exec_path["metrics"].log = tmp_path / "metrics.log"
+
+    out = print_exec_path_dict({0: ep}, stages, threshold_n_missing=1, logs=True)
+
+    assert "LOG (methods):" in out
+    assert "LOG (metrics):" in out
+    # The complete stage has no log line.
+    assert "LOG (data):" not in out
+
+
+def test_print_logs_off_emits_nothing(tmp_path):
+    stages = ["data", "methods"]
+    ep = _build_path(
+        [("data", "D1", "default", "."), ("methods", "M1", "default", "M")]
+    )
+    ep.exec_path["methods"].log = tmp_path / "methods.log"
+
+    out = print_exec_path_dict({0: ep}, stages, threshold_n_missing=1, logs=False)
+    assert "LOG (" not in out


### PR DESCRIPTION
## Ticket

#318 

## Description

### Problem

ob status --logs was supposed to print the log file path for any node whose output is missing or invalid, so you can jump straight to the failure. It never did — it always came up empty.

Two things were out of sync:

1. Wrong location. The status reporter looked for stdout.log / stderr.log inside each node's output directory. The Snakemake backend actually writes a single combined log to {out_dir}/.logs/{rule_name}.log, where rule_name is the sanitized, fully-nested node id. Those files never existed where status was looking.
2. Only the first failure. Even the dead code path only surfaced the first failed stage, not every stage with a missing/invalid output.

### Fix

- Point status at the real logs. New _attach_log_paths() rebuilds the same nested node id the backend uses and resolves {out_dir}/.logs/{rule_name}.log for every stage, attaching it as ExecPathStage.log (or None when the file isn't on disk).
- Keep the two sides in lockstep. The name-sanitization logic is extracted to a shared sanitize_rule_name() in core/_paths.py and used by both the Snakefile generator (which writes the log: path) and the status reporter (which locates it), so they can't drift apart. The path is also run through the same truncate_filename() the backend applies.
- Collapse stdout_log/stderr_log → a single log. Matches the backend's combined log file; remove_logs(), describe.py, and the status printer all updated.
- Show logs for all failed stages. The printer now emits a LOG (<stage>): line for every stage with a non-. per-stage code, not just the first.
- --logs implies --show-missing-files on incomplete runs, so the log lines have context.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.
