### PR TITLE
test: isolate global git cache to a per-session temp dir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,29 @@
 import io
+import os
+import shutil
+import tempfile
 
-import pytest
-import logging
+# Isolate the global omnibenchmark git cache from the developer's real cache and
+# from stale cross-run state.  The cache (normally ~/.cache/omnibenchmark/git) is
+# keyed partly by ephemeral tmp paths, so entries left by previous runs point at
+# deleted tmp dirs and can make `git` updates fail intermittently — surfacing as
+# flaky cli/e2e failures.  Redirecting XDG_CACHE_HOME to a fresh per-session dir
+# *before* omnibenchmark is imported (config freezes the cache path at import
+# time) fixes it for in-process code and for the CLI subprocesses that inherit
+# this environment.  Cleaned up in pytest_unconfigure.
+_TEST_XDG_CACHE_HOME = tempfile.mkdtemp(prefix="ob-test-xdg-cache-")
+os.environ["XDG_CACHE_HOME"] = _TEST_XDG_CACHE_HOME
 
-from pathlib import Path
-from .git_bundle import GitBundleManager
+import pytest  # noqa: E402
+import logging  # noqa: E402
+
+from pathlib import Path  # noqa: E402
+from .git_bundle import GitBundleManager  # noqa: E402
+
+
+def pytest_unconfigure(config):
+    """Remove the isolated git cache dir created at import time."""
+    shutil.rmtree(_TEST_XDG_CACHE_HOME, ignore_errors=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
The CLI git cache (~/.cache/omnibenchmark/git) is shared across all tests and across runs, and is keyed partly by ephemeral tmp paths. Stale entries from previous runs point at deleted tmp dirs, making git updates fail intermittently and surfacing as flaky cli/e2e failures. Redirect XDG_CACHE_HOME to a fresh per-session dir before omnibenchmark is imported (config freezes the cache path at import time), covering both in-process code and CLI subprocesses.
