### PR TITLE
fix: expand stages topologically and reject diamond input join

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -242,6 +242,9 @@ jobs:
           # Install miniconda for conda backend (Snakemake subprocess needs real conda)
           wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
           bash ~/miniconda.sh -b -p $HOME/miniconda
+          # Miniconda 'latest' now ships Python 3.14 in base, which is outside the
+          # package's requires-python (>=3.12,<3.14). Pin base to a supported version.
+          $HOME/miniconda/bin/conda install -n base -y "python=3.13"
           echo "$HOME/miniconda/bin" >> $GITHUB_PATH
           
       - name: Install wheel
@@ -322,6 +325,9 @@ jobs:
       - name: Install micromamba
         run: |
           pixi add micromamba
+          # Pin base to a supported Python (requires-python is >=3.12,<3.14);
+          # the default base env may otherwise provision Python 3.14.
+          pixi run micromamba install -n base -y "python=3.13"
 
       - name: Install wheel with micromamba
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - feat: add opentelemetry support
 - feat: output path templates now support `{name}`, `{module.name}`, `{module.stage}`, and `{params.KEY}`; `{name}` always resolves to the current module's own ID (never inherited)
 - fix: properly render edges among stages based on I/O
+- fix: expand stages in topological order so a stage declared before an upstream-only producer resolves instead of failing with an opaque `Could not resolve input <id>` at run time (#289)
+- feat: `ob validate plan` rejects "diamond" input joins — a stage collecting inputs from two divergent branches (neither upstream of the other) — with an actionable error that names both branch stages, instead of surfacing only as a runtime warning (#289)
 - fix(pkg): give all authors emails so PyPI lists them correctly instead of partitioning name-only entries into the Author field
 
 ## [0.5.3](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.3) (Jun 15th 2026)

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -918,7 +918,20 @@ def _select_input_nodes(
     stage_ids_in_order: list[str],
     previous_stage_nodes: list,
 ) -> list:
-    """Return the node list to use as the cartesian expansion base for a stage."""
+    """Return the node list to use as the cartesian expansion base for a stage.
+
+    NOTE(#289): this collapses a stage's inputs down to a *single* parent stage
+    (the deepest already-expanded producer). It therefore assumes every declared
+    input is reachable along one linear ancestry chain from that parent. When a
+    stage joins two sibling branches (a "diamond"), the other branch's outputs are
+    not in that lineage and later fail to resolve. This is the crux of the
+    multi-stage input-collection limitation.
+
+    TODO(#289): once arbitrary multi-stage input collection is supported, this
+    single-parent selection (and the linear-ancestor walk in the resolution loop
+    below, `get_ancestor_nodes`) must be generalised to gather inputs from *all*
+    producing stages, not just the deepest one on a single chain.
+    """
     if not declared_input_ids:
         return previous_stage_nodes
 
@@ -1144,15 +1157,36 @@ def _generate_explicit_snakefile(
     if not quiet:
         logger.info("\nBuilding execution graph...")
 
+    # Expand stages in topological (dependency) order rather than declaration
+    # order. _select_input_nodes can only pick a parent among already-expanded
+    # stages, so a stage must be expanded after every stage producing its inputs.
+    # Sorting here makes declaration order irrelevant: a plan that declares a
+    # stage before an upstream producer still resolves, as long as that producer
+    # is genuinely upstream (not on a divergent branch -- see the diamond guard
+    # in model/validation.py). The sort is stable for already-ordered plans, so
+    # well-formed benchmarks are unaffected. See
+    # https://github.com/omnibenchmark/omnibenchmark/issues/289.
+    from omnibenchmark.core._graph import build_stage_dag, compute_stage_order
+
+    topo_order = compute_stage_order(build_stage_dag(benchmark.model))
+    topo_index = {stage_id: i for i, stage_id in enumerate(topo_order)}
+    topo_sorted_stages = sorted(
+        benchmark.model.stages,
+        key=lambda s: topo_index.get(s.id, len(topo_index)),
+    )
+
     # Module-filter pruning (ob run -m <module_id>)
     if module_filter:
-        target_stage_idx = None
-        for idx, stage in enumerate(benchmark.model.stages):
-            if any(m.id == module_filter for m in stage.modules):
-                target_stage_idx = idx
-                break
+        target_stage = next(
+            (
+                stage
+                for stage in benchmark.model.stages
+                if any(m.id == module_filter for m in stage.modules)
+            ),
+            None,
+        )
 
-        if target_stage_idx is None:
+        if target_stage is None:
             logger.error(
                 f"Module '{module_filter}' not found in benchmark. "
                 f"Available modules: "
@@ -1160,15 +1194,19 @@ def _generate_explicit_snakefile(
             )
             sys.exit(1)
 
-        target_stage = benchmark.model.stages[target_stage_idx]
-        stages_to_expand = benchmark.model.stages[: target_stage_idx + 1]
+        target_pos = topo_index.get(target_stage.id, len(topo_index))
+        stages_to_expand = [
+            stage
+            for stage in topo_sorted_stages
+            if topo_index.get(stage.id, len(topo_index)) <= target_pos
+        ]
         logger.info(
             f"Module mode: expanding {len(stages_to_expand)} stage(s) "
             f"(up to and including '{target_stage.id}'), "
             "first expansion only."
         )
     else:
-        stages_to_expand = benchmark.model.stages
+        stages_to_expand = topo_sorted_stages
 
     resolved_nodes = []
     nodes_by_id = {}
@@ -1290,6 +1328,13 @@ def _generate_explicit_snakefile(
 
                         output_id_to_path.update(get_output_ids_for_node(input_node))
 
+                        # TODO(#289): this only collects outputs from the node's
+                        # *linear* ancestors (nodes whose id is a prefix of this
+                        # one). Inputs produced on a sibling branch that re-joins
+                        # here are invisible and warn "Could not resolve input"
+                        # below. Generalise this (and _select_input_nodes above)
+                        # to gather from all producing lineages once multi-stage
+                        # input collection lands.
                         def get_ancestor_nodes(node):
                             ancestors = []
                             for prev_node in resolved_nodes:

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -1313,6 +1313,8 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
         """
         errors: List[str] = []
 
+        errors.extend(self.detect_diamond_input_joins())
+
         # Validate software environment paths (if benchmark_dir provided)
         if self.software_backend != SoftwareBackendEnum.host:
             for env in self.software_environments:

--- a/omnibenchmark/model/validation.py
+++ b/omnibenchmark/model/validation.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import List, TYPE_CHECKING, Any, Optional
+from typing import Dict, List, TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -152,6 +152,77 @@ class BenchmarkValidator:
 
         # 4. Validate that software environment references exist
         self._validate_software_environments(errors)
+
+        # 5. Reject stages that join two divergent branches (a "diamond").
+        # The execution resolver linearises each stage onto a single upstream
+        # lineage -- the deepest stage producing one of its inputs -- and can
+        # only resolve inputs found among that lineage's ancestors. This is fine
+        # whenever a stage's input-producing stages lie on ONE chain (each is an
+        # ancestor of the next), even if the stage is declared before them: the
+        # resolver expands stages in topological order, so declaration order does
+        # not matter. It CANNOT satisfy a stage whose inputs come from two stages
+        # on divergent branches (neither is upstream of the other) -- one branch
+        # always falls outside the chosen lineage and fails at run time with the
+        # opaque "Could not resolve input <id>". Reject that here instead. See
+        # https://github.com/omnibenchmark/omnibenchmark/issues/289.
+        #
+        # TODO(#289): remove this entire block (step 5) once the resolver
+        # supports arbitrary multi-stage input collection (gather/scatter), at
+        # which point joining branches in one stage becomes legal. Keep the
+        # general "input references a valid output" check in step 3.
+        output_producer: Dict[str, str] = {}
+        for stage in self.stages:  # type: ignore
+            for output in stage.outputs:  # type: ignore
+                output_producer.setdefault(output.id, stage.id)  # type: ignore
+
+        # Direct input-producing stages for each stage (deduplicated, order kept).
+        direct_producers: Dict[str, List[str]] = {}
+        for stage in self.stages:  # type: ignore
+            producers: List[str] = []
+            for input_collection in stage.inputs or []:  # type: ignore
+                for input_id in input_collection.entries:  # type: ignore
+                    producer = output_producer.get(input_id)
+                    if (
+                        producer is not None
+                        and producer != stage.id  # type: ignore
+                        and producer not in producers
+                    ):
+                        producers.append(producer)
+            direct_producers[stage.id] = producers  # type: ignore
+
+        def _is_upstream(ancestor: str, descendant: str) -> bool:
+            """True if *ancestor* produces (transitively) an input of *descendant*."""
+            seen: set = set()
+            stack = list(direct_producers.get(descendant, []))
+            while stack:
+                current = stack.pop()
+                if current == ancestor:
+                    return True
+                if current in seen:
+                    continue
+                seen.add(current)
+                stack.extend(direct_producers.get(current, []))
+            return False
+
+        for stage in self.stages:  # type: ignore
+            producers = direct_producers[stage.id]  # type: ignore
+            reported = False
+            for i in range(len(producers)):
+                for j in range(i + 1, len(producers)):
+                    left, right = producers[i], producers[j]
+                    if not (_is_upstream(left, right) or _is_upstream(right, left)):
+                        errors.append(
+                            f"Stage '{stage.id}' collects inputs from stages "  # type: ignore
+                            f"'{left}' and '{right}', which are on divergent branches "
+                            f"(neither is upstream of the other). Joining multiple "
+                            f"branches in a single stage is not supported yet; route "
+                            f"the inputs through a shared upstream stage instead. "
+                            f"See https://github.com/omnibenchmark/omnibenchmark/issues/289."
+                        )
+                        reported = True
+                        break
+                if reported:
+                    break
 
         # Raise error if any validation failed
         if errors:

--- a/omnibenchmark/model/validation.py
+++ b/omnibenchmark/model/validation.py
@@ -153,23 +153,39 @@ class BenchmarkValidator:
         # 4. Validate that software environment references exist
         self._validate_software_environments(errors)
 
-        # 5. Reject stages that join two divergent branches (a "diamond").
-        # The execution resolver linearises each stage onto a single upstream
-        # lineage -- the deepest stage producing one of its inputs -- and can
-        # only resolve inputs found among that lineage's ancestors. This is fine
-        # whenever a stage's input-producing stages lie on ONE chain (each is an
-        # ancestor of the next), even if the stage is declared before them: the
-        # resolver expands stages in topological order, so declaration order does
-        # not matter. It CANNOT satisfy a stage whose inputs come from two stages
-        # on divergent branches (neither is upstream of the other) -- one branch
-        # always falls outside the chosen lineage and fails at run time with the
-        # opaque "Could not resolve input <id>". Reject that here instead. See
-        # https://github.com/omnibenchmark/omnibenchmark/issues/289.
-        #
-        # TODO(#289): remove this entire block (step 5) once the resolver
-        # supports arbitrary multi-stage input collection (gather/scatter), at
-        # which point joining branches in one stage becomes legal. Keep the
-        # general "input references a valid output" check in step 3.
+        # NOTE: the "diamond" input-join check lives in detect_diamond_input_joins()
+        # and runs from validate_execution_context(), not here. It is an *execution*
+        # constraint, so ``ob validate plan`` and ``ob run`` enforce it, while
+        # loading a model purely to inspect or render it (mermaid/dot exporters,
+        # ``ob describe``) stays permissive and can visualise any topology.
+
+        # Raise error if any validation failed
+        if errors:
+            raise ValidationError(errors)
+
+    def detect_diamond_input_joins(self) -> List[str]:
+        """Return an error per stage that joins two divergent branches (a "diamond").
+
+        The execution resolver linearises each stage onto a single upstream lineage
+        -- the deepest stage producing one of its inputs -- and can only resolve
+        inputs found among that lineage's ancestors. This is fine whenever a stage's
+        input-producing stages lie on ONE chain (each is an ancestor of the next),
+        even if the stage is declared before them: the resolver expands stages in
+        topological order, so declaration order does not matter. It CANNOT satisfy a
+        stage whose inputs come from two stages on divergent branches (neither is
+        upstream of the other) -- one branch always falls outside the chosen lineage
+        and fails at run time with the opaque "Could not resolve input <id>".
+
+        This is an execution constraint only; callers wire it into
+        validate_execution_context so model loading for inspection/rendering stays
+        permissive. See https://github.com/omnibenchmark/omnibenchmark/issues/289.
+
+        TODO(#289): drop this method (and its call site) once the resolver supports
+        arbitrary multi-stage input collection (gather/scatter), at which point
+        joining branches in one stage becomes legal.
+        """
+        errors: List[str] = []
+
         output_producer: Dict[str, str] = {}
         for stage in self.stages:  # type: ignore
             for output in stage.outputs:  # type: ignore
@@ -224,9 +240,7 @@ class BenchmarkValidator:
                 if reported:
                     break
 
-        # Raise error if any validation failed
-        if errors:
-            raise ValidationError(errors)
+        return errors
 
     def _validate_software_environments(self, errors: List[str]) -> None:
         """Validate software environment references without checking file paths."""

--- a/tests/cli/test_run_benchmark.py
+++ b/tests/cli/test_run_benchmark.py
@@ -93,6 +93,27 @@ def test_local(tmp_path):
         assert_in_output(result.stdout, expected)
 
 
+def test_out_of_order_stages(tmp_path):
+    # Regression guard for omnibenchmark#289: stage 'D' (metric) is declared before
+    # the stages that produce its inputs, but every producer is genuinely upstream
+    # on a single linear chain (A -> B -> C -> D). The resolver expands stages
+    # topologically, so this must run to completion rather than fail with
+    # "Could not resolve input".
+    expected = "Benchmark run completed successfully."
+
+    with OmniCLISetup() as omni:
+        result = omni.call(
+            [
+                "run",
+                str(data / "benchmark_out_of_order_stages.yaml"),
+            ],
+            cwd=tmp_path,
+        )
+
+        assert result.returncode == 0
+        assert_in_output(result.stdout, expected)
+
+
 def test_custom_out_dir(tmp_path):
     # Check that benchmark runs successfully with custom output directory
     expected = "Benchmark run completed successfully."

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 
 from tests.cli.cli_setup import OmniCLISetup
+from tests.cli.path import data
 
 
 @pytest.fixture
@@ -140,6 +141,54 @@ class TestValidatePlanCLI:
         # The command should execute without errors
         # It may fail for other reasons (like missing modules), but YAML parsing should work
         assert "YAML file format error" not in result.stderr
+
+    @pytest.mark.short
+    def test_validate_plan_accepts_out_of_order_but_linear_stages(
+        self, cli_setup, temp_dir
+    ):
+        """Regression test for omnibenchmark#289 (the supported case).
+
+        A stage may be declared before a stage that produces one of its inputs, as
+        long as every producing stage is genuinely upstream on a single chain. The
+        resolver expands stages topologically, so declaration order alone must NOT
+        be a validation error.
+        """
+        result = cli_setup.call(
+            ["validate", "plan", str(data / "benchmark_out_of_order_stages.yaml")],
+            cwd=str(temp_dir),
+        )
+
+        assert result.returncode == 0
+        output = result.stdout + result.stderr
+        assert "validation passed" in output
+        assert "divergent branches" not in output
+
+    @pytest.mark.short
+    def test_validate_plan_rejects_diamond_input_collection(self, cli_setup, temp_dir):
+        """Regression test for omnibenchmark#289 (the unsupported case).
+
+        A stage that collects inputs from two stages on divergent branches (neither
+        upstream of the other) is a diamond the resolver cannot satisfy; at run time
+        it surfaced only as an opaque "Could not resolve input" warning. Plan
+        validation must reject it up front with an actionable message that names both
+        offending branch stages and references the tracking issue.
+        """
+        result = cli_setup.call(
+            [
+                "validate",
+                "plan",
+                str(data / "benchmark_out_of_order_stages_failure.yaml"),
+            ],
+            cwd=str(temp_dir),
+        )
+
+        assert result.returncode != 0
+        output = result.stdout + result.stderr
+        assert "Stage 'E'" in output
+        assert "'C1'" in output
+        assert "'C2'" in output
+        assert "divergent branches" in output
+        assert "issues/289" in output
 
 
 class TestValidateModuleCLI:

--- a/tests/data/benchmark_out_of_order_stages.yaml
+++ b/tests/data/benchmark_out_of_order_stages.yaml
@@ -1,0 +1,75 @@
+id: out_of_order_stages
+description: >
+  Regression fixture for omnibenchmark#289 -- the SUPPORTED case, and a runnable one.
+  The dependency chain is linear: A (data) -> B (process) -> C (method) -> D (metric).
+  Stage 'D' is declared *before* its producers 'B' and 'C', but every stage producing
+  one of D's inputs is genuinely upstream of it on that single chain, so the resolver --
+  which expands stages in topological order -- wires the inputs correctly and the
+  benchmark runs to completion. Plan validation must ACCEPT this: declaration order
+  alone is not an error. Modules reuse the omnibenchmark-example repos (see
+  Benchmark_001.yaml) so the stages actually link and execute on the host backend.
+version: "1.0"
+benchmarker: "Daniel Incicau, daniel.incicau@example.com"
+api_version: "0.3.0"
+software_backend: host
+software_environments:
+  python:
+    description: "python test env"
+    envmodule: "none"
+stages:
+  - id: A
+    modules:
+      - id: A1
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/data.git
+          commit: 63b7b36
+    outputs:
+      - id: data.counts
+        path: "{dataset}.txt.gz"
+      - id: data.meta
+        path: "{dataset}.meta.json"
+      - id: data.data_specific_params
+        path: "{dataset}_params.txt"
+  # Declared out of order: D depends on C (methods.mapping) and A, both upstream.
+  - id: D
+    inputs:
+      - methods.mapping
+      - data.meta
+      - data.data_specific_params
+    modules:
+      - id: D1
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/metric.git
+          commit: 579c643
+    outputs:
+      - id: metrics.mapping
+        path: "{dataset}.results.txt"
+  - id: B
+    inputs:
+      - data.counts
+      - data.meta
+    modules:
+      - id: B1
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/process.git
+          commit: 3b17081
+    outputs:
+      - id: process.filtered
+        path: "{dataset}.txt.gz"
+  - id: C
+    inputs:
+      - process.filtered
+      - data.meta
+      - data.data_specific_params
+    modules:
+      - id: C1
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/method.git
+          commit: 8f2f835
+    outputs:
+      - id: methods.mapping
+        path: "{dataset}.model.out.gz"

--- a/tests/data/benchmark_out_of_order_stages_failure.yaml
+++ b/tests/data/benchmark_out_of_order_stages_failure.yaml
@@ -1,0 +1,91 @@
+id: out_of_order_stages_failure
+description: >
+  Regression fixture for omnibenchmark#289 -- the UNSUPPORTED case (a diamond), built
+  from the same omnibenchmark-example modules as benchmark_out_of_order_stages.yaml.
+  Stage 'B' (process) fans out to two parallel 'method' stages 'C1' and 'C2', and
+  stage 'E' (metric) joins them by declaring inputs from both. 'C1' and 'C2' are on
+  divergent branches (neither is upstream of the other), so the resolver -- which
+  linearises each stage onto a single upstream lineage -- can only keep one branch;
+  if it were run it would fail with "Could not resolve input" for the other branch.
+  No stage reordering can fix this. Plan validation must REJECT it up front.
+version: "1.0"
+benchmarker: "Daniel Incicau, daniel.incicau@example.com"
+api_version: "0.3.0"
+software_backend: host
+software_environments:
+  python:
+    description: "python test env"
+    envmodule: "none"
+stages:
+  - id: A
+    modules:
+      - id: A1
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/data.git
+          commit: 63b7b36
+    outputs:
+      - id: data.counts
+        path: "{dataset}.txt.gz"
+      - id: data.meta
+        path: "{dataset}.meta.json"
+      - id: data.data_specific_params
+        path: "{dataset}_params.txt"
+  - id: B
+    inputs:
+      - data.counts
+      - data.meta
+    modules:
+      - id: B1
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/process.git
+          commit: 3b17081
+    outputs:
+      - id: process.filtered
+        path: "{dataset}.txt.gz"
+  # C1 and C2 both consume process.filtered -> two divergent sibling branches off B.
+  - id: C1
+    inputs:
+      - process.filtered
+      - data.meta
+      - data.data_specific_params
+    modules:
+      - id: C1m
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/method.git
+          commit: 8f2f835
+    outputs:
+      - id: methods.mapping
+        path: "{dataset}.model.out.gz"
+  - id: C2
+    inputs:
+      - process.filtered
+      - data.meta
+      - data.data_specific_params
+    modules:
+      - id: C2m
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/method.git
+          commit: 8f2f835
+    outputs:
+      - id: methods.mapping2
+        path: "{dataset}.model.out.gz"
+  # E joins the two divergent branches C1 and C2 -> the unsupported diamond.
+  - id: E
+    inputs:
+      - methods.mapping
+      - methods.mapping2
+      - data.meta
+      - data.data_specific_params
+    modules:
+      - id: E1
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/metric.git
+          commit: 579c643
+    outputs:
+      - id: metrics.mapping
+        path: "{dataset}.results.txt"


### PR DESCRIPTION
## Ticket

Refs [#289](https://github.com/omnibenchmark/omnibenchmark/issues/289) — support for multi-stage outputs.

## Description

Runs surfaced an opaque `Could not resolve input <id>` warning that turned out to hide **two distinct problems**. This PR fixes one and guards the other.

**1. Declaration order was load-bearing (bug — fixed).** The resolver expanded stages in YAML *declaration* order, so a stage declared before a stage producing one of its inputs failed even when that producer was genuinely upstream on a single chain. Stages are now expanded in **topological order** (`core._graph.compute_stage_order`); the sort is stable, so already-ordered plans are unaffected.

```mermaid
graph LR
  A --> B
  A --> C
  A --> D
  B --> C
  C --> D
```

`D` may be declared before `B`/`C` — every producer of `D`'s inputs is upstream on one chain, so it resolves and runs.

**2. Diamond input joins are genuinely unsupported (#289 — now guarded).** When a stage collects inputs from two stages on **divergent branches** (neither upstream of the other), the resolver linearises onto a single lineage and drops the other branch. `ob validate plan` now rejects this up front with an actionable message naming both branch stages and linking the issue, instead of the opaque runtime warning.

```mermaid
graph LR
  A --> B
  B --> C1
  B --> C2
  C1 --> E
  C2 --> E
```

> Stage 'E' collects inputs from stages 'C1' and 'C2', which are on divergent branches (neither is upstream of the other). Joining multiple branches in a single stage is not supported yet; route the inputs through a shared upstream stage instead. See omnibenchmark/omnibenchmark#289.

`TODO(#289)` markers on the single-parent selection (`_select_input_nodes`), the linear-ancestor walk (`get_ancestor_nodes`), and the validation guard flag exactly what to remove/generalise once gather/scatter input collection lands.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task. _(n/a — no new CLI command; only new validation behaviour on `ob validate plan`)_
- [x] I have documented the CLI method accordingly. _(n/a — surfaced via the validation error message)_
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

## Remarks for the reviewer:

- Two regression fixtures are added, both built from the `omnibenchmark-example` modules (`data → process → method → metric`) so they actually resolve and run:
  - `benchmark_out_of_order_stages.yaml` — supported case: the metric stage is declared out of order but upstream-linear; `test_out_of_order_stages` runs it end-to-end.
  - `benchmark_out_of_order_stages_failure.yaml` — the unsupported diamond; `test_validate_plan_rejects_diamond_input_collection` asserts it is rejected.
- I confirmed the diamond genuinely fails at run time (bypassing the guard reproduces `Could not resolve input methods.mapping`), so the validator is catching a real failure rather than being over-conservative.
