### PR TITLE
fix: derive topology edges from declared inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 
 - feat: add opentelemetry support
 - feat: output path templates now support `{name}`, `{module.name}`, `{module.stage}`, and `{params.KEY}`; `{name}` always resolves to the current module's own ID (never inherited)
+- fix: properly render edges among stages based on I/O
 
 ## [0.5.3](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.3) (Jun 15th 2026)
 

--- a/omnibenchmark/core/_graph.py
+++ b/omnibenchmark/core/_graph.py
@@ -1,5 +1,6 @@
+from collections import defaultdict
 from pathlib import Path
-from typing import List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional
 
 from omnibenchmark.dag import (
     DiGraph,
@@ -110,6 +111,94 @@ def build_stage_dag(model: Benchmark) -> DiGraph:
                 g.add_edge(dep.id, stage.id)
 
     return g
+
+
+def stage_adjacency(model: Benchmark) -> List[Tuple[str, str, List[str]]]:
+    """Declared stage-to-stage topology edges.
+
+    Returns one ``(upstream_stage_id, stage_id, shared_output_ids)`` triple per
+    pair of stages where the downstream stage's declared inputs reference one or
+    more of the upstream stage's outputs. ``shared_output_ids`` is exactly those
+    outputs (sorted) — suitable for edge labels. Triples are ordered by
+    downstream stage, then by first appearance of the upstream stage in the
+    downstream stage's inputs.
+
+    This is the single source of truth for topology edges. It reads the model's
+    *declared* inputs directly (every upstream stage of an input group, not just
+    the topologically-latest one the execution DAG keeps for output-path
+    chaining), so it stays correct when an input group spans multiple stages.
+
+    Consumers:
+      * ``upstream_stage_ids`` / ``build_topology_dag`` here, which back the
+        mermaid and dot exporters.
+      * **obeditor** — the browser-based benchmark editor loads omnibenchmark as
+        a Pyodide wheel and calls this to render its pipeline-topology diagram
+        (stage-level, labeled edges). It is an *external* consumer, so this
+        function has no in-repo caller beyond the wrappers below; do not flag it
+        as dead code or inline it away.
+    """
+    adjacency: List[Tuple[str, str, List[str]]] = []
+    for stage in model.get_stages().values():
+        shared_by_stage: Dict[str, List[str]] = {}
+        order: List[str] = []
+        for entries in model.get_stage_implicit_inputs(stage):
+            for output_id in entries:
+                producing_stage = model.get_output_stage(output_id)
+                if producing_stage is None or producing_stage.id == stage.id:
+                    continue
+                if producing_stage.id not in shared_by_stage:
+                    shared_by_stage[producing_stage.id] = []
+                    order.append(producing_stage.id)
+                if output_id not in shared_by_stage[producing_stage.id]:
+                    shared_by_stage[producing_stage.id].append(output_id)
+        for up_stage_id in order:
+            adjacency.append(
+                (up_stage_id, stage.id, sorted(shared_by_stage[up_stage_id]))
+            )
+    return adjacency
+
+
+def upstream_stage_ids(model: Benchmark, stage: "Stage") -> List[str]:
+    """IDs of every stage feeding *stage* via its declared inputs.
+
+    Thin wrapper over :func:`stage_adjacency`. Unlike the execution DAG's
+    ``after`` join (which keeps only the topologically-latest producing stage so
+    output-path construction stays a linear ancestry), this returns *all*
+    upstream stages — every declared dependency, regardless of how many stages a
+    single input group spans.
+    """
+    return [
+        up_stage_id
+        for up_stage_id, stage_id, _ in stage_adjacency(model)
+        if stage_id == stage.id
+    ]
+
+
+def build_topology_dag(model: Benchmark, graph: DiGraph) -> DiGraph:
+    """Build a display-only DAG with every declared cross-stage edge.
+
+    Reuses the nodes of the execution *graph* but recomputes edges from the
+    model's declared inputs: every node of each upstream stage connects to every
+    node of the consuming stage. The execution DAG connects each node only to
+    its single ``after`` stage (correct for linear output-path chaining but
+    lossy when an input group spans multiple upstream stages); this restores the
+    dropped edges for visualization without perturbing execution.
+    """
+    display = DiGraph()
+
+    nodes_by_stage: dict = defaultdict(list)
+    for node in graph.nodes:
+        nodes_by_stage[node.stage_id].append(node)
+        display.add_node(node, stage=node.stage_id)
+
+    for stage in model.get_stages().values():
+        targets = nodes_by_stage.get(stage.id, [])
+        for up_stage_id in upstream_stage_ids(model, stage):
+            for source in nodes_by_stage.get(up_stage_id, []):
+                for target in targets:
+                    display.add_edge(source, target)
+
+    return display
 
 
 def find_initial_and_terminal_nodes(

--- a/omnibenchmark/core/_mermaid.py
+++ b/omnibenchmark/core/_mermaid.py
@@ -3,14 +3,32 @@
 from typing import Dict, List
 from omnibenchmark.model import Benchmark as BenchmarkModel
 from omnibenchmark.model.benchmark import Parameter
-from omnibenchmark.core._graph import get_nodes_by_module_id
+from omnibenchmark.core._graph import upstream_stage_ids
 from omnibenchmark.model.params import Params
+
+
+def _quote_label(text: str) -> str:
+    """Wrap a node label so Mermaid treats it as literal text.
+
+    Mermaid only tolerates quotes, commas, brackets and other punctuation
+    inside a node label when the label is wrapped in double quotes; embedded
+    double quotes themselves must be entity-escaped. Without this, labels such
+    as ``--alpha 0.1`` or ``'--beta', '2'`` break the parser.
+    """
+    return '"' + text.replace('"', "&quot;") + '"'
 
 
 class MermaidDiagramGenerator:
     """Generates Mermaid diagrams for benchmark workflows."""
 
-    def __init__(self, model: BenchmarkModel, graph):
+    def __init__(self, model: BenchmarkModel, graph=None):
+        # ``graph`` (the execution DAG) is accepted for backward compatibility
+        # but no longer used to derive edges. The execution DAG connects each
+        # node only to its single "latest" upstream stage (so that output-path
+        # construction stays a linear ancestry); that drops edges whenever an
+        # input group spans multiple upstream stages. The topology view instead
+        # reads the model's declared inputs directly, so every declared
+        # stage-to-stage dependency is rendered.
         self.model = model
         self.graph = graph
 
@@ -58,34 +76,36 @@ class MermaidDiagramGenerator:
         for stage_id, stage in self.model.get_stages().items():
             subgraph_lines = [f"\tsubgraph {stage_id}"]
 
+            # All modules in a stage share the stage's declared inputs, so the
+            # set of upstream modules is the same for every module in the stage.
+            upstream_module_ids = self._get_upstream_module_ids(stage)
+
             # Add modules to the stage subgraph
             for module_id, module in self.model.get_modules_by_stage(stage).items():
                 subgraph_lines.append(f"\t\t{module_id}")
 
-                # Add connections from predecessor modules
-                module_connections = self._get_module_connections(module_id)
-                subgraph_lines.extend(module_connections)
+                # Add connections from every upstream module the stage depends on
+                for from_module_id in upstream_module_ids:
+                    subgraph_lines.append(f"\t\t{from_module_id} --> {module_id}")
 
             subgraph_lines.append("\tend")
             subgraphs.append("\n".join(subgraph_lines))
 
         return "\n".join(subgraphs)
 
-    def _get_module_connections(self, module_id: str) -> List[str]:
-        """Get Mermaid connection strings for a module's dependencies."""
-        connections = []
-        module_nodes = self._get_nodes_by_module_id(module_id)
+    def _get_upstream_module_ids(self, stage) -> List[str]:
+        """Module IDs of every stage feeding *stage* via its declared inputs.
 
-        from_nodes = [list(self.graph.predecessors[node]) for node in module_nodes]
+        Collects the modules of every stage feeding *stage* (see
+        :func:`upstream_stage_ids`). Unlike the execution DAG, a single input
+        group spanning multiple upstream stages contributes edges from *all* of
+        them, not just the topologically-latest one.
+        """
+        module_ids = set()
+        for stage_id in upstream_stage_ids(self.model, stage):
+            module_ids.update(self.model.get_modules_by_stage(stage_id).keys())
 
-        from_node_module_ids = sorted(
-            list(set([node.module_id for flatten in from_nodes for node in flatten]))
-        )
-
-        for from_module_id in from_node_module_ids:
-            connections.append(f"\t\t{from_module_id} --> {module_id}")
-
-        return connections
+        return sorted(module_ids)
 
     def _generate_parameter_subgraphs(self, compact_params: bool) -> str:
         """Generate parameter subgraphs and their connections to modules."""
@@ -102,12 +122,15 @@ class MermaidDiagramGenerator:
                         continue
                     comp_str = " ".join(f"{k}:{v}" for k, v in parameter.params.items())
                     paramset_node = f"{module_id}_paramset{paramset}"
-                    subgraph_lines.append(f"\t\t{paramset_node}[{comp_str}]")
+                    subgraph_lines.append(
+                        f"\t\t{paramset_node}[{_quote_label(comp_str)}]"
+                    )
             else:
                 # Expand each Parameter and render one node per combination
                 for parameter in parameters:
                     for param in Params.expand_from_parameter(parameter):
-                        param_node = f"{param.hash()}{param.to_cli_args()}"
+                        label = " ".join(param.to_cli_args())
+                        param_node = f"{param.hash()}[{_quote_label(label)}]"
                         subgraph_lines.append(f"\t\t{param_node}")
 
             subgraph_lines.extend(
@@ -128,19 +151,19 @@ class MermaidDiagramGenerator:
 
         return module_id_params_dict
 
-    def _get_nodes_by_module_id(self, module_id: str) -> List:
-        """Get all graph nodes for a given module ID."""
-        return get_nodes_by_module_id(self.graph, module_id)
-
 
 def generate_mermaid_diagram(
-    model: BenchmarkModel, graph, show_params: bool = True, compact_params: bool = False
+    model: BenchmarkModel,
+    graph=None,
+    show_params: bool = True,
+    compact_params: bool = False,
 ) -> str:
     """Generate a Mermaid diagram for a benchmark workflow.
 
     Args:
         model: The benchmark model containing workflow definition
-        graph: The benchmark DAG graph
+        graph: Deprecated/unused — the execution DAG. Topology edges are now
+            derived from the model's declared inputs.
         show_params: Whether to include parameter subgraphs
 
     Returns:

--- a/omnibenchmark/core/execution.py
+++ b/omnibenchmark/core/execution.py
@@ -230,7 +230,10 @@ class BenchmarkExecution:
     # Visualization functions
 
     def export_to_dot(self):
-        return export_to_dot(self.G, title=self.get_benchmark_name())
+        # Render the topology view (every declared cross-stage edge), not the
+        # execution DAG, whose single-``after`` edges drop cross-stage links.
+        display_graph = graph.build_topology_dag(self.model, self.G)
+        return export_to_dot(display_graph, title=self.get_benchmark_name())
 
     def get_environment_path(
         self, env_key: str, software_backend: SoftwareBackendEnum

--- a/tests/benchmark/test_mermaid.py
+++ b/tests/benchmark/test_mermaid.py
@@ -1,0 +1,318 @@
+"""Topology-focused tests for Mermaid diagram generation.
+
+These build benchmark *models* directly (no execution DAG / out_dir needed) and
+assert on the module-to-module edges the generator emits. They cover the
+regression where an input group spanning multiple upstream stages dropped every
+edge except the one to the topologically-latest stage.
+"""
+
+import re
+
+from omnibenchmark.model import Benchmark
+from omnibenchmark.core._mermaid import generate_mermaid_diagram
+
+_HEADER = """\
+id: {id}
+description: stress
+version: "1.0"
+benchmarker: x
+storage: https://storage.github.com/
+api_version: "0.3.0"
+storage_api: S3
+storage_bucket_name: b
+software_backend: host
+software_environments:
+  e:
+    description: e
+    easyconfig: e.eb
+    envmodule: e
+    conda: e.yaml
+    apptainer: http://registry.ch/x.sif
+"""
+
+_REPO = "{url: https://github.com/omnibenchmark-example/data.git, commit: 63b7b36}"
+
+
+def _module(mid, params=None):
+    """*params* is a list of parameter sets. A set given as a list renders the
+    deprecated ``values:`` form; given as a dict it renders the dict form (the
+    only form ``--compact-params`` can display)."""
+    lines = [
+        f"      - id: {mid}",
+        "        software_environment: e",
+        f"        repository: {_REPO}",
+    ]
+    if params:
+        lines.append("        parameters:")
+        for p in params:
+            if isinstance(p, dict):
+                first = True
+                for k, v in p.items():
+                    prefix = "          - " if first else "            "
+                    lines.append(f"{prefix}{k}: {v}")
+                    first = False
+            else:
+                vals = ", ".join(f'"{v}"' for v in p)
+                lines.append(f"          - values: [{vals}]")
+    return "\n".join(lines)
+
+
+def _stage(sid, modules, inputs=None, output_id=None):
+    """Compose a stage block. *inputs* is a list of input groups; each group is
+    a list of output ids (flat-list form). *modules* is a list of (id, params)."""
+    out = output_id or f"{sid}.out"
+    block = [f"  - id: {sid}", "    modules:"]
+    block += [_module(mid, params) for mid, params in modules]
+    if inputs is not None:
+        block.append("    inputs:")
+        for group in inputs:
+            if len(group) == 1:
+                block.append(f"      - {group[0]}")
+            else:
+                block.append("      - entries:")
+                block += [f"          - {e}" for e in group]
+    block.append("    outputs:")
+    block.append(f'      - {{id: {out}, path: "{sid}.txt"}}')
+    return "\n".join(block)
+
+
+def _model(bid, stages):
+    yaml = _HEADER.format(id=bid) + "stages:\n" + "\n".join(stages)
+    return Benchmark.from_yaml(yaml)
+
+
+def _edges(model, **kw):
+    diagram = generate_mermaid_diagram(model, show_params=False, **kw)
+    return {(a, b) for a, b in re.findall(r"(\w+) --> (\w+)", diagram)}
+
+
+# --------------------------------------------------------------------------- #
+# Edge topology
+# --------------------------------------------------------------------------- #
+
+
+def test_single_input_group_spanning_two_stages():
+    """Regression: one input group that references outputs from two upstream
+    stages must produce edges from BOTH, not only the latest one."""
+    model = _model(
+        "diamond",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("proc", [("P", None)], inputs=[["data.out"]], output_id="proc.out"),
+            _stage(
+                "combine",
+                [("C", None)],
+                inputs=[["data.out", "proc.out"]],
+                output_id="combine.out",
+            ),
+        ],
+    )
+    assert _edges(model) == {("D", "P"), ("D", "C"), ("P", "C")}
+
+
+def test_input_group_spanning_three_stages():
+    model = _model(
+        "triple",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("s1", [("S1", None)], inputs=[["data.out"]], output_id="s1.out"),
+            _stage("s2", [("S2", None)], inputs=[["s1.out"]], output_id="s2.out"),
+            _stage(
+                "fin",
+                [("F", None)],
+                inputs=[["data.out", "s1.out", "s2.out"]],
+                output_id="fin.out",
+            ),
+        ],
+    )
+    assert _edges(model) == {
+        ("D", "S1"),
+        ("S1", "S2"),
+        ("D", "F"),
+        ("S1", "F"),
+        ("S2", "F"),
+    }
+
+
+def test_separate_single_stage_groups_equivalent():
+    """The deprecated multi-`entries` form (separate groups) yields the same
+    edges as a single multi-stage group."""
+    model = _model(
+        "groups",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("proc", [("P", None)], inputs=[["data.out"]], output_id="proc.out"),
+            _stage(
+                "combine",
+                [("C", None)],
+                inputs=[["data.out"], ["proc.out"]],
+                output_id="combine.out",
+            ),
+        ],
+    )
+    assert _edges(model) == {("D", "P"), ("D", "C"), ("P", "C")}
+
+
+def test_skip_level_dependency():
+    """A stage depending only on an early stage skips the intermediate one."""
+    model = _model(
+        "skip",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("proc", [("P", None)], inputs=[["data.out"]], output_id="proc.out"),
+            _stage("tail", [("T", None)], inputs=[["data.out"]], output_id="tail.out"),
+        ],
+    )
+    assert _edges(model) == {("D", "P"), ("D", "T")}
+
+
+def test_fan_in_from_independent_roots():
+    """Two independent initial stages feeding one downstream stage both connect."""
+    model = _model(
+        "fanin",
+        [
+            _stage("a", [("A", None)], output_id="a.out"),
+            _stage("b", [("B", None)], output_id="b.out"),
+            _stage(
+                "merge",
+                [("M", None)],
+                inputs=[["a.out", "b.out"]],
+                output_id="merge.out",
+            ),
+        ],
+    )
+    assert _edges(model) == {("A", "M"), ("B", "M")}
+
+
+def test_full_cartesian_across_modules():
+    """Every upstream module connects to every downstream module in a stage."""
+    model = _model(
+        "cart",
+        [
+            _stage("data", [("D1", None), ("D2", None)], output_id="data.out"),
+            _stage(
+                "proc",
+                [("P1", None), ("P2", None)],
+                inputs=[["data.out"]],
+                output_id="proc.out",
+            ),
+        ],
+    )
+    assert _edges(model) == {
+        ("D1", "P1"),
+        ("D1", "P2"),
+        ("D2", "P1"),
+        ("D2", "P2"),
+    }
+
+
+def test_initial_stage_has_no_incoming_edges():
+    model = _model(
+        "init",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("proc", [("P", None)], inputs=[["data.out"]], output_id="proc.out"),
+        ],
+    )
+    edges = _edges(model)
+    assert not any(target == "D" for _, target in edges)
+
+
+def test_no_self_edges():
+    model = _model(
+        "self",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("proc", [("P", None)], inputs=[["data.out"]], output_id="proc.out"),
+        ],
+    )
+    assert not any(a == b for a, b in _edges(model))
+
+
+# --------------------------------------------------------------------------- #
+# Structure / params
+# --------------------------------------------------------------------------- #
+
+
+def test_header_and_declaration():
+    model = _model("MyBench", [_stage("data", [("D", None)], output_id="data.out")])
+    diagram = generate_mermaid_diagram(model, show_params=False)
+    assert "title: MyBench" in diagram
+    assert "flowchart LR" in diagram
+    assert "classDef param fill:#f96" in diagram
+
+
+def test_stage_subgraphs_present():
+    model = _model(
+        "subg",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("proc", [("P", None)], inputs=[["data.out"]], output_id="proc.out"),
+        ],
+    )
+    diagram = generate_mermaid_diagram(model, show_params=False)
+    assert "subgraph data" in diagram
+    assert "subgraph proc" in diagram
+
+
+def test_show_params_toggle():
+    model = _model(
+        "pbench",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage(
+                "proc",
+                [("P", [["-a 0", "-b 1"]])],
+                inputs=[["data.out"]],
+                output_id="proc.out",
+            ),
+        ],
+    )
+    assert "subgraph params_P" not in generate_mermaid_diagram(model, show_params=False)
+    assert "subgraph params_P" in generate_mermaid_diagram(model, show_params=True)
+
+
+def test_compact_params_render_one_node_per_paramset():
+    model = _model(
+        "cbench",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage(
+                "proc",
+                [("P", [{"alpha": 0.1}, {"alpha": 0.5}])],
+                inputs=[["data.out"]],
+                output_id="proc.out",
+            ),
+        ],
+    )
+    diagram = generate_mermaid_diagram(model, show_params=True, compact_params=True)
+    assert "P_paramset0" in diagram
+    assert "P_paramset1" in diagram
+    # The param subgraph is wired to its module
+    assert "params_P:::param --o P" in diagram
+
+
+def test_module_without_params_has_no_param_subgraph():
+    model = _model(
+        "nopar",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("proc", [("P", None)], inputs=[["data.out"]], output_id="proc.out"),
+        ],
+    )
+    diagram = generate_mermaid_diagram(model, show_params=True)
+    assert "subgraph params_" not in diagram
+
+
+def test_graph_argument_is_ignored():
+    """Passing an (irrelevant) graph object must not change the output."""
+    model = _model(
+        "ign",
+        [
+            _stage("data", [("D", None)], output_id="data.out"),
+            _stage("proc", [("P", None)], inputs=[["data.out"]], output_id="proc.out"),
+        ],
+    )
+    assert generate_mermaid_diagram(
+        model, graph=None, show_params=False
+    ) == generate_mermaid_diagram(model, graph=object(), show_params=False)

--- a/tests/benchmark/test_visualisation.py
+++ b/tests/benchmark/test_visualisation.py
@@ -6,7 +6,116 @@ from pathlib import Path
 
 from omnibenchmark.core import Benchmark
 from omnibenchmark.core._dot import export_to_dot
+from omnibenchmark.core._graph import (
+    build_benchmark_dag,
+    build_topology_dag,
+    stage_adjacency,
+)
+from omnibenchmark.model import Benchmark as BenchmarkModel
 from omnibenchmark.dag import DiGraph
+
+
+def _module_edges(model):
+    """Module-level edges of the display (topology) DAG built from *model*."""
+    exec_dag = build_benchmark_dag(model, Path("."))
+    display = build_topology_dag(model, exec_dag)
+    return {(u.module_id, v.module_id) for u, v in display.edges}
+
+
+_TWO_STAGE_DIAMOND = """\
+id: diamond
+description: d
+version: "1.0"
+benchmarker: x
+storage: https://s/
+api_version: "0.3.0"
+storage_api: S3
+storage_bucket_name: b
+software_backend: host
+software_environments:
+  e: {description: e, easyconfig: e.eb, envmodule: e, conda: e.yaml, apptainer: http://x/y.sif}
+stages:
+  - id: data
+    modules:
+      - {id: D, software_environment: e, repository: {url: https://github.com/o/data.git, commit: 63b7b36}}
+    outputs:
+      - {id: data.out, path: "{dataset}.txt"}
+  - id: proc
+    modules:
+      - {id: P, software_environment: e, repository: {url: https://github.com/o/p.git, commit: 63b7b36}}
+    inputs: [data.out]
+    outputs:
+      - {id: proc.out, path: "p.txt"}
+  - id: combine
+    modules:
+      - {id: C, software_environment: e, repository: {url: https://github.com/o/c.git, commit: 63b7b36}}
+    inputs: [data.out, proc.out]
+    outputs:
+      - {id: combine.out, path: "c.txt"}
+"""
+
+
+def test_topology_dag_restores_cross_stage_edges():
+    """The display DAG draws an edge from *every* declared upstream stage, even
+    when one input group spans several (regression: only the latest survived)."""
+    model = BenchmarkModel.from_yaml(_TWO_STAGE_DIAMOND)
+    assert _module_edges(model) == {("D", "P"), ("D", "C"), ("P", "C")}
+
+
+def test_topology_dag_does_not_mutate_execution_dag():
+    """Building the display DAG must not perturb the execution DAG's edges
+    (which must stay a linear ancestry for correct output-path construction)."""
+    model = BenchmarkModel.from_yaml(_TWO_STAGE_DIAMOND)
+    exec_dag = build_benchmark_dag(model, Path("."))
+    before = {(u.module_id, v.module_id) for u, v in exec_dag.edges}
+    build_topology_dag(model, exec_dag)
+    after = {(u.module_id, v.module_id) for u, v in exec_dag.edges}
+    assert before == after == {("D", "P"), ("P", "C")}
+
+
+def test_export_to_dot_contains_cross_stage_edge():
+    """The rendered dot graph includes the restored data->combine edge."""
+    model = BenchmarkModel.from_yaml(_TWO_STAGE_DIAMOND)
+    display = build_topology_dag(model, build_benchmark_dag(model, Path(".")))
+    dot = export_to_dot(display, title="diamond")
+    rendered = str(dot)
+    assert "combine-C" in rendered and "data-D" in rendered
+
+
+def test_stage_adjacency_edges_and_labels():
+    """stage_adjacency yields every declared edge with its shared output ids."""
+    model = BenchmarkModel.from_yaml(_TWO_STAGE_DIAMOND)
+    adjacency = stage_adjacency(model)
+    assert adjacency == [
+        ("data", "proc", ["data.out"]),
+        ("data", "combine", ["data.out"]),
+        ("proc", "combine", ["proc.out"]),
+    ]
+
+
+def test_stage_adjacency_groups_multiple_shared_outputs():
+    """Multiple outputs shared between the same stage pair collapse to one edge
+    whose label lists all of them (sorted)."""
+    model = BenchmarkModel.from_yaml(
+        Path(__file__).parent / "../data/Benchmark_001.yaml"
+    )
+    adjacency = stage_adjacency(model)
+    # metrics declares methods.mapping + data.meta + data.data_specific_params
+    metrics_from_data = [
+        shared for up, down, shared in adjacency if down == "metrics" and up == "data"
+    ]
+    assert metrics_from_data == [["data.data_specific_params", "data.meta"]]
+    # ... and a single edge from methods as well
+    assert any(up == "methods" and down == "metrics" for up, down, _ in adjacency)
+
+
+def test_upstream_stage_ids_consistent_with_adjacency():
+    """The wrapper returns exactly the upstream stages from the adjacency."""
+    model = BenchmarkModel.from_yaml(_TWO_STAGE_DIAMOND)
+    combine = model.get_stage("combine")
+    from omnibenchmark.core._graph import upstream_stage_ids
+
+    assert upstream_stage_ids(model, combine) == ["data", "proc"]
 
 
 @pytest.mark.short
@@ -97,12 +206,18 @@ def test_export_topology_to_mermaid(tmp_path):
         \tend
         \tsubgraph metrics
             \t\tm1
+            \t\tD1 --> m1
+            \t\tD2 --> m1
             \t\tM1 --> m1
             \t\tM2 --> m1
             \t\tm2
+            \t\tD1 --> m2
+            \t\tD2 --> m2
             \t\tM1 --> m2
             \t\tM2 --> m2
             \t\tm3
+            \t\tD1 --> m3
+            \t\tD2 --> m3
             \t\tM1 --> m3
             \t\tM2 --> m3
         \tend


### PR DESCRIPTION
Fixes for the mermaid and dot renderers. Also factor out a common functino so that obeditor doesn't need to re-derive the DAG in the javascript code.

The execution DAG connects each node only to its single latest upstream stage so output-path construction stays a linear ancestry. That dropped cross-stage edges whenever an input group referenced outputs from more than one upstream stage.

Derive topology edges from the model's declared inputs instead:
- stage_adjacency / upstream_stage_ids / build_topology_dag in _graph.py
- mermaid generator reads declared inputs (graph arg now unused)
- export_to_dot renders the topology DAG without mutating execution DAG

## Description

Provide a small description of Pull Request.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

## Remarks for the reviewer:

Test with graphviz and dot code.