### PR TITLE
fix: replace O(2^depth) ancestor recursion in Snakefile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 
 - feat: add opentelemetry support
 - feat: output path templates now support `{name}`, `{module.name}`, `{module.stage}`, and `{params.KEY}`; `{name}` always resolves to the current module's own ID (never inherited)
-- fix: properly render edges among stages based on I/O
-- fix: expand stages in topological order so a stage declared before an upstream-only producer resolves instead of failing with an opaque `Could not resolve input <id>` at run time (#289)
 - feat: `ob validate plan` rejects "diamond" input joins — a stage collecting inputs from two divergent branches (neither upstream of the other) — with an actionable error that names both branch stages, instead of surfacing only as a runtime warning (#289)
 - feat: `ob validate plan` rejects modules whose `exclude` rules leave no valid upstream lineage — they would expand to zero nodes and make downstream consumers fail with `Could not resolve input` at run time; the error names the module that can never run and the input it can no longer receive (#289)
+- fix: properly render edges among stages based on I/O
+- fix: expand stages in topological order so a stage declared before an upstream-only producer resolves instead of failing with an opaque `Could not resolve input <id>` at run time (#289)
 - fix(pkg): give all authors emails so PyPI lists them correctly instead of partitioning name-only entries into the Author field
-- bug: make status --logs display logs for failed rules (#318)
+- fix: make status --logs display logs for failed rules (#318)
+- fix: replace O(2^depth) ancestor recursion in Snakefile generation
 
 ## [0.5.3](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.5.3) (Jun 15th 2026)
 

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -24,6 +24,12 @@ from omnibenchmark.core._paths import (
     collect_path_exclusions,
     is_lineage_excluded,
 )
+from omnibenchmark.core._lineage import (
+    lineage_ancestors,
+    lineage_module_ids,
+    satisfies_requires,
+    select_input_nodes,
+)
 from omnibenchmark.model.params import Params
 from omnibenchmark.cli.formatting import pretty_print_parse_error
 from omnibenchmark.logging import logger
@@ -911,83 +917,6 @@ def _build_template_context(
     return TemplateContext(provides=provides, module_attrs=module_attrs)
 
 
-def _select_input_nodes(
-    declared_input_ids: list[str],
-    output_to_nodes: dict,
-    resolved_nodes: list,
-    stage_ids_in_order: list[str],
-    previous_stage_nodes: list,
-) -> list:
-    """Return the node list to use as the cartesian expansion base for a stage.
-
-    NOTE(#289): this collapses a stage's inputs down to a *single* parent stage
-    (the deepest already-expanded producer). It therefore assumes every declared
-    input is reachable along one linear ancestry chain from that parent. When a
-    stage joins two sibling branches (a "diamond"), the other branch's outputs are
-    not in that lineage and later fail to resolve. This is the crux of the
-    multi-stage input-collection limitation.
-
-    TODO(#289): once arbitrary multi-stage input collection is supported, this
-    single-parent selection (and the linear-ancestor walk in the resolution loop
-    below, `get_ancestor_nodes`) must be generalised to gather inputs from *all*
-    producing stages, not just the deepest one on a single chain.
-    """
-    if not declared_input_ids:
-        return previous_stage_nodes
-
-    providing_stage_id_to_depth: dict[str, int] = {}
-    for input_id in declared_input_ids:
-        for node_id, _path in output_to_nodes.get(input_id, []):
-            node_obj = next(
-                (n for n in resolved_nodes if n.id == node_id),
-                None,
-            )
-            if node_obj is not None:
-                depth = (
-                    stage_ids_in_order.index(node_obj.stage_id)
-                    if node_obj.stage_id in stage_ids_in_order
-                    else -1
-                )
-                existing = providing_stage_id_to_depth.get(node_obj.stage_id, -1)
-                if depth > existing:
-                    providing_stage_id_to_depth[node_obj.stage_id] = depth
-
-    if not providing_stage_id_to_depth:
-        return previous_stage_nodes
-
-    deepest_stage_id = max(
-        providing_stage_id_to_depth,
-        key=providing_stage_id_to_depth.__getitem__,
-    )
-    return [n for n in resolved_nodes if n.stage_id == deepest_stage_id]
-
-
-def _satisfies_requires(requires: dict, input_node) -> bool:
-    """Return True if the input_node's lineage satisfies all requires constraints."""
-    if not input_node.template_context:
-        return False
-    for label, required_value in requires.items():
-        actual_value = input_node.template_context.provides.get(label)
-        if actual_value != required_value:
-            return False
-    return True
-
-
-def _lineage_module_ids(input_node, nodes_by_id) -> set:
-    """Return the module_ids along input_node's full lineage, inclusive.
-
-    Walks the explicit ``parent_id`` chain rather than matching node-ID string
-    prefixes, so it is unaffected by module/stage ids that contain the id
-    separator. ``nodes_by_id`` maps node id → node.
-    """
-    lineage = set()
-    node = input_node
-    while node is not None:
-        lineage.add(node.module_id)
-        node = nodes_by_id.get(node.parent_id) if node.parent_id else None
-    return lineage
-
-
 def _generate_explicit_snakefile(
     benchmark: BenchmarkExecution,
     benchmark_yaml_path: Path,
@@ -1214,6 +1143,11 @@ def _generate_explicit_snakefile(
     previous_stage_nodes = []
     dag_errors: list[tuple[str, str, str]] = []
 
+    # stage_id -> ordered output ids. Precomputed once so per-node output lookup
+    # is O(1) instead of scanning every stage and doing an O(outputs) pydantic
+    # `.index()` (was ~180k __eq__ calls during generation).
+    stage_output_ids = {s.id: [o.id for o in s.outputs] for s in benchmark.model.stages}
+
     # Lineage-wide exclusion rules, shared with execution-path pruning so the
     # two code paths agree (see core._paths.is_lineage_excluded).
     path_exclusions = collect_path_exclusions(benchmark.model)
@@ -1260,10 +1194,11 @@ def _generate_explicit_snakefile(
                     ]
 
                     stage_ids_in_order = [s.id for s in stages_to_expand]
-                    input_node_combinations = _select_input_nodes(
+                    input_node_combinations = select_input_nodes(
                         declared_input_ids=declared_input_ids,
                         output_to_nodes=output_to_nodes,
                         resolved_nodes=resolved_nodes,
+                        nodes_by_id=nodes_by_id,
                         stage_ids_in_order=stage_ids_in_order,
                         previous_stage_nodes=previous_stage_nodes,
                     )
@@ -1282,7 +1217,7 @@ def _generate_explicit_snakefile(
                     # the immediate predecessor: prune if any exclusion rule has
                     # both endpoints present along this node's lineage.
                     if input_node:
-                        lineage = _lineage_module_ids(input_node, nodes_by_id) | {
+                        lineage = lineage_module_ids(input_node, nodes_by_id) | {
                             module_id
                         }
                         if is_lineage_excluded(lineage, path_exclusions):
@@ -1293,7 +1228,7 @@ def _generate_explicit_snakefile(
                             continue
 
                     if input_node and module.requires:
-                        if not _satisfies_requires(module.requires, input_node):
+                        if not satisfies_requires(module.requires, input_node):
                             logger.debug(
                                 f"      Skipping combination: requires not satisfied for {module_id} "
                                 f"(upstream context: {input_node.template_context.provides})"
@@ -1315,16 +1250,13 @@ def _generate_explicit_snakefile(
                         output_id_to_path = {}
 
                         def get_output_ids_for_node(node):
-                            result = {}
-                            for s in benchmark.model.stages:
-                                if s.id == node.stage_id:
-                                    for output_spec in s.outputs:
-                                        output_index = s.outputs.index(output_spec)
-                                        if output_index < len(node.outputs):
-                                            result[output_spec.id] = node.outputs[
-                                                output_index
-                                            ]
-                            return result
+                            return {
+                                output_id: node.outputs[i]
+                                for i, output_id in enumerate(
+                                    stage_output_ids.get(node.stage_id, [])
+                                )
+                                if i < len(node.outputs)
+                            }
 
                         output_id_to_path.update(get_output_ids_for_node(input_node))
 
@@ -1335,15 +1267,7 @@ def _generate_explicit_snakefile(
                         # below. Generalise this (and _select_input_nodes above)
                         # to gather from all producing lineages once multi-stage
                         # input collection lands.
-                        def get_ancestor_nodes(node):
-                            ancestors = []
-                            for prev_node in resolved_nodes:
-                                if node.id.startswith(prev_node.id + "-"):
-                                    ancestors.append(prev_node)
-                                    ancestors.extend(get_ancestor_nodes(prev_node))
-                            return ancestors
-
-                        for ancestor in get_ancestor_nodes(input_node):
+                        for ancestor in lineage_ancestors(input_node, nodes_by_id):
                             output_id_to_path.update(get_output_ids_for_node(ancestor))
 
                         if stage.inputs:

--- a/omnibenchmark/cli/run.py
+++ b/omnibenchmark/cli/run.py
@@ -1087,7 +1087,7 @@ def _generate_explicit_snakefile(
         logger.info("\nBuilding execution graph...")
 
     # Expand stages in topological (dependency) order rather than declaration
-    # order. _select_input_nodes can only pick a parent among already-expanded
+    # order. select_input_nodes can only pick a parent among already-expanded
     # stages, so a stage must be expanded after every stage producing its inputs.
     # Sorting here makes declaration order irrelevant: a plan that declares a
     # stage before an upstream producer still resolves, as long as that producer
@@ -1264,7 +1264,7 @@ def _generate_explicit_snakefile(
                         # *linear* ancestors (nodes whose id is a prefix of this
                         # one). Inputs produced on a sibling branch that re-joins
                         # here are invisible and warn "Could not resolve input"
-                        # below. Generalise this (and _select_input_nodes above)
+                        # below. Generalise this (and select_input_nodes)
                         # to gather from all producing lineages once multi-stage
                         # input collection lands.
                         for ancestor in lineage_ancestors(input_node, nodes_by_id):

--- a/omnibenchmark/core/_lineage.py
+++ b/omnibenchmark/core/_lineage.py
@@ -1,0 +1,107 @@
+"""Pure lineage/selection helpers over resolved nodes.
+
+These operate on the ``parent_id`` chain of resolved nodes (see
+``model.resolved.ResolvedNode``) and back the stage-expansion loop in
+``cli/run.py``. Kept out of the CLI layer because they are pure and unit-tested
+in isolation.
+"""
+
+
+def select_input_nodes(
+    declared_input_ids: list[str],
+    output_to_nodes: dict,
+    resolved_nodes: list,
+    nodes_by_id: dict,
+    stage_ids_in_order: list[str],
+    previous_stage_nodes: list,
+) -> list:
+    """Return the node list to use as the cartesian expansion base for a stage.
+
+    NOTE(#289): this collapses a stage's inputs down to a *single* parent stage
+    (the deepest already-expanded producer). It therefore assumes every declared
+    input is reachable along one linear ancestry chain from that parent. When a
+    stage joins two sibling branches (a "diamond"), the other branch's outputs are
+    not in that lineage and later fail to resolve. This is the crux of the
+    multi-stage input-collection limitation.
+
+    TODO(#289): once arbitrary multi-stage input collection is supported, this
+    single-parent selection (and the linear-ancestor walk ``lineage_ancestors``)
+    must be generalised to gather inputs from *all* producing stages, not just the
+    deepest one on a single chain.
+    """
+    if not declared_input_ids:
+        return previous_stage_nodes
+
+    providing_stage_id_to_depth: dict[str, int] = {}
+    for input_id in declared_input_ids:
+        for node_id, _path in output_to_nodes.get(input_id, []):
+            node_obj = nodes_by_id.get(
+                node_id
+            )  # O(1); was an O(N) scan of resolved_nodes
+            if node_obj is not None:
+                depth = (
+                    stage_ids_in_order.index(node_obj.stage_id)
+                    if node_obj.stage_id in stage_ids_in_order
+                    else -1
+                )
+                existing = providing_stage_id_to_depth.get(node_obj.stage_id, -1)
+                if depth > existing:
+                    providing_stage_id_to_depth[node_obj.stage_id] = depth
+
+    if not providing_stage_id_to_depth:
+        return previous_stage_nodes
+
+    deepest_stage_id = max(
+        providing_stage_id_to_depth,
+        key=providing_stage_id_to_depth.__getitem__,
+    )
+    return [n for n in resolved_nodes if n.stage_id == deepest_stage_id]
+
+
+def satisfies_requires(requires: dict, input_node) -> bool:
+    """Return True if the input_node's lineage satisfies all requires constraints."""
+    if not input_node.template_context:
+        return False
+    for label, required_value in requires.items():
+        actual_value = input_node.template_context.provides.get(label)
+        if actual_value != required_value:
+            return False
+    return True
+
+
+def lineage_module_ids(input_node, nodes_by_id) -> set:
+    """Return the module_ids along input_node's full lineage, inclusive.
+
+    Walks the explicit ``parent_id`` chain rather than matching node-ID string
+    prefixes, so it is unaffected by module/stage ids that contain the id
+    separator. ``nodes_by_id`` maps node id → node.
+    """
+    lineage = set()
+    node = input_node
+    while node is not None:
+        lineage.add(node.module_id)
+        node = nodes_by_id.get(node.parent_id) if node.parent_id else None
+    return lineage
+
+
+def lineage_ancestors(input_node, nodes_by_id) -> list:
+    """Strict ancestors of ``input_node``, shallowest first.
+
+    Node ids are built as ``{parent.id}-...``, so this is exactly the set of
+    nodes whose id is a strict prefix of ``input_node.id`` -- i.e. its linear
+    lineage. Walks the explicit ``parent_id`` chain (O(depth)), like
+    ``lineage_module_ids``.
+
+    The prior implementation found these by scanning all resolved nodes for
+    id-prefix matches and RE-RECURSING on every match with no memo -- O(2^depth)
+    -- which hung Snakefile generation on deep lineages. Shallowest-first so a
+    caller doing ``dict.update`` per ancestor lets the deepest win on any
+    output-id collision.
+    """
+    ancestors = []
+    node = nodes_by_id.get(input_node.parent_id) if input_node.parent_id else None
+    while node is not None:
+        ancestors.append(node)
+        node = nodes_by_id.get(node.parent_id) if node.parent_id else None
+    ancestors.reverse()
+    return ancestors

--- a/omnibenchmark/core/_lineage.py
+++ b/omnibenchmark/core/_lineage.py
@@ -11,11 +11,15 @@ def select_input_nodes(
     declared_input_ids: list[str],
     output_to_nodes: dict,
     resolved_nodes: list,
-    nodes_by_id: dict,
     stage_ids_in_order: list[str],
     previous_stage_nodes: list,
+    nodes_by_id: dict | None = None,
 ) -> list:
     """Return the node list to use as the cartesian expansion base for a stage.
+
+    ``nodes_by_id`` (id → node) is an optional prebuilt index for the O(1) node
+    lookup; it is built from ``resolved_nodes`` when omitted, so callers that
+    already keep the index (the run loop) avoid the O(N) rebuild.
 
     NOTE(#289): this collapses a stage's inputs down to a *single* parent stage
     (the deepest already-expanded producer). It therefore assumes every declared
@@ -31,6 +35,9 @@ def select_input_nodes(
     """
     if not declared_input_ids:
         return previous_stage_nodes
+
+    if nodes_by_id is None:
+        nodes_by_id = {n.id: n for n in resolved_nodes}
 
     providing_stage_id_to_depth: dict[str, int] = {}
     for input_id in declared_input_ids:

--- a/tests/cli/test_run_unit.py
+++ b/tests/cli/test_run_unit.py
@@ -16,10 +16,13 @@ from omnibenchmark.cli.run import (
     _run_snakemake,
     _substitute_params_in_path,
     _build_template_context,
-    _select_input_nodes,
-    _satisfies_requires,
-    _lineage_module_ids,
     run,
+)
+from omnibenchmark.core._lineage import (
+    select_input_nodes,
+    satisfies_requires,
+    lineage_module_ids,
+    lineage_ancestors,
 )
 from omnibenchmark.core.prefetch import populate_git_cache
 from omnibenchmark.model import SoftwareBackendEnum
@@ -299,7 +302,7 @@ class TestBuildTemplateContext:
 
 
 # ---------------------------------------------------------------------------
-# _satisfies_requires
+# satisfies_requires
 # ---------------------------------------------------------------------------
 
 
@@ -307,7 +310,7 @@ class TestBuildTemplateContext:
 class TestSatisfiesRequires:
     def test_no_template_context_returns_false(self):
         node = _make_input_node("D1", "data", template_context=None)
-        assert _satisfies_requires({"dataset": "pbmc3k"}, node) is False
+        assert satisfies_requires({"dataset": "pbmc3k"}, node) is False
 
     def test_matching_single_constraint(self):
         ctx = TemplateContext(
@@ -315,7 +318,7 @@ class TestSatisfiesRequires:
             module_attrs={"id": "D1", "stage": "data"},
         )
         node = _make_input_node("D1", "data", template_context=ctx)
-        assert _satisfies_requires({"dataset": "pbmc3k"}, node) is True
+        assert satisfies_requires({"dataset": "pbmc3k"}, node) is True
 
     def test_mismatched_constraint(self):
         ctx = TemplateContext(
@@ -323,7 +326,7 @@ class TestSatisfiesRequires:
             module_attrs={"id": "D1", "stage": "data"},
         )
         node = _make_input_node("D1", "data", template_context=ctx)
-        assert _satisfies_requires({"dataset": "other"}, node) is False
+        assert satisfies_requires({"dataset": "other"}, node) is False
 
     def test_missing_label_returns_false(self):
         ctx = TemplateContext(
@@ -331,7 +334,7 @@ class TestSatisfiesRequires:
             module_attrs={"id": "D1", "stage": "data"},
         )
         node = _make_input_node("D1", "data", template_context=ctx)
-        assert _satisfies_requires({"dataset": "pbmc3k"}, node) is False
+        assert satisfies_requires({"dataset": "pbmc3k"}, node) is False
 
     def test_empty_requires_returns_true(self):
         ctx = TemplateContext(
@@ -339,7 +342,7 @@ class TestSatisfiesRequires:
             module_attrs={"id": "D1", "stage": "data"},
         )
         node = _make_input_node("D1", "data", template_context=ctx)
-        assert _satisfies_requires({}, node) is True
+        assert satisfies_requires({}, node) is True
 
     def test_multiple_constraints_all_match(self):
         ctx = TemplateContext(
@@ -348,8 +351,7 @@ class TestSatisfiesRequires:
         )
         node = _make_input_node("D1", "data", template_context=ctx)
         assert (
-            _satisfies_requires({"dataset": "pbmc3k", "treatment": "ctrl"}, node)
-            is True
+            satisfies_requires({"dataset": "pbmc3k", "treatment": "ctrl"}, node) is True
         )
 
     def test_multiple_constraints_partial_mismatch(self):
@@ -359,13 +361,13 @@ class TestSatisfiesRequires:
         )
         node = _make_input_node("D1", "data", template_context=ctx)
         assert (
-            _satisfies_requires({"dataset": "pbmc3k", "treatment": "stim"}, node)
+            satisfies_requires({"dataset": "pbmc3k", "treatment": "stim"}, node)
             is False
         )
 
 
 # ---------------------------------------------------------------------------
-# _lineage_module_ids
+# lineage_module_ids
 # ---------------------------------------------------------------------------
 
 
@@ -385,12 +387,12 @@ def _by_id(*nodes):
 class TestLineageModuleIds:
     def test_root_node_lineage_is_self(self):
         root = _make_lineage_node("adamson")
-        assert _lineage_module_ids(root, _by_id(root)) == {"adamson"}
+        assert lineage_module_ids(root, _by_id(root)) == {"adamson"}
 
     def test_immediate_predecessor_in_lineage(self):
         root = _make_lineage_node("adamson")
         child = _make_lineage_node("prep", parent_id=root.id)
-        assert _lineage_module_ids(child, _by_id(root, child)) == {"adamson", "prep"}
+        assert lineage_module_ids(child, _by_id(root, child)) == {"adamson", "prep"}
 
     def test_transitive_lineage_across_non_adjacent_stages(self):
         """Regression: a download module several stages upstream must appear in
@@ -400,7 +402,7 @@ class TestLineageModuleIds:
         split = _make_lineage_node("sim", parent_id=preprocess.id)
         # split is the immediate predecessor of a `methods` node; its lineage
         # must still include the non-adjacent `adamson` download module.
-        assert _lineage_module_ids(split, _by_id(download, preprocess, split)) == {
+        assert lineage_module_ids(split, _by_id(download, preprocess, split)) == {
             "adamson",
             "prep",
             "sim",
@@ -410,7 +412,7 @@ class TestLineageModuleIds:
         download = _make_lineage_node("adamson")
         other = _make_lineage_node("norman")  # sibling root, not an ancestor
         child = _make_lineage_node("prep", parent_id=download.id)
-        assert _lineage_module_ids(child, _by_id(download, other, child)) == {
+        assert lineage_module_ids(child, _by_id(download, other, child)) == {
             "adamson",
             "prep",
         }
@@ -426,14 +428,62 @@ class TestLineageModuleIds:
             parent_id=download.id,
             node_id="download-adamson-v2.default-methods-my-method.default",
         )
-        assert _lineage_module_ids(method, _by_id(download, method)) == {
+        assert lineage_module_ids(method, _by_id(download, method)) == {
             "adamson-v2",
             "my-method",
         }
 
 
 # ---------------------------------------------------------------------------
-# _select_input_nodes
+# lineage_ancestors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.short
+class TestLineageAncestors:
+    def test_root_node_has_no_ancestors(self):
+        root = _make_lineage_node("adamson")
+        assert lineage_ancestors(root, _by_id(root)) == []
+
+    def test_ancestors_returned_shallowest_first(self):
+        # deepest-wins on output-id collisions relies on shallow -> deep order.
+        download = _make_lineage_node("adamson", node_id="d")
+        prep = _make_lineage_node("prep", parent_id="d", node_id="d-p")
+        method = _make_lineage_node("m", parent_id="d-p", node_id="d-p-m")
+        by_id = _by_id(download, prep, method)
+        assert lineage_ancestors(method, by_id) == [download, prep]
+
+    def test_only_own_chain_not_sibling_branch(self):
+        download = _make_lineage_node("adamson", node_id="d")
+        sibling = _make_lineage_node("norman", node_id="n")  # different root
+        child = _make_lineage_node("prep", parent_id="d", node_id="d-p")
+        assert lineage_ancestors(child, _by_id(download, sibling, child)) == [download]
+
+    @pytest.mark.timeout(5)
+    def test_deep_chain_is_linear_not_exponential(self):
+        # Regression guard for the O(2^depth) ancestor recursion that hung
+        # Snakefile generation (get_ancestor_nodes). The old prefix-scan re-
+        # recursed on every match: for a chain of depth 200 it would visit
+        # ~2^200 nodes and never return. The parent_id walk is O(depth), so this
+        # completes instantly; a reintroduced exponential version hangs CI.
+        chain = []
+        parent_id = None
+        for i in range(200):
+            node_id = "n0" if i == 0 else f"{chain[-1].id}-n{i}"
+            chain.append(
+                _make_lineage_node(f"m{i}", parent_id=parent_id, node_id=node_id)
+            )
+            parent_id = node_id
+        by_id = _by_id(*chain)
+
+        ancestors = lineage_ancestors(chain[-1], by_id)
+
+        assert ancestors == chain[:-1]  # every strict ancestor, shallowest first
+        assert len(ancestors) == 199
+
+
+# ---------------------------------------------------------------------------
+# select_input_nodes
 # ---------------------------------------------------------------------------
 
 
@@ -448,12 +498,12 @@ def _make_node(node_id, stage_id):
 class TestSelectInputNodes:
     def test_empty_declared_inputs_returns_previous(self):
         prev = [_make_node("n1", "data")]
-        result = _select_input_nodes([], {}, [], [], prev)
+        result = select_input_nodes([], {}, [], [], prev)
         assert result is prev
 
     def test_no_matching_outputs_returns_previous(self):
         prev = [_make_node("n1", "data")]
-        result = _select_input_nodes(["data.raw"], {}, [], ["data"], prev)
+        result = select_input_nodes(["data.raw"], {}, [], ["data"], prev)
         assert result is prev
 
     def test_single_input_selects_correct_stage(self):
@@ -463,7 +513,7 @@ class TestSelectInputNodes:
         output_to_nodes = {"data.raw": [("data-D1", "data/D1/out.json")]}
         stage_ids = ["data", "methods"]
         prev = []
-        result = _select_input_nodes(
+        result = select_input_nodes(
             ["data.raw"], output_to_nodes, resolved, stage_ids, prev
         )
         assert all(n.stage_id == "data" for n in result)
@@ -478,7 +528,7 @@ class TestSelectInputNodes:
         }
         stage_ids = ["data", "preprocessing", "methods"]
         prev = []
-        result = _select_input_nodes(
+        result = select_input_nodes(
             ["data.raw", "prep.out"], output_to_nodes, resolved, stage_ids, prev
         )
         assert all(n.stage_id == "preprocessing" for n in result)
@@ -486,7 +536,7 @@ class TestSelectInputNodes:
     def test_node_not_in_resolved_skipped(self):
         output_to_nodes = {"data.raw": [("ghost-node", "p.json")]}
         prev = [_make_node("fallback", "data")]
-        result = _select_input_nodes(["data.raw"], output_to_nodes, [], ["data"], prev)
+        result = select_input_nodes(["data.raw"], output_to_nodes, [], ["data"], prev)
         assert result is prev
 
 

--- a/tests/cli/test_select_input_nodes.py
+++ b/tests/cli/test_select_input_nodes.py
@@ -1,13 +1,13 @@
-"""Unit tests for _select_input_nodes and the dag_errors abort path in run.py."""
+"""Unit tests for select_input_nodes and the dag_errors abort path in run.py."""
 
 from dataclasses import dataclass
 
-from omnibenchmark.cli.run import _select_input_nodes
+from omnibenchmark.core._lineage import select_input_nodes
 
 
 # ---------------------------------------------------------------------------
 # Minimal stub that satisfies the .id / .stage_id duck-typing used by
-# _select_input_nodes.  Using a plain dataclass avoids importing heavy
+# select_input_nodes.  Using a plain dataclass avoids importing heavy
 # ResolvedNode infrastructure.
 # ---------------------------------------------------------------------------
 
@@ -38,12 +38,12 @@ def _reg(*pairs):
 
 
 class TestSelectInputNodes:
-    """Tests for _select_input_nodes pure function."""
+    """Tests for select_input_nodes pure function."""
 
     def test_no_declared_inputs_returns_previous(self):
         """When declared_input_ids is empty fall back to previous_stage_nodes."""
         prev = [_StubNode("n1", "stage_a")]
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=[],
             output_to_nodes={},
             resolved_nodes=[],
@@ -55,7 +55,7 @@ class TestSelectInputNodes:
     def test_unresolvable_inputs_return_previous(self):
         """When no declared input exists in the registry fall back to previous."""
         prev = [_StubNode("n1", "stage_a")]
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=["unknown_output"],
             output_to_nodes={},
             resolved_nodes=[],
@@ -69,7 +69,7 @@ class TestSelectInputNodes:
         n1 = _StubNode("n1", "stage_a")
         reg = _reg(("pca.csv", "n1"))
 
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=["pca.csv"],
             output_to_nodes=reg,
             resolved_nodes=[n1],
@@ -83,7 +83,7 @@ class TestSelectInputNodes:
         Skip-dependency scenario:
           data → pca → (leiden) → umap
         umap declares inputs produced by *pca*, not leiden.
-        _select_input_nodes must return pca nodes even though leiden is the
+        select_input_nodes must return pca nodes even though leiden is the
         most recent previous stage.
         """
         n_pca = _StubNode("pca-M1-default", "pca")
@@ -92,7 +92,7 @@ class TestSelectInputNodes:
         # umap declares "neighbors.h5ad" which was produced by pca
         reg = _reg(("neighbors.h5ad", "pca-M1-default"))
 
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=["neighbors.h5ad"],
             output_to_nodes=reg,
             resolved_nodes=[n_pca, n_leiden],
@@ -114,7 +114,7 @@ class TestSelectInputNodes:
             ("pca.csv", "pca-M1-default"),
         )
 
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=["data.h5ad", "pca.csv"],
             output_to_nodes=reg,
             resolved_nodes=[n_data, n_pca],
@@ -130,7 +130,7 @@ class TestSelectInputNodes:
         n2 = _StubNode("pca-M2-default", "pca")
         reg = _reg(("pca.csv", "pca-M1-default"), ("pca.csv", "pca-M2-default"))
 
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=["pca.csv"],
             output_to_nodes=reg,
             resolved_nodes=[n1, n2],
@@ -147,7 +147,7 @@ class TestSelectInputNodes:
             ("pca.csv", "ghost-node"),  # ghost not in resolved_nodes
         )
 
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=["pca.csv"],
             output_to_nodes=reg,
             resolved_nodes=[n1],
@@ -169,7 +169,7 @@ class TestSelectInputNodes:
             ("output.csv", "pca-M1-default"),
         )
 
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=["output.csv"],
             output_to_nodes=reg,
             resolved_nodes=[n_orphan, n_real],
@@ -198,7 +198,7 @@ class TestSelectInputNodes:
         stage_order = ["data", "pca", "harmony", "leiden", "umap"]
         previous = [n_leiden_s, n_leiden_r]
 
-        result = _select_input_nodes(
+        result = select_input_nodes(
             declared_input_ids=["harmony.csv", "neighbors.h5ad"],
             output_to_nodes=reg,
             resolved_nodes=[n_pca, n_harmony, n_leiden_s, n_leiden_r],


### PR DESCRIPTION
Node expansion built each node's input map by collecting its lineage ancestors with get_ancestor_nodes(), which found ancestors by scanning all resolved_nodes for id-prefix matches and then RE-RECURSED on every match with no memoization. For a lineage of depth k that is T(k)=Σ T(i) = O(2^k), each level also doing an O(N) scan -- so generation hung outright on deep benchmarks (30-module scRNA plan never finished; the faulthandler stack sat in get_ancestor_nodes at run.py:1343).

The bug has existed since explicit Snakefile generation landed, but only bites when lineages actually get deep. Topological stage expansion (#289, 8f21934) is what surfaced it: expanding stages in dependency order lets every producer resolve before its consumers, so the 18-stage plans now chain into deep linear lineages instead of stalling out at shallow depth in declaration order. 2^depth then became fatal.

Node ids are built as `{parent.id}-...`, so the prefix-ancestor set is exactly the parent_id chain -- a linked list. Walk it directly (O(depth), no scan), the same walk _lineage_module_ids already uses. Shallowest-first so the deepest ancestor still wins on any output-id collision.

Two adjacent O(N) scans in the same loop fixed while here:
- _select_input_nodes: next(n for n in resolved_nodes ...) -> nodes_by_id O(1) lookup (2.6s of a 30-module run).
- get_output_ids_for_node: per-call stage scan + pydantic list.index() -> precomputed stage_id->output_ids map (~180k __eq__ calls removed).

30-module scRNA plan: hang -> 6.7s, identical 26197 rules.
