### PR TITLE
feat(cli): add --until STAGE to truncate the resolved DAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 
 - feat: capability filters by --with-capability (#360)
 - feat: emit threads per rule according if the module requests a number of cores
+- feat: `ob run benchmark --until STAGE` truncates the DAG to that stage and its transitive ancestors (#361)
 
 ## [0.6.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.6.0) (Jul 21st 2026)
 

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -455,6 +455,28 @@ Semantics worth knowing:
   development mode, nothing is filtered out from under you — it runs (and fails
   plainly at run time if the machine really lacks the resource).
 
+## Stop a run partway through the benchmark
+
+`--until` runs a benchmark up to one stage and no further — useful to check that
+preprocessing looks right before paying for the methods, or to materialize
+intermediate outputs other people can consume.
+
+```bash
+ob run benchmark benchmark.yaml --until preprocessing
+```
+
+Semantics worth knowing:
+
+- **Ancestors follow automatically.** Everything the named stage transitively
+  depends on is kept; everything downstream or unrelated is pruned. This uses
+  the input/output topology, not the order stages happen to appear in the YAML,
+  so an upstream stage declared *after* the named one is still kept.
+- **Metric collectors that reach past the cut are skipped.** A collector whose
+  inputs reference a pruned stage is dropped with a log line rather than
+  failing.
+- **Not combinable with `-m/--module`**, which already truncates the DAG its own
+  way; passing both is an error.
+
 ## Use a custom apptainer container to run methods
 
 We recommend building apptainer containers using apptainer. Still, it is possible to use any apptainer container from an ORAS-compatible registry (could be a GitLab registry), or available locally as a SIF file.

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -138,6 +138,18 @@ def format_pydantic_errors(e: PydanticValidationError) -> str:
     default=None,
     help="Write telemetry to file instead of stdout. Allows Rich progress to remain active. Implies --telemetry.",
 )
+@click.option(
+    "--until",
+    "until_stage",
+    default=None,
+    type=str,
+    help=(
+        "Stop the pipeline at and including the named stage. "
+        "Stages declared after the named stage in the benchmark YAML are "
+        "pruned from the resolved DAG, and metric collectors whose inputs "
+        "reference pruned stages are skipped."
+    ),
+)
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def run(
@@ -154,6 +166,7 @@ def run(
     module_filter,
     telemetry,
     telemetry_output,
+    until_stage,
     snakemake_args,
 ):
     """Run a benchmark.
@@ -198,6 +211,14 @@ def run(
             f"-m {module_filter}: single execution path, first param expansion only."
         )
 
+    if module_filter and until_stage:
+        log_error_and_quit(
+            logger,
+            "--until and -m/--module cannot be combined: -m already truncates "
+            "the DAG at the target module's stage.",
+        )
+        return
+
     _run_benchmark(
         benchmark_path=benchmark,
         cores=cores,
@@ -211,6 +232,7 @@ def run(
         module_filter=module_filter,
         telemetry=telemetry,
         telemetry_output=telemetry_output,
+        until_stage=until_stage,
         snakemake_args=list(snakemake_args),
     )
 
@@ -228,6 +250,7 @@ def _run_benchmark(
     module_filter=None,
     telemetry=None,
     telemetry_output=None,
+    until_stage=None,
     snakemake_args=None,
 ):
     """Run a full benchmark, or a single-module sub-graph when module_filter is set."""
@@ -280,17 +303,22 @@ def _run_benchmark(
     populate_git_cache(b, quiet=use_clean_ui, cores=cores)
 
     # Step 2: Generate explicit Snakefile
-    resolved_nodes = _generate_explicit_snakefile(
-        benchmark=b,
-        benchmark_yaml_path=benchmark_path_abs,
-        out_dir=out_dir_path,
-        cores=cores,
-        quiet=use_clean_ui,
-        start_time=start_time,
-        dirty=dirty,
-        unpinned=unpinned,
-        module_filter=module_filter,
-    )
+    try:
+        resolved_nodes = _generate_explicit_snakefile(
+            benchmark=b,
+            benchmark_yaml_path=benchmark_path_abs,
+            out_dir=out_dir_path,
+            cores=cores,
+            quiet=use_clean_ui,
+            start_time=start_time,
+            dirty=dirty,
+            unpinned=unpinned,
+            module_filter=module_filter,
+            until_stage=until_stage,
+        )
+    except ValueError as e:
+        log_error_and_quit(logger, str(e))
+        return
 
     # Initialize telemetry with resolved nodes and emit module-resolution span
     if telemetry_emitter and resolved_nodes:
@@ -917,6 +945,62 @@ def _build_template_context(
     return TemplateContext(provides=provides, module_attrs=module_attrs)
 
 
+def _apply_until_filter(stages, until_stage, parents):
+    """Restrict a stage list to `until_stage` plus its transitive ancestors.
+
+    `parents` maps a stage id to the set of its *direct* upstream stage ids
+    (built from the model's declared inputs — see `stage_adjacency`). Stages are
+    kept by declared lineage, not by their order of appearance in the YAML: a
+    benchmark may declare an ancestor of `until_stage` *after* it, and every
+    stage downstream of (or unrelated to) `until_stage` is pruned regardless of
+    declaration order. Output preserves the original declaration order.
+
+    Returns the original sequence as a list when `until_stage` is None.
+    Raises ValueError when the named stage is not present.
+    """
+    stages = list(stages)
+    if until_stage is None:
+        return stages
+    if not any(s.id == until_stage for s in stages):
+        available = ", ".join(s.id for s in stages)
+        raise ValueError(
+            f"--until: stage '{until_stage}' not found. Available stages: {available}"
+        )
+    keep = {until_stage}
+    queue = [until_stage]
+    while queue:
+        for up in parents.get(queue.pop(), ()):
+            if up not in keep:
+                keep.add(up)
+                queue.append(up)
+    return [s for s in stages if s.id in keep]
+
+
+def _filter_collectors_by_stages(collectors, included_stage_ids, benchmark):
+    """Drop metric collectors whose declared inputs reference pruned stages.
+
+    Returns a tuple (kept, dropped_ids). A collector is dropped when any of its
+    declared input ids resolves to a stage outside `included_stage_ids` (or to
+    no stage at all — that case is left to the regular collector resolver to
+    warn about).
+    """
+    kept = []
+    dropped = []
+    for c in collectors or []:
+        keep = True
+        for input_ref in c.inputs:
+            input_id = input_ref if isinstance(input_ref, str) else input_ref.id
+            stage = benchmark.get_stage_by_output(input_id)
+            if stage is not None and stage.id not in included_stage_ids:
+                keep = False
+                break
+        if keep:
+            kept.append(c)
+        else:
+            dropped.append(c.id)
+    return kept, dropped
+
+
 def _generate_explicit_snakefile(
     benchmark: BenchmarkExecution,
     benchmark_yaml_path: Path,
@@ -928,6 +1012,7 @@ def _generate_explicit_snakefile(
     dirty: bool = False,
     unpinned: bool = False,
     module_filter: Optional[str] = None,
+    until_stage: Optional[str] = None,
 ):
     """Generate explicit Snakefile from resolved modules."""
     from omnibenchmark.progress import ProgressDisplay
@@ -951,8 +1036,73 @@ def _generate_explicit_snakefile(
         benchmark_dir=benchmark_dir,
     )
 
+    # Select the stages to expand *before* module resolution, so that modules
+    # in pruned stages are never checked out or environment-resolved. Expansion
+    # runs in topological (dependency) order rather than declaration order:
+    # select_input_nodes can only pick a parent among already-expanded stages,
+    # so a stage must be expanded after every stage producing its inputs. See
+    # https://github.com/omnibenchmark/omnibenchmark/issues/289.
+    from omnibenchmark.core._graph import (
+        build_stage_dag,
+        compute_stage_order,
+        stage_adjacency,
+    )
+
+    topo_order = compute_stage_order(build_stage_dag(benchmark.model))
+    topo_index = {stage_id: i for i, stage_id in enumerate(topo_order)}
+    topo_sorted_stages = sorted(
+        benchmark.model.stages,
+        key=lambda s: topo_index.get(s.id, len(topo_index)),
+    )
+
+    target_stage = None
+    if module_filter:
+        # ob run -m <module_id>: keep the target stage and its topological ancestors.
+        target_stage = next(
+            (
+                stage
+                for stage in benchmark.model.stages
+                if any(m.id == module_filter for m in stage.modules)
+            ),
+            None,
+        )
+        if target_stage is None:
+            logger.error(
+                f"Module '{module_filter}' not found in benchmark. "
+                f"Available modules: "
+                + ", ".join(m.id for s in benchmark.model.stages for m in s.modules)
+            )
+            sys.exit(1)
+
+        target_pos = topo_index.get(target_stage.id, len(topo_index))
+        stages_to_expand = [
+            stage
+            for stage in topo_sorted_stages
+            if topo_index.get(stage.id, len(topo_index)) <= target_pos
+        ]
+        logger.info(
+            f"Module mode: expanding {len(stages_to_expand)} stage(s) "
+            f"(up to and including '{target_stage.id}'), "
+            "first expansion only."
+        )
+    elif until_stage is not None:
+        # --until <stage>: keep the named stage and its transitive ancestors.
+        parents = {}
+        for up_id, down_id, _ in stage_adjacency(benchmark.model):
+            parents.setdefault(down_id, set()).add(up_id)
+        kept_ids = {s.id for s in _apply_until_filter(
+            benchmark.model.stages, until_stage, parents
+        )}
+        stages_to_expand = [s for s in topo_sorted_stages if s.id in kept_ids]
+        logger.info(
+            f"--until {until_stage}: expanding {len(stages_to_expand)} stage(s) "
+            f"('{until_stage}' and its upstream lineage)."
+        )
+    else:
+        stages_to_expand = topo_sorted_stages
+
     unique_modules = {}
-    for stage in benchmark.model.stages:
+    for stage in stages_to_expand:
         for module in stage.modules:
             cache_key = (stage.id, module.id)
             if cache_key not in unique_modules:
@@ -1086,57 +1236,8 @@ def _generate_explicit_snakefile(
     if not quiet:
         logger.info("\nBuilding execution graph...")
 
-    # Expand stages in topological (dependency) order rather than declaration
-    # order. select_input_nodes can only pick a parent among already-expanded
-    # stages, so a stage must be expanded after every stage producing its inputs.
-    # Sorting here makes declaration order irrelevant: a plan that declares a
-    # stage before an upstream producer still resolves, as long as that producer
-    # is genuinely upstream (not on a divergent branch -- see the diamond guard
-    # in model/validation.py). The sort is stable for already-ordered plans, so
-    # well-formed benchmarks are unaffected. See
-    # https://github.com/omnibenchmark/omnibenchmark/issues/289.
-    from omnibenchmark.core._graph import build_stage_dag, compute_stage_order
-
-    topo_order = compute_stage_order(build_stage_dag(benchmark.model))
-    topo_index = {stage_id: i for i, stage_id in enumerate(topo_order)}
-    topo_sorted_stages = sorted(
-        benchmark.model.stages,
-        key=lambda s: topo_index.get(s.id, len(topo_index)),
-    )
-
-    # Module-filter pruning (ob run -m <module_id>)
-    if module_filter:
-        target_stage = next(
-            (
-                stage
-                for stage in benchmark.model.stages
-                if any(m.id == module_filter for m in stage.modules)
-            ),
-            None,
-        )
-
-        if target_stage is None:
-            logger.error(
-                f"Module '{module_filter}' not found in benchmark. "
-                f"Available modules: "
-                + ", ".join(m.id for s in benchmark.model.stages for m in s.modules)
-            )
-            sys.exit(1)
-
-        target_pos = topo_index.get(target_stage.id, len(topo_index))
-        stages_to_expand = [
-            stage
-            for stage in topo_sorted_stages
-            if topo_index.get(stage.id, len(topo_index)) <= target_pos
-        ]
-        logger.info(
-            f"Module mode: expanding {len(stages_to_expand)} stage(s) "
-            f"(up to and including '{target_stage.id}'), "
-            "first expansion only."
-        )
-    else:
-        stages_to_expand = topo_sorted_stages
-
+    # stages_to_expand / target_stage / topo ordering are computed above, before
+    # module resolution, so pruned stages are never checked out.
     resolved_nodes = []
     nodes_by_id = {}
     output_to_nodes = {}
@@ -1394,9 +1495,20 @@ def _generate_explicit_snakefile(
 
     # Resolve metric collectors (skip in -m module mode)
     if not module_filter:
+        collectors_to_resolve = benchmark.model.get_metric_collectors()
+        if until_stage is not None:
+            included_ids = {s.id for s in stages_to_expand}
+            collectors_to_resolve, dropped = _filter_collectors_by_stages(
+                collectors_to_resolve, included_ids, benchmark.model
+            )
+            for cid in dropped:
+                logger.info(
+                    f"--until {until_stage}: skipping metric collector "
+                    f"'{cid}' (references pruned stages)."
+                )
         try:
             collector_nodes = resolve_metric_collectors(
-                metric_collectors=benchmark.model.get_metric_collectors(),
+                metric_collectors=collectors_to_resolve,
                 resolved_nodes=resolved_nodes,
                 benchmark=benchmark.model,
                 resolver=resolver,

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -149,6 +149,18 @@ def format_pydantic_errors(e: PydanticValidationError) -> str:
         "Example: --with-capability gpu --with-capability large_mem"
     ),
 )
+@click.option(
+    "--until",
+    "until_stage",
+    default=None,
+    type=str,
+    help=(
+        "Stop the pipeline at and including the named stage. "
+        "Stages declared after the named stage in the benchmark YAML are "
+        "pruned from the resolved DAG, and metric collectors whose inputs "
+        "reference pruned stages are skipped."
+    ),
+)
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def run(
@@ -166,6 +178,7 @@ def run(
     telemetry,
     telemetry_output,
     with_capability,
+    until_stage,
     snakemake_args,
 ):
     """Run a benchmark.
@@ -210,6 +223,14 @@ def run(
             f"-m {module_filter}: single execution path, first param expansion only."
         )
 
+    if module_filter and until_stage:
+        log_error_and_quit(
+            logger,
+            "--until and -m/--module cannot be combined: -m already truncates "
+            "the DAG at the target module's stage.",
+        )
+        return
+
     _run_benchmark(
         benchmark_path=benchmark,
         cores=cores,
@@ -224,6 +245,7 @@ def run(
         telemetry=telemetry,
         telemetry_output=telemetry_output,
         available_capabilities=set(with_capability),
+        until_stage=until_stage,
         snakemake_args=list(snakemake_args),
     )
 
@@ -242,6 +264,7 @@ def _run_benchmark(
     telemetry=None,
     telemetry_output=None,
     available_capabilities=None,
+    until_stage=None,
     snakemake_args=None,
 ):
     """Run a full benchmark, or a single-module sub-graph when module_filter is set."""
@@ -294,18 +317,23 @@ def _run_benchmark(
     populate_git_cache(b, quiet=use_clean_ui, cores=cores)
 
     # Step 2: Generate explicit Snakefile
-    resolved_nodes = _generate_explicit_snakefile(
-        benchmark=b,
-        benchmark_yaml_path=benchmark_path_abs,
-        out_dir=out_dir_path,
-        cores=cores,
-        quiet=use_clean_ui,
-        start_time=start_time,
-        dirty=dirty,
-        unpinned=unpinned,
-        module_filter=module_filter,
-        available_capabilities=available_capabilities,
-    )
+    try:
+        resolved_nodes = _generate_explicit_snakefile(
+            benchmark=b,
+            benchmark_yaml_path=benchmark_path_abs,
+            out_dir=out_dir_path,
+            cores=cores,
+            quiet=use_clean_ui,
+            start_time=start_time,
+            dirty=dirty,
+            unpinned=unpinned,
+            module_filter=module_filter,
+            available_capabilities=available_capabilities,
+            until_stage=until_stage,
+        )
+    except ValueError as e:
+        log_error_and_quit(logger, str(e))
+        return
 
     # Initialize telemetry with resolved nodes and emit module-resolution span
     if telemetry_emitter and resolved_nodes:
@@ -979,6 +1007,62 @@ def _capability_prune_summary(pruned_modules, available_capabilities) -> str:
     )
 
 
+def _apply_until_filter(stages, until_stage, parents):
+    """Restrict a stage list to `until_stage` plus its transitive ancestors.
+
+    `parents` maps a stage id to the set of its *direct* upstream stage ids
+    (built from the model's declared inputs — see `stage_adjacency`). Stages are
+    kept by declared lineage, not by their order of appearance in the YAML: a
+    benchmark may declare an ancestor of `until_stage` *after* it, and every
+    stage downstream of (or unrelated to) `until_stage` is pruned regardless of
+    declaration order. Output preserves the original declaration order.
+
+    Returns the original sequence as a list when `until_stage` is None.
+    Raises ValueError when the named stage is not present.
+    """
+    stages = list(stages)
+    if until_stage is None:
+        return stages
+    if not any(s.id == until_stage for s in stages):
+        available = ", ".join(s.id for s in stages)
+        raise ValueError(
+            f"--until: stage '{until_stage}' not found. Available stages: {available}"
+        )
+    keep = {until_stage}
+    queue = [until_stage]
+    while queue:
+        for up in parents.get(queue.pop(), ()):
+            if up not in keep:
+                keep.add(up)
+                queue.append(up)
+    return [s for s in stages if s.id in keep]
+
+
+def _filter_collectors_by_stages(collectors, included_stage_ids, benchmark):
+    """Drop metric collectors whose declared inputs reference pruned stages.
+
+    Returns a tuple (kept, dropped_ids). A collector is dropped when any of its
+    declared input ids resolves to a stage outside `included_stage_ids` (or to
+    no stage at all — that case is left to the regular collector resolver to
+    warn about).
+    """
+    kept = []
+    dropped = []
+    for c in collectors or []:
+        keep = True
+        for input_ref in c.inputs:
+            input_id = input_ref if isinstance(input_ref, str) else input_ref.id
+            stage = benchmark.get_stage_by_output(input_id)
+            if stage is not None and stage.id not in included_stage_ids:
+                keep = False
+                break
+        if keep:
+            kept.append(c)
+        else:
+            dropped.append(c.id)
+    return kept, dropped
+
+
 def _generate_explicit_snakefile(
     benchmark: BenchmarkExecution,
     benchmark_yaml_path: Path,
@@ -991,6 +1075,7 @@ def _generate_explicit_snakefile(
     unpinned: bool = False,
     module_filter: Optional[str] = None,
     available_capabilities: Optional[set] = None,
+    until_stage: Optional[str] = None,
 ):
     """Generate explicit Snakefile from resolved modules."""
     from omnibenchmark.progress import ProgressDisplay
@@ -1014,11 +1099,78 @@ def _generate_explicit_snakefile(
         benchmark_dir=benchmark_dir,
     )
 
+    # Select the stages to expand *before* module resolution, so that modules
+    # in pruned stages are never checked out or environment-resolved. Expansion
+    # runs in topological (dependency) order rather than declaration order:
+    # select_input_nodes can only pick a parent among already-expanded stages,
+    # so a stage must be expanded after every stage producing its inputs. See
+    # https://github.com/omnibenchmark/omnibenchmark/issues/289.
+    from omnibenchmark.core._graph import (
+        build_stage_dag,
+        compute_stage_order,
+        stage_adjacency,
+    )
+
+    topo_order = compute_stage_order(build_stage_dag(benchmark.model))
+    topo_index = {stage_id: i for i, stage_id in enumerate(topo_order)}
+    topo_sorted_stages = sorted(
+        benchmark.model.stages,
+        key=lambda s: topo_index.get(s.id, len(topo_index)),
+    )
+
+    target_stage_id = None
+    if module_filter:
+        # ob run -m <module_id>: keep the target stage and its topological ancestors.
+        target_stage = next(
+            (
+                stage
+                for stage in benchmark.model.stages
+                if any(m.id == module_filter for m in stage.modules)
+            ),
+            None,
+        )
+        if target_stage is None:
+            logger.error(
+                f"Module '{module_filter}' not found in benchmark. "
+                f"Available modules: "
+                + ", ".join(m.id for s in benchmark.model.stages for m in s.modules)
+            )
+            sys.exit(1)
+
+        target_stage_id = target_stage.id
+        target_pos = topo_index.get(target_stage_id, len(topo_index))
+        stages_to_expand = [
+            stage
+            for stage in topo_sorted_stages
+            if topo_index.get(stage.id, len(topo_index)) <= target_pos
+        ]
+        logger.info(
+            f"Module mode: expanding {len(stages_to_expand)} stage(s) "
+            f"(up to and including '{target_stage_id}'), "
+            "first expansion only."
+        )
+    elif until_stage is not None:
+        # --until <stage>: keep the named stage and its transitive ancestors.
+        parents = {}
+        for up_id, down_id, _ in stage_adjacency(benchmark.model):
+            parents.setdefault(down_id, set()).add(up_id)
+        kept_ids = {
+            s.id
+            for s in _apply_until_filter(benchmark.model.stages, until_stage, parents)
+        }
+        stages_to_expand = [s for s in topo_sorted_stages if s.id in kept_ids]
+        logger.info(
+            f"--until {until_stage}: expanding {len(stages_to_expand)} stage(s) "
+            f"('{until_stage}' and its upstream lineage)."
+        )
+    else:
+        stages_to_expand = topo_sorted_stages
+
     # Capability gate: drop modules whose required host capabilities are not all
     # provided, before any checkout/env resolution. -m/--module bypasses it.
     unique_modules = {}
     pruned_modules = []
-    for stage in benchmark.model.stages:
+    for stage in stages_to_expand:
         kept, pruned = _select_capable_modules(
             stage.modules, module_filter, available_capabilities
         )
@@ -1167,57 +1319,8 @@ def _generate_explicit_snakefile(
     if not quiet:
         logger.info("\nBuilding execution graph...")
 
-    # Expand stages in topological (dependency) order rather than declaration
-    # order. select_input_nodes can only pick a parent among already-expanded
-    # stages, so a stage must be expanded after every stage producing its inputs.
-    # Sorting here makes declaration order irrelevant: a plan that declares a
-    # stage before an upstream producer still resolves, as long as that producer
-    # is genuinely upstream (not on a divergent branch -- see the diamond guard
-    # in model/validation.py). The sort is stable for already-ordered plans, so
-    # well-formed benchmarks are unaffected. See
-    # https://github.com/omnibenchmark/omnibenchmark/issues/289.
-    from omnibenchmark.core._graph import build_stage_dag, compute_stage_order
-
-    topo_order = compute_stage_order(build_stage_dag(benchmark.model))
-    topo_index = {stage_id: i for i, stage_id in enumerate(topo_order)}
-    topo_sorted_stages = sorted(
-        benchmark.model.stages,
-        key=lambda s: topo_index.get(s.id, len(topo_index)),
-    )
-
-    # Module-filter pruning (ob run -m <module_id>)
-    if module_filter:
-        target_stage = next(
-            (
-                stage
-                for stage in benchmark.model.stages
-                if any(m.id == module_filter for m in stage.modules)
-            ),
-            None,
-        )
-
-        if target_stage is None:
-            logger.error(
-                f"Module '{module_filter}' not found in benchmark. "
-                f"Available modules: "
-                + ", ".join(m.id for s in benchmark.model.stages for m in s.modules)
-            )
-            sys.exit(1)
-
-        target_pos = topo_index.get(target_stage.id, len(topo_index))
-        stages_to_expand = [
-            stage
-            for stage in topo_sorted_stages
-            if topo_index.get(stage.id, len(topo_index)) <= target_pos
-        ]
-        logger.info(
-            f"Module mode: expanding {len(stages_to_expand)} stage(s) "
-            f"(up to and including '{target_stage.id}'), "
-            "first expansion only."
-        )
-    else:
-        stages_to_expand = topo_sorted_stages
-
+    # stages_to_expand / target_stage_id / topo ordering are computed above, before
+    # module resolution, so pruned stages are never checked out.
     resolved_nodes = []
     nodes_by_id = {}
     output_to_nodes = {}
@@ -1238,7 +1341,7 @@ def _generate_explicit_snakefile(
 
         # Module-filter: which modules to expand per stage
         if module_filter:
-            is_target_stage = stage.id == target_stage.id
+            is_target_stage = stage.id == target_stage_id
             if is_target_stage:
                 modules_to_expand = [m for m in stage.modules if m.id == module_filter]
             else:
@@ -1477,9 +1580,20 @@ def _generate_explicit_snakefile(
 
     # Resolve metric collectors (skip in -m module mode)
     if not module_filter:
+        collectors_to_resolve = benchmark.model.get_metric_collectors()
+        if until_stage is not None:
+            included_ids = {s.id for s in stages_to_expand}
+            collectors_to_resolve, dropped = _filter_collectors_by_stages(
+                collectors_to_resolve, included_ids, benchmark.model
+            )
+            for cid in dropped:
+                logger.info(
+                    f"--until {until_stage}: skipping metric collector "
+                    f"'{cid}' (references pruned stages)."
+                )
         try:
             collector_nodes = resolve_metric_collectors(
-                metric_collectors=benchmark.model.get_metric_collectors(),
+                metric_collectors=collectors_to_resolve,
                 resolved_nodes=resolved_nodes,
                 benchmark=benchmark.model,
                 resolver=resolver,

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -156,9 +156,9 @@ def format_pydantic_errors(e: PydanticValidationError) -> str:
     type=str,
     help=(
         "Stop the pipeline at and including the named stage. "
-        "Stages declared after the named stage in the benchmark YAML are "
-        "pruned from the resolved DAG, and metric collectors whose inputs "
-        "reference pruned stages are skipped."
+        "Only the named stage and its transitive ancestors are kept in the "
+        "resolved DAG, and metric collectors whose inputs reference pruned "
+        "stages are skipped."
     ),
 )
 @click.argument("snakemake_args", nargs=-1, type=click.UNPROCESSED)

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -20,6 +20,8 @@ from omnibenchmark.cli.run import (
     _module_capabilities_met,
     _capability_prune_summary,
     _select_capable_modules,
+    _apply_until_filter,
+    _filter_collectors_by_stages,
     run,
 )
 from omnibenchmark.core._lineage import (
@@ -1344,3 +1346,221 @@ def test_run_benchmark_remote_storage_true_bool_appended(tmp_path):
         _, kwargs = mock_snakemake.call_args
         extra = kwargs["extra_snakemake_args"]
         assert "--use-conda" in extra
+
+
+# ---------------------------------------------------------------------------
+# _apply_until_filter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubStage:
+    id: str
+
+
+@pytest.mark.short
+class TestApplyUntilFilter:
+    def _stages(self, *ids):
+        return [_StubStage(i) for i in ids]
+
+    # parents: stage_id -> set of direct upstream stage ids (declared lineage)
+    def _linear(self, *ids):
+        """Parents map for a simple chain ids[0] -> ids[1] -> ... ."""
+        return {ids[i]: {ids[i - 1]} for i in range(1, len(ids))}
+
+    def test_none_returns_all_stages_as_list(self):
+        stages = self._stages("a", "b", "c")
+        result = _apply_until_filter(stages, None, {})
+        assert [s.id for s in result] == ["a", "b", "c"]
+        # must be a fresh list, not the same object
+        assert result is not stages
+
+    def test_initial_stage_keeps_only_first(self):
+        result = _apply_until_filter(
+            self._stages("a", "b", "c"), "a", self._linear("a", "b", "c")
+        )
+        assert [s.id for s in result] == ["a"]
+
+    def test_middle_stage_includes_named_and_ancestors(self):
+        result = _apply_until_filter(
+            self._stages("a", "b", "c", "d"), "b", self._linear("a", "b", "c", "d")
+        )
+        assert [s.id for s in result] == ["a", "b"]
+
+    def test_terminal_stage_returns_full_list(self):
+        result = _apply_until_filter(
+            self._stages("a", "b", "c"), "c", self._linear("a", "b", "c")
+        )
+        assert [s.id for s in result] == ["a", "b", "c"]
+
+    def test_ancestor_declared_after_target_is_kept(self):
+        # Lineage a -> b -> c, but declared out of topological order [c, b, a].
+        # Old declaration-order slicing kept only [c]; transitive closure keeps all.
+        result = _apply_until_filter(
+            self._stages("c", "b", "a"), "c", self._linear("a", "b", "c")
+        )
+        assert [s.id for s in result] == ["c", "b", "a"]  # declaration order preserved
+
+    def test_unrelated_branch_is_pruned(self):
+        # root feeds both branch_a and branch_b; --until branch_a drops branch_b
+        # even though it is declared before branch_a.
+        parents = {"branch_a": {"root"}, "branch_b": {"root"}}
+        result = _apply_until_filter(
+            self._stages("root", "branch_b", "branch_a"), "branch_a", parents
+        )
+        assert [s.id for s in result] == ["root", "branch_a"]
+
+    def test_diamond_keeps_both_paths(self):
+        # a -> {b, c} -> d ; --until d keeps everything, --until b drops c.
+        parents = {"b": {"a"}, "c": {"a"}, "d": {"b", "c"}}
+        stages = self._stages("a", "b", "c", "d")
+        assert [s.id for s in _apply_until_filter(stages, "d", parents)] == [
+            "a",
+            "b",
+            "c",
+            "d",
+        ]
+        assert [s.id for s in _apply_until_filter(stages, "b", parents)] == ["a", "b"]
+
+    def test_root_stage_keeps_only_itself(self):
+        result = _apply_until_filter(
+            self._stages("a", "b", "c"), "a", {"b": {"a"}, "c": {"b"}}
+        )
+        assert [s.id for s in result] == ["a"]
+
+    def test_unknown_stage_raises(self):
+        with pytest.raises(ValueError, match="stage 'nope' not found"):
+            _apply_until_filter(self._stages("a", "b"), "nope", {})
+
+    def test_unknown_stage_lists_available(self):
+        with pytest.raises(ValueError, match="a, b"):
+            _apply_until_filter(self._stages("a", "b"), "missing", {})
+
+    def test_empty_stages_with_until_raises(self):
+        with pytest.raises(ValueError):
+            _apply_until_filter([], "anything", {})
+
+    def test_empty_stages_without_until_returns_empty(self):
+        assert _apply_until_filter([], None, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# _filter_collectors_by_stages
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubCollector:
+    id: str
+    inputs: list
+
+
+@pytest.mark.short
+class TestFilterCollectorsByStages:
+    def _benchmark(self, output_to_stage):
+        """Build a stub benchmark whose get_stage_by_output returns mapped stages."""
+        bench = MagicMock()
+        bench.get_stage_by_output.side_effect = lambda oid: output_to_stage.get(oid)
+        return bench
+
+    def test_keeps_collector_when_all_inputs_in_included_stages(self):
+        bench = self._benchmark({"methods.result": _StubStage("methods")})
+        collectors = [_StubCollector("MC1", inputs=["methods.result"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data", "methods"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC1"]
+        assert dropped == []
+
+    def test_drops_collector_when_any_input_in_pruned_stage(self):
+        bench = self._benchmark(
+            {
+                "methods.result": _StubStage("methods"),
+                "data.raw": _StubStage("data"),
+            }
+        )
+        collectors = [_StubCollector("MC1", inputs=["methods.result", "data.raw"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == ["MC1"]
+
+    def test_unknown_input_does_not_drop(self):
+        # Unknown outputs are left to the regular collector resolver to warn about.
+        bench = self._benchmark({})
+        collectors = [_StubCollector("MC1", inputs=["unknown.id"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC1"]
+        assert dropped == []
+
+    def test_handles_iofile_inputs(self):
+        # Inputs may be IOFile objects (with `.id`) rather than bare strings.
+        from types import SimpleNamespace
+
+        bench = self._benchmark({"methods.result": _StubStage("methods")})
+        iofile = SimpleNamespace(id="methods.result")
+        collectors = [_StubCollector("MC1", inputs=[iofile])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == ["MC1"]
+
+    def test_empty_collector_list(self):
+        bench = self._benchmark({})
+        kept, dropped = _filter_collectors_by_stages(
+            [], included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == []
+
+    def test_none_collector_list(self):
+        bench = self._benchmark({})
+        kept, dropped = _filter_collectors_by_stages(
+            None, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == []
+
+    def test_partial_pruning_keeps_unrelated_collector(self):
+        bench = self._benchmark(
+            {
+                "methods.result": _StubStage("methods"),
+                "data.raw": _StubStage("data"),
+            }
+        )
+        collectors = [
+            _StubCollector("MC1", inputs=["methods.result"]),
+            _StubCollector("MC2", inputs=["data.raw"]),
+        ]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC2"]
+        assert dropped == ["MC1"]
+
+
+# ---------------------------------------------------------------------------
+# CLI conflict guard: --until + -m
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestUntilCliConflict:
+    def test_until_and_module_are_exclusive(self, caplog):
+        import logging
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("dummy.yaml").write_text("name: dummy")
+            with caplog.at_level(logging.ERROR, logger="omnibenchmark"):
+                result = runner.invoke(
+                    run,
+                    ["dummy.yaml", "-m", "M1", "--until", "methods"],
+                    catch_exceptions=False,
+                )
+        assert result.exit_code != 0
+        assert any("cannot be combined" in record.message for record in caplog.records)

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 
 import pytest
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from pydantic import ValidationError as PydanticValidationError
@@ -16,6 +17,8 @@ from omnibenchmark.cli.run import (
     _run_snakemake,
     _substitute_params_in_path,
     _build_template_context,
+    _apply_until_filter,
+    _filter_collectors_by_stages,
     run,
 )
 from omnibenchmark.core._lineage import (
@@ -1223,3 +1226,221 @@ def test_run_benchmark_remote_storage_true_bool_appended(tmp_path):
         _, kwargs = mock_snakemake.call_args
         extra = kwargs["extra_snakemake_args"]
         assert "--use-conda" in extra
+
+
+# ---------------------------------------------------------------------------
+# _apply_until_filter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubStage:
+    id: str
+
+
+@pytest.mark.short
+class TestApplyUntilFilter:
+    def _stages(self, *ids):
+        return [_StubStage(i) for i in ids]
+
+    # parents: stage_id -> set of direct upstream stage ids (declared lineage)
+    def _linear(self, *ids):
+        """Parents map for a simple chain ids[0] -> ids[1] -> ... ."""
+        return {ids[i]: {ids[i - 1]} for i in range(1, len(ids))}
+
+    def test_none_returns_all_stages_as_list(self):
+        stages = self._stages("a", "b", "c")
+        result = _apply_until_filter(stages, None, {})
+        assert [s.id for s in result] == ["a", "b", "c"]
+        # must be a fresh list, not the same object
+        assert result is not stages
+
+    def test_initial_stage_keeps_only_first(self):
+        result = _apply_until_filter(
+            self._stages("a", "b", "c"), "a", self._linear("a", "b", "c")
+        )
+        assert [s.id for s in result] == ["a"]
+
+    def test_middle_stage_includes_named_and_ancestors(self):
+        result = _apply_until_filter(
+            self._stages("a", "b", "c", "d"), "b", self._linear("a", "b", "c", "d")
+        )
+        assert [s.id for s in result] == ["a", "b"]
+
+    def test_terminal_stage_returns_full_list(self):
+        result = _apply_until_filter(
+            self._stages("a", "b", "c"), "c", self._linear("a", "b", "c")
+        )
+        assert [s.id for s in result] == ["a", "b", "c"]
+
+    def test_ancestor_declared_after_target_is_kept(self):
+        # Lineage a -> b -> c, but declared out of topological order [c, b, a].
+        # Old declaration-order slicing kept only [c]; transitive closure keeps all.
+        result = _apply_until_filter(
+            self._stages("c", "b", "a"), "c", self._linear("a", "b", "c")
+        )
+        assert [s.id for s in result] == ["c", "b", "a"]  # declaration order preserved
+
+    def test_unrelated_branch_is_pruned(self):
+        # root feeds both branch_a and branch_b; --until branch_a drops branch_b
+        # even though it is declared before branch_a.
+        parents = {"branch_a": {"root"}, "branch_b": {"root"}}
+        result = _apply_until_filter(
+            self._stages("root", "branch_b", "branch_a"), "branch_a", parents
+        )
+        assert [s.id for s in result] == ["root", "branch_a"]
+
+    def test_diamond_keeps_both_paths(self):
+        # a -> {b, c} -> d ; --until d keeps everything, --until b drops c.
+        parents = {"b": {"a"}, "c": {"a"}, "d": {"b", "c"}}
+        stages = self._stages("a", "b", "c", "d")
+        assert [s.id for s in _apply_until_filter(stages, "d", parents)] == [
+            "a",
+            "b",
+            "c",
+            "d",
+        ]
+        assert [s.id for s in _apply_until_filter(stages, "b", parents)] == ["a", "b"]
+
+    def test_root_stage_keeps_only_itself(self):
+        result = _apply_until_filter(
+            self._stages("a", "b", "c"), "a", {"b": {"a"}, "c": {"b"}}
+        )
+        assert [s.id for s in result] == ["a"]
+
+    def test_unknown_stage_raises(self):
+        with pytest.raises(ValueError, match="stage 'nope' not found"):
+            _apply_until_filter(self._stages("a", "b"), "nope", {})
+
+    def test_unknown_stage_lists_available(self):
+        with pytest.raises(ValueError, match="a, b"):
+            _apply_until_filter(self._stages("a", "b"), "missing", {})
+
+    def test_empty_stages_with_until_raises(self):
+        with pytest.raises(ValueError):
+            _apply_until_filter([], "anything", {})
+
+    def test_empty_stages_without_until_returns_empty(self):
+        assert _apply_until_filter([], None, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# _filter_collectors_by_stages
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubCollector:
+    id: str
+    inputs: list
+
+
+@pytest.mark.short
+class TestFilterCollectorsByStages:
+    def _benchmark(self, output_to_stage):
+        """Build a stub benchmark whose get_stage_by_output returns mapped stages."""
+        bench = MagicMock()
+        bench.get_stage_by_output.side_effect = lambda oid: output_to_stage.get(oid)
+        return bench
+
+    def test_keeps_collector_when_all_inputs_in_included_stages(self):
+        bench = self._benchmark({"methods.result": _StubStage("methods")})
+        collectors = [_StubCollector("MC1", inputs=["methods.result"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data", "methods"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC1"]
+        assert dropped == []
+
+    def test_drops_collector_when_any_input_in_pruned_stage(self):
+        bench = self._benchmark(
+            {
+                "methods.result": _StubStage("methods"),
+                "data.raw": _StubStage("data"),
+            }
+        )
+        collectors = [_StubCollector("MC1", inputs=["methods.result", "data.raw"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == ["MC1"]
+
+    def test_unknown_input_does_not_drop(self):
+        # Unknown outputs are left to the regular collector resolver to warn about.
+        bench = self._benchmark({})
+        collectors = [_StubCollector("MC1", inputs=["unknown.id"])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC1"]
+        assert dropped == []
+
+    def test_handles_iofile_inputs(self):
+        # Inputs may be IOFile objects (with `.id`) rather than bare strings.
+        from types import SimpleNamespace
+
+        bench = self._benchmark({"methods.result": _StubStage("methods")})
+        iofile = SimpleNamespace(id="methods.result")
+        collectors = [_StubCollector("MC1", inputs=[iofile])]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == ["MC1"]
+
+    def test_empty_collector_list(self):
+        bench = self._benchmark({})
+        kept, dropped = _filter_collectors_by_stages(
+            [], included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == []
+
+    def test_none_collector_list(self):
+        bench = self._benchmark({})
+        kept, dropped = _filter_collectors_by_stages(
+            None, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert kept == []
+        assert dropped == []
+
+    def test_partial_pruning_keeps_unrelated_collector(self):
+        bench = self._benchmark(
+            {
+                "methods.result": _StubStage("methods"),
+                "data.raw": _StubStage("data"),
+            }
+        )
+        collectors = [
+            _StubCollector("MC1", inputs=["methods.result"]),
+            _StubCollector("MC2", inputs=["data.raw"]),
+        ]
+        kept, dropped = _filter_collectors_by_stages(
+            collectors, included_stage_ids={"data"}, benchmark=bench
+        )
+        assert [c.id for c in kept] == ["MC2"]
+        assert dropped == ["MC1"]
+
+
+# ---------------------------------------------------------------------------
+# CLI conflict guard: --until + -m
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestUntilCliConflict:
+    def test_until_and_module_are_exclusive(self, caplog):
+        import logging
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("dummy.yaml").write_text("name: dummy")
+            with caplog.at_level(logging.ERROR, logger="omnibenchmark"):
+                result = runner.invoke(
+                    run,
+                    ["dummy.yaml", "-m", "M1", "--until", "methods"],
+                    catch_exceptions=False,
+                )
+        assert result.exit_code != 0
+        assert any("cannot be combined" in record.message for record in caplog.records)

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -1412,6 +1412,13 @@ class TestApplyUntilFilter:
 
     def test_diamond_keeps_both_paths(self):
         # a -> {b, c} -> d ; --until d keeps everything, --until b drops c.
+        #
+        # Algorithm-only: `d` has two divergent direct parents, which
+        # detect_diamond_input_joins rejects at validate/run time (#289), so this
+        # topology never reaches _apply_until_filter in a real benchmark. (Two
+        # parents on ONE chain are legal and do reach it; two on divergent
+        # branches, as here, do not.) Kept because the traversal must stay
+        # correct for when #289 lifts and divergent joins become legal.
         parents = {"b": {"a"}, "c": {"a"}, "d": {"b", "c"}}
         stages = self._stages("a", "b", "c", "d")
         assert [s.id for s in _apply_until_filter(stages, "d", parents)] == [
@@ -1564,3 +1571,41 @@ class TestUntilCliConflict:
                 )
         assert result.exit_code != 0
         assert any("cannot be combined" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# --until does not narrow validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestUntilValidatesWholeModel:
+    def test_diamond_outside_until_subgraph_still_rejected(self, caplog):
+        """--until cuts the DAG, it does not scope validation to the kept stages.
+
+        The fixture's diamond is at stage 'E', which is not an ancestor of 'B', so
+        the subgraph `--until B` actually needs is fine. It must still be rejected:
+        validation of the declared benchmark runs first (BenchmarkExecution's
+        constructor), the cut is applied afterwards, and `-m/--module` behaves the
+        same way. Pins that ordering so a rebase cannot silently move validation
+        behind the pruning.
+        """
+        import logging
+
+        fixture = (
+            Path(__file__).parent.parent
+            / "data"
+            / "benchmark_out_of_order_stages_failure.yaml"
+        )
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with caplog.at_level(logging.ERROR, logger="omnibenchmark"):
+                result = runner.invoke(
+                    run, [str(fixture), "--until", "B"], catch_exceptions=False
+                )
+
+        assert result.exit_code != 0
+        messages = " ".join(record.message for record in caplog.records)
+        assert "divergent branches" in messages
+        assert "'C1'" in messages and "'C2'" in messages

--- a/tests/e2e/test_03_data_preprocessing_methods_metrics.py
+++ b/tests/e2e/test_03_data_preprocessing_methods_metrics.py
@@ -34,3 +34,77 @@ def test_data_preprocessing_methods_metrics_pipeline(
     runner.verify_output_file_count(2, "*_data.json")  # 2 data files
     runner.verify_output_file_count(4, "*_preprocessed*.json")  # 4 preprocessing files
     runner.verify_output_file_count(8, "*_method*.json")  # 8 method result files
+
+
+@pytest.mark.e2e
+def test_until_preprocessing_truncates_pipeline(
+    data_preprocessing_methods_metrics_config, tmp_path, bundled_repos, keep_files
+):
+    """`--until preprocessing` runs data + preprocessing only; methods/metrics pruned."""
+    from tests.e2e.common import (
+        E2ETestRunner,
+        filter_files_excluding_symlinked_dirs,
+    )
+
+    runner = E2ETestRunner(tmp_path, keep_files)
+    config_file_in_tmp = runner.setup_test_environment(
+        data_preprocessing_methods_metrics_config,
+        "03_data_preprocessing_methods_metrics.yaml",
+    )
+
+    runner.execute_cli_command(
+        config_file_in_tmp,
+        ["--continue-on-error", "--until", "preprocessing"],
+    )
+
+    # data + preprocessing outputs are produced
+    data_files = filter_files_excluding_symlinked_dirs(runner.out_dir, "*_data.json")
+    preproc_files = filter_files_excluding_symlinked_dirs(
+        runner.out_dir, "*_preprocessed*.json"
+    )
+    assert len(data_files) >= 2, f"expected ≥2 data files, got {len(data_files)}"
+    assert (
+        len(preproc_files) >= 4
+    ), f"expected ≥4 preprocessing files, got {len(preproc_files)}"
+
+    # methods stage and metric collector outputs must NOT be produced
+    method_files = filter_files_excluding_symlinked_dirs(
+        runner.out_dir, "*_method*.json"
+    )
+    metrics_files = filter_files_excluding_symlinked_dirs(
+        runner.out_dir, "metrics.json"
+    )
+    assert method_files == [], f"unexpected method outputs: {method_files}"
+    assert metrics_files == [], f"unexpected metrics outputs: {metrics_files}"
+
+
+@pytest.mark.e2e
+def test_until_unknown_stage_errors(
+    data_preprocessing_methods_metrics_config, tmp_path, bundled_repos
+):
+    """`--until <unknown>` exits non-zero with a helpful message."""
+    from tests.cli.cli_setup import OmniCLISetup
+
+    runner_tmp = tmp_path / "out"
+    config_in_tmp = tmp_path / "03_data_preprocessing_methods_metrics.yaml"
+    import shutil
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(data_preprocessing_methods_metrics_config, config_in_tmp)
+
+    with OmniCLISetup() as omni:
+        result = omni.call(
+            [
+                "run",
+                str(config_in_tmp),
+                "--out-dir",
+                str(runner_tmp),
+                "--until",
+                "no_such_stage",
+            ],
+            cwd=str(tmp_path),
+        )
+
+    assert result.returncode != 0, "expected non-zero exit"
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "no_such_stage" in combined

--- a/tests/model/test_parse_errors.py
+++ b/tests/model/test_parse_errors.py
@@ -266,6 +266,21 @@ storage:
         assert error.original_error is not None
 
 
+def _field_warnings(recorded, field: str):
+    """FutureWarnings about *field*, ignoring anything else raised in the block.
+
+    Asserting on the total length of the recorded list makes these tests depend on
+    every warning `from_yaml` happens to trigger, including first-time-import
+    warnings from dependencies -- which are order- and environment-dependent and
+    have failed in CI while passing locally.
+    """
+    return [
+        x
+        for x in recorded
+        if issubclass(x.category, FutureWarning) and field in str(x.message)
+    ]
+
+
 @pytest.mark.short
 class TestDeprecationWarningForNumericFields:
     """Tests for deprecation warnings when version or benchmark_yaml_spec are numeric."""
@@ -293,12 +308,11 @@ outputs: []
             benchmark = Benchmark.from_yaml(yaml_file)
 
             # Verify warning was triggered
-            assert len(w) == 1
-            assert issubclass(w[0].category, FutureWarning)
-            assert "version" in str(w[0].message)
-            assert "should be a string" in str(w[0].message)
-            assert "1.4" in str(w[0].message)
-            assert "will not be valid in a future release" in str(w[0].message)
+            found = _field_warnings(w, "version")
+            assert len(found) == 1
+            assert "should be a string" in str(found[0].message)
+            assert "1.4" in str(found[0].message)
+            assert "will not be valid in a future release" in str(found[0].message)
 
         # Verify the benchmark loaded with the converted value
         assert benchmark.version == "1.4"
@@ -329,9 +343,7 @@ outputs: []
                 Benchmark.from_yaml(yaml_file)
 
             # Verify deprecation warning was triggered before validation error
-            assert len(w) == 1
-            assert issubclass(w[0].category, FutureWarning)
-            assert "version" in str(w[0].message)
+            assert len(_field_warnings(w, "version")) == 1
 
             # Verify the error is about semantic versioning format
             assert "does not follow strict semantic versioning format" in str(
@@ -359,10 +371,9 @@ outputs: []
             warnings.simplefilter("always")
             benchmark = Benchmark.from_yaml(yaml_file)
 
-            assert len(w) == 1
-            assert issubclass(w[0].category, FutureWarning)
-            assert "benchmark_yaml_spec" in str(w[0].message)
-            assert "should be a string" in str(w[0].message)
+            found = _field_warnings(w, "benchmark_yaml_spec")
+            assert len(found) == 1
+            assert "should be a string" in str(found[0].message)
 
         assert benchmark.benchmark_yaml_spec == "0.3"
 


### PR DESCRIPTION
Keeps the named stage plus its transitive ancestors (from declared topology, not YAML declaration order) before module resolution; skips metric collectors whose inputs reference pruned stages; rejects combination with -m/--module.

## Ticket

Provide a link to the [project](https://github.com/orgs/omnibenchmark/projects/1) ticket.

## Description

Provide a small description of Pull Request.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task.
- [x] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

## Remarks for the reviewer:

Leave here some remarks for the reviewer.