### PR TITLE
feat: reject excludes that leave a module with no valid lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - fix: properly render edges among stages based on I/O
 - fix: expand stages in topological order so a stage declared before an upstream-only producer resolves instead of failing with an opaque `Could not resolve input <id>` at run time (#289)
 - feat: `ob validate plan` rejects "diamond" input joins — a stage collecting inputs from two divergent branches (neither upstream of the other) — with an actionable error that names both branch stages, instead of surfacing only as a runtime warning (#289)
+- feat: `ob validate plan` rejects modules whose `exclude` rules leave no valid upstream lineage — they would expand to zero nodes and make downstream consumers fail with `Could not resolve input` at run time; the error names the module that can never run and the input it can no longer receive (#289)
 - fix(pkg): give all authors emails so PyPI lists them correctly instead of partitioning name-only entries into the Author field
 
 ## [0.5.3](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.3) (Jun 15th 2026)

--- a/omnibenchmark/model/benchmark.py
+++ b/omnibenchmark/model/benchmark.py
@@ -1315,6 +1315,8 @@ class Benchmark(DescribableEntity, BenchmarkValidator):
 
         errors.extend(self.detect_diamond_input_joins())
 
+        errors.extend(self.detect_unsatisfiable_excludes())
+
         # Validate software environment paths (if benchmark_dir provided)
         if self.software_backend != SoftwareBackendEnum.host:
             for env in self.software_environments:

--- a/omnibenchmark/model/validation.py
+++ b/omnibenchmark/model/validation.py
@@ -242,6 +242,171 @@ class BenchmarkValidator:
 
         return errors
 
+    def detect_unsatisfiable_excludes(self) -> List[str]:
+        """Return an error per module that can never produce a node because its
+        ``exclude`` rules leave no valid upstream lineage.
+
+        ``exclude`` makes two module ids mutually incompatible within a lineage
+        (see ``core._paths.is_lineage_excluded``). Combined with the data-flow
+        dependencies, a module's excludes -- or those of the stages producing its
+        inputs -- can eliminate every root ("initial"-stage) lineage that would
+        supply its inputs. The module then expands to **zero nodes**, and every
+        downstream consumer of its outputs fails at run time with the opaque
+        "Could not resolve input <id>". Detect that here instead.
+
+        Method: propagate, per module, the set of root-stage module ids from which
+        a valid lineage to that module exists -- compatible under ``exclude``, with
+        every declared input satisfiable by some compatible producer sharing that
+        root. A module whose reachable-root set is empty can never run.
+
+        The reachable set is an over-approximation (it does not track pairwise
+        incompatibilities between two *different* producer modules on the same
+        lineage), so an empty set is a **sound** signal: it always means zero
+        nodes, never a false positive.
+        """
+        errors: List[str] = []
+        stages = list(self.stages)  # type: ignore
+        if not stages:
+            return errors
+
+        # exclude relation (symmetric in effect, matching is_lineage_excluded)
+        excludes: Dict[str, set] = {}
+        for stage in stages:
+            for module in stage.modules:  # type: ignore
+                declared = self.get_module_excludes(module.id)  # type: ignore
+                if declared:
+                    excludes[module.id] = set(declared)
+
+        def incompatible(a: str, b: str) -> bool:
+            return b in excludes.get(a, ()) or a in excludes.get(b, ())
+
+        # output id -> producing stage id (first declarer)
+        output_stage: Dict[str, str] = {}
+        for stage in stages:
+            for output in stage.outputs:  # type: ignore
+                output_stage.setdefault(output.id, stage.id)  # type: ignore
+
+        stage_by_id = {stage.id: stage for stage in stages}  # type: ignore
+
+        def input_groups(stage) -> List[List[str]]:
+            return [ic.entries for ic in (stage.inputs or [])]  # type: ignore
+
+        def producer_stage_ids(stage) -> set:
+            result: set = set()
+            for group in input_groups(stage):
+                for input_id in group:
+                    producer = output_stage.get(input_id)
+                    if producer is not None and producer != stage.id:  # type: ignore
+                        result.add(producer)
+            return result
+
+        # Topologically order stages (producers before consumers). Kahn-style;
+        # bail out on a cycle (reported elsewhere) to avoid spurious errors.
+        deps = {stage.id: producer_stage_ids(stage) for stage in stages}  # type: ignore
+        order: List[str] = []
+        placed: set = set()
+        while len(order) < len(stages):
+            progressed = False
+            for stage in stages:  # declaration order → deterministic
+                if stage.id not in placed and deps[stage.id] <= placed:  # type: ignore
+                    order.append(stage.id)  # type: ignore
+                    placed.add(stage.id)  # type: ignore
+                    progressed = True
+            if not progressed:
+                return errors
+
+        # reachable roots per module id (over-approximation)
+        reachable: Dict[str, set] = {}
+        for stage_id in order:
+            stage = stage_by_id[stage_id]
+            groups = input_groups(stage)
+            for module in stage.modules:  # type: ignore
+                if not groups:
+                    # initial stage: the module is itself a root
+                    reachable[module.id] = {module.id}  # type: ignore
+                    continue
+
+                all_roots: set = (
+                    set().union(*reachable.values()) if reachable else set()
+                )
+                module_roots: set = set()
+                for root in all_roots:
+                    if incompatible(module.id, root):  # type: ignore
+                        continue
+                    for group in groups:
+                        if all(
+                            output_stage.get(input_id) is not None
+                            and any(
+                                not incompatible(module.id, pm.id)  # type: ignore
+                                and root in reachable.get(pm.id, ())
+                                for pm in stage_by_id[output_stage[input_id]].modules  # type: ignore
+                            )
+                            for input_id in group
+                        ):
+                            module_roots.add(root)
+                            break
+                reachable[module.id] = module_roots  # type: ignore
+
+                if module_roots:
+                    continue
+
+                culprit = self._first_unsatisfiable_input(
+                    module.id,  # type: ignore
+                    groups,
+                    all_roots,
+                    output_stage,
+                    stage_by_id,
+                    reachable,
+                    incompatible,
+                )
+
+                # Suppress downstream cascades: if the blocking input's producer
+                # stage cannot run *at all* (every module there is itself zero-node),
+                # this failure is a consequence of that upstream module, which is
+                # reported as its own primary cause. Only report primary causes —
+                # where the input is genuinely produced somewhere but this module's
+                # excludes keep it off every compatible lineage.
+                if culprit is not None:
+                    producers = stage_by_id[culprit[1]].modules  # type: ignore
+                    if all(not reachable.get(pm.id) for pm in producers):  # type: ignore
+                        continue
+
+                detail = (
+                    f" Input '{culprit[0]}' (produced by stage '{culprit[1]}') "
+                    f"is only available on lineages excluded here."
+                    if culprit
+                    else ""
+                )
+                errors.append(
+                    f"Module '{stage_id}/{module.id}' can never run: its "  # type: ignore
+                    f"`exclude` rules (with those of its input-producing modules) "
+                    f"leave no valid upstream lineage, so it expands to zero nodes "
+                    f"and downstream consumers fail with 'Could not resolve input'."
+                    f"{detail} Reconcile the `exclude` lists on this module and the "
+                    f"stages producing its inputs."
+                )
+        return errors
+
+    @staticmethod
+    def _first_unsatisfiable_input(
+        module_id, groups, all_roots, output_stage, stage_by_id, reachable, incompatible
+    ):
+        """Name the first declared input with no exclude-compatible producer lineage."""
+        own_roots = {r for r in all_roots if not incompatible(module_id, r)}
+        for group in groups:
+            for input_id in group:
+                producer_stage_id = output_stage.get(input_id)
+                if producer_stage_id is None:
+                    continue
+                producers = stage_by_id[producer_stage_id].modules
+                satisfiable_roots: set = set()
+                for pm in producers:
+                    if not incompatible(module_id, pm.id):
+                        satisfiable_roots |= reachable.get(pm.id, set())
+                if not (own_roots & satisfiable_roots):
+                    return (input_id, producer_stage_id)
+        return None
+
     def _validate_software_environments(self, errors: List[str]) -> None:
         """Validate software environment references without checking file paths."""
         env_ids = {env.id for env in self.software_environments}  # type: ignore

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -190,6 +190,26 @@ class TestValidatePlanCLI:
         assert "divergent branches" in output
         assert "issues/289" in output
 
+    @pytest.mark.short
+    def test_validate_plan_rejects_exclude_zero_nodes(self, cli_setup, temp_dir):
+        """Regression test for omnibenchmark#289 (exclude reachability).
+
+        A module whose `exclude` rules leave no valid upstream lineage expands to
+        zero nodes; consumers of its outputs then fail at run time with the opaque
+        "Could not resolve input". Plan validation must reject it up front, naming
+        the module that can never run and the input that is unavailable.
+        """
+        result = cli_setup.call(
+            ["validate", "plan", str(data / "benchmark_exclude_zero_nodes.yaml")],
+            cwd=str(temp_dir),
+        )
+
+        assert result.returncode != 0
+        output = result.stdout + result.stderr
+        assert "PCA/pc" in output
+        assert "can never run" in output
+        assert "feat.out" in output
+
 
 class TestValidateModuleCLI:
     """Test suite for the validate module command."""

--- a/tests/data/benchmark_exclude_zero_nodes.yaml
+++ b/tests/data/benchmark_exclude_zero_nodes.yaml
@@ -1,0 +1,60 @@
+id: exclude_zero_nodes
+description: >
+  Regression fixture for omnibenchmark#289 -- exclude reachability. The DATA stage
+  offers two collections (dA, dB). FEAT's module excludes dB, so FEAT only produces
+  'feat.out' on the dA lineage. PCA's module excludes dA, so PCA can only run on the
+  dB lineage -- but 'feat.out' (its input) never exists there. PCA therefore expands
+  to zero nodes, and its output can never be produced, so any downstream consumer
+  fails at run time with "Could not resolve input". Plan validation must REJECT this.
+version: "1.0"
+benchmarker: "Daniel Incicau, daniel.incicau@gmail.com"
+api_version: "0.3.0"
+software_backend: host
+software_environments:
+  python:
+    description: "py"
+    envmodule: "none"
+stages:
+  - id: DATA
+    modules:
+      - id: dA
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/data.git
+          commit: 63b7b36
+      - id: dB
+        software_environment: python
+        repository:
+          url: https://github.com/omnibenchmark-example/data.git
+          commit: 63b7b36
+    outputs:
+      - id: raw
+        path: "{dataset}.txt.gz"
+  - id: FEAT
+    inputs:
+      - raw
+    modules:
+      - id: fe
+        software_environment: python
+        exclude:
+          - dB
+        repository:
+          url: https://github.com/omnibenchmark-example/process.git
+          commit: 3b17081
+    outputs:
+      - id: feat.out
+        path: "{dataset}.feat.tsv"
+  - id: PCA
+    inputs:
+      - feat.out
+    modules:
+      - id: pc
+        software_environment: python
+        exclude:
+          - dA
+        repository:
+          url: https://github.com/omnibenchmark-example/process.git
+          commit: 3b17081
+    outputs:
+      - id: pca.out
+        path: "{dataset}.pca.tsv"

--- a/tests/model/test_exclude_reachability.py
+++ b/tests/model/test_exclude_reachability.py
@@ -1,0 +1,86 @@
+"""Unit tests for exclude-reachability validation (omnibenchmark#289).
+
+`detect_unsatisfiable_excludes()` flags modules whose `exclude` rules leave no
+valid upstream lineage, so they would expand to zero nodes at run time.
+"""
+
+import textwrap
+from pathlib import Path
+
+from omnibenchmark.model import Benchmark
+
+_HEADER = """
+id: t
+version: "1.0"
+benchmarker: "t"
+api_version: "0.3.0"
+software_backend: host
+software_environments:
+  py:
+    description: py
+    envmodule: none
+stages:
+"""
+
+
+def _model(tmp_path: Path, stages_yaml: str) -> Benchmark:
+    yaml_file = tmp_path / "b.yaml"
+    yaml_file.write_text(_HEADER + textwrap.dedent(stages_yaml))
+    return Benchmark.from_yaml(yaml_file)
+
+
+# Two DATA collections; a downstream module per collection, each excluding the
+# other collection. Every module still has a valid lineage — nothing is zero-node.
+_BENIGN = """
+  - id: DATA
+    modules:
+      - {id: dA, software_environment: py, repository: {url: u, commit: c}}
+      - {id: dB, software_environment: py, repository: {url: u, commit: c}}
+    outputs:
+      - {id: raw, path: "{dataset}.txt"}
+  - id: PROC
+    inputs: [raw]
+    modules:
+      - {id: pA, software_environment: py, exclude: [dB], repository: {url: u, commit: c}}
+      - {id: pB, software_environment: py, exclude: [dA], repository: {url: u, commit: c}}
+    outputs:
+      - {id: proc.out, path: "{dataset}.out"}
+"""
+
+# FEAT excludes dB (runs only on dA); PCA excludes dA (runs only on dB) but consumes
+# FEAT's output, which never exists on dB → PCA is zero-node.
+_ZERO_NODE = """
+  - id: DATA
+    modules:
+      - {id: dA, software_environment: py, repository: {url: u, commit: c}}
+      - {id: dB, software_environment: py, repository: {url: u, commit: c}}
+    outputs:
+      - {id: raw, path: "{dataset}.txt"}
+  - id: FEAT
+    inputs: [raw]
+    modules:
+      - {id: fe, software_environment: py, exclude: [dB], repository: {url: u, commit: c}}
+    outputs:
+      - {id: feat.out, path: "{dataset}.feat"}
+  - id: PCA
+    inputs: [feat.out]
+    modules:
+      - {id: pc, software_environment: py, exclude: [dA], repository: {url: u, commit: c}}
+    outputs:
+      - {id: pca.out, path: "{dataset}.pca"}
+"""
+
+
+def test_benign_excludes_are_not_flagged(tmp_path):
+    model = _model(tmp_path, _BENIGN)
+    assert model.detect_unsatisfiable_excludes() == []
+
+
+def test_zero_node_module_is_flagged(tmp_path):
+    model = _model(tmp_path, _ZERO_NODE)
+    errors = model.detect_unsatisfiable_excludes()
+    # Only the primary cause (PCA/pc) is reported, not FEAT (which can run).
+    assert len(errors) == 1
+    assert "PCA/pc" in errors[0]
+    assert "feat.out" in errors[0]
+    assert "can never run" in errors[0]


### PR DESCRIPTION
## Description

Adds a static validation that catches a class of `exclude` misconfiguration which currently passes `ob validate plan` but fails at run time with the opaque `Could not resolve input <id>`.

**The problem.** `exclude` makes two module ids mutually incompatible within a lineage. When a stage's excludes — or those of the stages producing its inputs — eliminate *every* root ("initial"-stage) lineage that could supply its inputs, that module expands to **zero nodes**. Its outputs are then never produced, and every downstream consumer fails to resolve them. Stage-level topology validation can't see this because it doesn't simulate `exclude`-based node pruning.

Concrete example (the shape that surfaced this — see `benchmark_exclude_zero_nodes.yaml`): `DATA` offers two collections, and `FEAT`/`PCA` are pinned to *different* ones, while `PCA` depends on `FEAT`:

| Stage/module | `exclude` | ⇒ runs only on | needs |
|---|---|---|---|
| `FEAT/fe` | `dB` | `dA` | `raw` |
| `PCA/pc` | `dA` | `dB` | `feat.out` (from `FEAT`) |

`PCA` can only run on `dB`, but `feat.out` is only produced on `dA` → `PCA` produces no nodes → consumers hit `Could not resolve input`.

**The fix.** `BenchmarkValidator.detect_unsatisfiable_excludes()` propagates, per module in topological order, the set of root modules from which a valid `exclude`-compatible lineage exists that satisfies all its inputs. A module with an empty set can never run and is reported. The set is an over-approximation (it doesn't track pairwise incompatibilities between two *different* producers on one lineage), so an empty set is a **sound** signal — no false positives. It runs in `validate_execution_context`, so `ob validate plan`/`ob run` enforce it while model loading for inspection/rendering (mermaid/dot, `ob describe`) stays permissive.

Only **primary** causes are reported (downstream cascades suppressed): on the plan that triggered this, the output drops from 16 errors to the 2 real ones, e.g.

> Module 'PCA/pc' can never run: its `exclude` rules (with those of its input-producing modules) leave no valid upstream lineage, so it expands to zero nodes and downstream consumers fail with 'Could not resolve input'. Input 'feat.out' (produced by stage 'FEAT') is only available on lineages excluded here. Reconcile the `exclude` lists on this module and the stages producing its inputs. See omnibenchmark/omnibenchmark#289.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My CLI method respects the signature defined in the task. _(n/a — no new CLI command; new validation behaviour on `ob validate plan`)_
- [x] I have documented the CLI method accordingly. _(n/a — surfaced via the validation error message)_
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.

## Remarks for the reviewer:

- `benchmark_exclude_zero_nodes.yaml` is a minimal, abstract repro. Tests: `tests/cli/test_validate.py::TestValidatePlanCLI::test_validate_plan_rejects_exclude_zero_nodes` (CLI) and `tests/model/test_exclude_reachability.py` (unit — flagged case **and** a benign `exclude` case that must pass, guarding against false positives; `Benchmark_001`'s existing `exclude`s also still validate clean).
- Soundness note: the reachable-root set over-approximates, so the check only ever *misses* some zero-node cases (false negatives) — it never rejects a valid plan.
- No new run-time behaviour: purely additive validation, gated to the execution-context path.
