### PR TITLE
backend: emit snakemake's threads: directive from resources.cores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 ## [0.7.0](UNRELEASED)
 
 - feat: capability filters by --with-capability (#360)
+- feat: emit threads per rule according if the module requests a number of cores
 
 ## [0.6.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.6.0) (Jul 21st 2026)
 

--- a/omnibenchmark/backend/snakemake.py
+++ b/omnibenchmark/backend/snakemake.py
@@ -153,6 +153,7 @@ class SnakemakeGenerator:
         f.write(f'        ".logs/{log_filename}"\n')
 
         self._write_environment_directive(f, node.module)
+        self._write_threads_directive(f, node)
         self._write_resources_directive(f, node)
 
         if is_collector or is_gather:
@@ -190,6 +191,28 @@ class SnakemakeGenerator:
         elif env.backend_type.value == "envmodules":
             f.write(f'    envmodules: "{env.reference}"\n')
         # host backend needs no directive
+
+    def _write_threads_directive(self, f: TextIO, node: ResolvedNode):
+        """Write Snakemake's threads: directive when a stage asks for cores.
+
+        Distinct from the `cores` custom resource written below. Two things
+        follow from threads: that the resource alone cannot give:
+
+        * Snakemake exports OMP_NUM_THREADS=<threads> into every shell job, so
+          BLAS/OpenMP libraries in the module actually get more than one
+          thread. Left unset, threads is 1 and every module runs
+          single-threaded no matter what the machine has.
+        * The scheduler reserves that many of --cores for the job, instead of
+          assuming 1 and oversubscribing the box.
+
+        Only emitted when the stage declares resources.cores explicitly.
+        Defaulting it would silently change scheduling for every existing
+        benchmark, so opting in stays deliberate.
+        """
+        r = node.resources
+        cores = r.cores if r is not None else None
+        if cores:
+            f.write(f"    threads: {cores}\n")
 
     def _write_resources_directive(self, f: TextIO, node: ResolvedNode):
         """Write Snakemake resources: directive for a node.

--- a/tests/backend/test_snakemake_gen.py
+++ b/tests/backend/test_snakemake_gen.py
@@ -289,6 +289,34 @@ class TestWriteEnvironmentDirective:
 
 
 # ---------------------------------------------------------------------------
+# _write_threads_directive
+# ---------------------------------------------------------------------------
+
+
+class TestWriteThreadsDirective:
+    def test_no_resources_emits_nothing(self):
+        """Default must stay unset: emitting threads would change scheduling
+        for every existing benchmark."""
+        node = _make_node(resources=None)
+        out = _capture(_gen()._write_threads_directive, node)
+        assert out == ""
+
+    def test_cores_emits_threads(self):
+        resources = MagicMock()
+        resources.cores = 8
+        node = _make_node(resources=resources)
+        out = _capture(_gen()._write_threads_directive, node)
+        assert "threads: 8" in out
+
+    def test_zero_cores_emits_nothing(self):
+        resources = MagicMock()
+        resources.cores = 0
+        node = _make_node(resources=resources)
+        out = _capture(_gen()._write_threads_directive, node)
+        assert out == ""
+
+
+# ---------------------------------------------------------------------------
 # _write_resources_directive
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The generated rules carried resources: cores=N but never a threads: directive, so threads stayed at snakemake's default of 1. Two consequences:

* Snakemake exports OMP_NUM_THREADS=<threads> into every shell job, so every module ran single-threaded regardless of the machine. A benchmark comparing BLAS implementations measured no difference at all, because both arms were pinned to one thread by the harness.
* The scheduler assumed each job cost one core, so --cores N launched N jobs that each spawned their own thread pool and oversubscribed the box.

Emitted only when a stage declares resources.cores. Defaulting it would change scheduling for every existing benchmark, so opting in stays deliberate.
.

## Checklist:
- [x] My code follows the code style of this project.
- [na] My CLI method respects the signature defined in the task.
- [na] I have documented the CLI method accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.
