### PR TITLE
fix: status crashed on DAGs with several terminal stages (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/) and [Conventi
 - feat: lineage gating — `provides:` labels a lineage, `requires:` runs a module only on matching lineages (api 0.7.0, #354)
 - feat: reject gates that can never fire at parse time (#354)
 - fix: compare `api_version` by components, not lexicographically (#354)
+- fix: `ob describe status` no longer crashes with a `KeyError` on benchmarks whose DAG has more than one terminal stage (#371)
 
 ## [0.6.0](https://github.com/omnibenchmark/omnibenchmark/releases/tag/v0.6.0) (Jul 21st 2026)
 

--- a/omnibenchmark/core/status/status.py
+++ b/omnibenchmark/core/status/status.py
@@ -71,7 +71,13 @@ def print_exec_path_dict(
 
             else:
                 outls2.append("")
-        outls2.append(Path(exec_path_dict[i].exec_path[st].get_output_files()[0]).name)
+        # The last column is a representative output of *this* path's terminal
+        # stage.  Branching DAGs have several terminal stages, so it is not
+        # necessarily the last entry of `stages` (issue #371).
+        last_st = exec_path_dict[i].stages[-1]
+        outls2.append(
+            Path(exec_path_dict[i].exec_path[last_st].get_output_files()[0]).name
+        )
 
         if logs:
             tmps2 = ""

--- a/tests/status/test_status_logs.py
+++ b/tests/status/test_status_logs.py
@@ -137,3 +137,32 @@ def test_print_logs_off_emits_nothing(tmp_path):
 
     out = print_exec_path_dict({0: ep}, stages, threshold_n_missing=1, logs=False)
     assert "LOG (" not in out
+
+
+def test_print_handles_paths_with_different_terminal_stages():
+    """A branching DAG has several terminal stages (issue #371).
+
+    The last column showed the output of the globally-last stage, which paths
+    ending on another branch never contain -> KeyError.
+    """
+    stages = ["data", "methods", "metrics", "other"]
+    short = _FakeExecPath(
+        [
+            ("data", _FakeStage(_node("data", "D1", "default"), ".", "out/d.txt")),
+            (
+                "methods",
+                _FakeStage(_node("methods", "M1", "default"), ".", "out/m.txt"),
+            ),
+        ]
+    )
+    long = _FakeExecPath(
+        [
+            ("data", _FakeStage(_node("data", "D1", "default"), ".", "out/d.txt")),
+            ("other", _FakeStage(_node("other", "O1", "default"), ".", "out/o.txt")),
+        ]
+    )
+
+    out = print_exec_path_dict({0: short, 1: long}, stages, threshold_n_missing=0)
+
+    assert "m.txt" in out
+    assert "o.txt" in out


### PR DESCRIPTION
The last column of the exec-path table read a leaked loop variable, i.e. always the globally last stage. Any path terminating on another branch raised KeyError. Use the path's own terminal stage instead.

## Ticket

#371 

## Description

status reports break with current omni-scrna plan

## Checklist:
- [x] My code follows the code style of this project.
- [na] My CLI method respects the signature defined in the task.
- [na] I have documented the CLI method accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a CHANGELOG entry.
